### PR TITLE
Add missing WebIDL for ready

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -358,6 +358,7 @@ interface WebTransport {
 
   Promise&lt;WebTransportStats&gt; getStats();
   readonly attribute WebTransportState state;
+  readonly attribute Promise&lt;undefined&gt; ready;
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
   undefined close(optional WebTransportCloseInfo closeInfo = {});
   attribute EventHandler onstatechange;


### PR DESCRIPTION
PR https://github.com/w3c/webtransport/pull/150 did not include the WebIDL for ready.  The problem was not caught because the PR evaluation process doesn't include a bikeshed compile automatic action (Issue https://github.com/w3c/webtransport/issues/108 )

Partial fix for Issue https://github.com/w3c/webtransport/issues/137