### PR TITLE
Update CONTRIBUTING.md to w3c.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Web Platform Incubator Community Group
-
-This repository is being used for work in the W3C Web Platform Incubator Community Group, governed by the [W3C Community License
-Agreement (CLA)](http://www.w3.org/community/about/agreements/cla/). To make substantive contributions,
-you must join the CG.
+Contributions to this repository are intended to become part of Recommendation-track documents governed by the
+[W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20200915/) and
+[Document License](https://www.w3.org/Consortium/Legal/copyright-documents). To bring substantive contributions
+to specifications, you must either participate in the relevant W3C Working Group or make a non-member patent
+licensing commitment.
 
 If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request comment.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,13 @@
+Since we are a lot of people contributing to the specification, we have defined a few guidelines. Please follow them and we will be able to review your PR a lot faster when we don't have to point out style and other non-technical issues. Thank you.
+
+### W3C Legal
 Contributions to this repository are intended to become part of Recommendation-track documents governed by the
 [W3C Patent Policy](https://www.w3.org/Consortium/Patent-Policy-20200915/) and
 [Document License](https://www.w3.org/Consortium/Legal/copyright-documents). To bring substantive contributions
 to specifications, you must either participate in the relevant W3C Working Group or make a non-member patent
 licensing commitment.
 
+### Adding/removing contributors
 If you are not the sole contributor to a contribution (pull request), please identify all
 contributors in the pull request comment.
 
@@ -21,3 +25,14 @@ If you added a contributor by mistake, you can remove them in a comment with:
 
 If you are making a pull request on behalf of someone else but you had no part in designing the
 feature, you can remove yourself with the above syntax.
+
+### Notes on bikeshedding :bicyclist:
+To compile `index.bs` into `index.html` , I'm using the online compiler:
+```
+curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F force=1 > index.html
+```
+if the produced file has a strange size (i.e. zero, a few KBs), then something went terribly wrong; run instead:
+```
+curl https://api.csswg.org/bikeshed/ -F file=@index.bs -F output=err
+```
+and try to figure out why `bikeshed` did not like the `.bs` :'(


### PR DESCRIPTION
Please check:

1. @ylafon that I got the right patent policy links
2. @vasilvv I left the instructions for adding additional contributors the same though they differ from [other w3c specs](https://github.com/w3c/webrtc-pc/blob/master/CONTRIBUTING.md). Did they rely on WICG specific tooling? Do we want to keep them or converge?
3. Do we want to mention/give credit to WICG?
