### PR TITLE
Mapping to QUIC

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -890,7 +890,7 @@ in this specification as well as in [[WHATWG-STREAMS]].
         <td>receive STREAM or STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{IncomingStream/readable}}.getReader().cancel</td>
+        <td>{{IncomingStream/readable}}.getReader().cancel()</td>
         <td>send STOP_SENDING</td>
       </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -838,6 +838,64 @@ interface ReceiveStream {
 ReceiveStream includes IncomingStream;
 </pre>
 
+# Protocol Mappings # {#protocol-mapping}
+
+This section specifies the [[QUIC-TRANSPORT]] protocol behavior expected from methods defined
+in this specification as well as in [[WHATWG-STREAMS]].
+
+  <table class="data">
+    <colgroup class="header"></colgroup>
+    <colgroup span=2></colgroup>
+    <thead>
+      <tr>
+        <th>Method</th>
+        <th>QUIC Protocol Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{IncomingStream/abortReading}}</td>
+        <td>send STOP_SENDING with code</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/abortWriting}}</td>
+        <td>send RESET_STREAM with code</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/writable}}.abort()</td>
+        <td>send RESET_STREAM</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/writable}}.close()</td>
+        <td>send STREAM_FINAL</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/writable}}.getWriter().write()</td>
+        <td>send STREAM</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/writable}}.getWriter().close()</td>
+        <td>send STREAM_FINAL</td>
+      </tr>
+      <tr>
+        <td>{{OutgoingStream/writable}}.getWriter().abort()</td>
+        <td>send RESET_STREAM</td>
+      </tr>
+      <tr>
+        <td>{{IncomingStream/readable}}.cancel()</td>
+        <td>send STOP_SENDING</td>
+      </tr>
+      <tr>
+        <td>{{IncomingStream/readable}}.getReader().read()</td>
+        <td>receive STREAM or STREAM_FINAL</td>
+      </tr>
+      <tr>
+        <td>{{IncomingStream/readable}}.getReader().cancel</td>
+        <td>send STOP_SENDING</td>
+      </tr>
+    </tbody>
+  </table>
+
 # Privacy and Security Considerations #  {#privacy-security}
 
 This section is non-normative; it specifies no new behaviour, but instead


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/137


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webtransport/pull/176.html" title="Last updated on Feb 3, 2021, 1:39 AM UTC (ea1a397)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/176/b8d1a94...aboba:ea1a397.html" title="Last updated on Feb 3, 2021, 1:39 AM UTC (ea1a397)">Diff</a>