### PR TITLE
Remove "consent freshness" requirement

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -881,9 +881,6 @@ described in [[!WEB-TRANSPORT-OVERVIEW]]. Notable ones include:
    [[RFC7301]] for that purpose.
 1. All transports must allow the server to filter connections based on the
    origin of the resource originating the transport session.
-1. All transports require the user agents to continually verify that the server
-   is still interested in talking to them (concept commonly known as "Consent
-   Freshness").
 
 Protocol security considersations related to the individual transports are
 described in the *Security Considerations* sections of the corresponding


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/174


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webtransport/pull/177.html" title="Last updated on Jan 6, 2021, 12:15 AM UTC (71db404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/177/b8d1a94...aboba:71db404.html" title="Last updated on Jan 6, 2021, 12:15 AM UTC (71db404)">Diff</a>