### PR TITLE
Update boilerplate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2,9 +2,9 @@
 Title: WebTransport
 Shortname: webtransport
 Level: none
-Status: w3c/CG-DRAFT
-Group: wicg
-ED: https://wicg.github.io/web-transport/
+Status: w3c/ED
+Group: webtransport
+ED: https://github.com/w3c/webtransport
 Editor: Peter Thatcher, Google
 Editor: Bernard Aboba, Microsoft Corporation
 Editor: Robin Raymond, Optical Tone Ltd.


### PR DESCRIPTION
Update the boilerplate to refer to the current W3C WG, document status and github repo.

Fix for Issue https://github.com/w3c/webtransport/issues/158

Overtaken by PR https://github.com/w3c/webtransport/pull/162