### PR TITLE
Convert the spec into Bikeshed

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -63,7 +63,7 @@ spec:streams; type:interface; text:ReadableStream
 spec:html; type:dfn; for:/; text:origin
 </pre>
 <pre class="anchors">
-urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCIRPT-6.0
+urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
   type: dfn
     text: fulfilled; url: sec-promise-objects
     text: rejected; url: sec-promise-objects

--- a/index.html
+++ b/index.html
@@ -1215,7 +1215,7 @@ Possible extra rowspan handling
   <link href="https://www.w3.org/StyleSheets/TR/2016/cg-draft" rel="stylesheet">
   <meta content="Bikeshed version 450e0499b28bb4c684052ad936ad1e7d36c4eac5" name="generator">
   <link href="https://wicg.github.io/web-transport/" rel="canonical">
-  <meta content="84d5b51552f4df42257005f7a0d771bfbc1badc8" name="document-revision">
+  <meta content="e6b89a065a9bf71a29aee40d021072f034bf90a5" name="document-revision">
 <style>/* style-md-lists */
 
 /* This is a weird hack for me not yet following the commonmark spec
@@ -1473,7 +1473,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   <div class="head">
    <p data-fill-with="logo"></p>
    <h1 class="p-name no-ref" id="title">WebTransport</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-08-26">26 August 2019</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2019-08-27">27 August 2019</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -2874,7 +2874,7 @@ use in this specification.</p>
      <li><span class="dfn-paneled" id="term-for-concept-event" style="color:initial">event</span>
     </ul>
    <li>
-    <a data-link-type="biblio">[ecmascirpt-6.0]</a> defines the following terms:
+    <a data-link-type="biblio">[ECMASCRIPT-6.0]</a> defines the following terms:
     <ul>
      <li><span class="dfn-paneled" id="term-for-sec-promise-objects" style="color:initial">fulfilled</span>
      <li><span class="dfn-paneled" id="term-for-sec-promise-objects①" style="color:initial">pending</span>


### PR DESCRIPTION
This mostly leaves the text as-is, with exception fixing some
typos, missing reference warnings and WebIDL compile errors.