### PR TITLE
automatic spec build

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -12,4 +12,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v1
         with:
-          GH_PAGES_BRANCH: master
+          GH_PAGES_BRANCH: gh-pages
+          TOOLCHAIN: bikeshed

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -1,0 +1,15 @@
+# .github/workflows/pr-push.yml
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [master]
+jobs:
+  main:
+    name: Build, Validate and Deploy Locally
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v1
+        with:
+          GH_PAGES_BRANCH: master


### PR DESCRIPTION
his should build the spec for every push to the main branch, result will be published in the gh-pages branch.