### PR TITLE
Fix remaining case of s/in background/in parallel/

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -526,7 +526,7 @@ To <dfn>initialize WebTransport over HTTP</dfn> for a given |transport| and
      1. Let |p| be a new promise.
      1. If the URL scheme associated with |transport| is not `quic-transport`,
         [=reject=] |p| with {{NotSupportedError}} and return |p|.
-     1. Return |p| and continue the following steps in background.
+     1. Return |p| and continue the following steps [=in parallel=].
          1. Gather the stats from the underlying QUIC connection.
          1. Once stats have been gathered, resolve |p| with the
             {{WebTransportStats}} object, representing the gathered stats.


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/111 by hitting the remaining instance left after https://github.com/w3c/webtransport/pull/202.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/203.html" title="Last updated on Feb 17, 2021, 8:41 PM UTC (65f3ffe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/203/a813b4c...jan-ivar:65f3ffe.html" title="Last updated on Feb 17, 2021, 8:41 PM UTC (65f3ffe)">Diff</a>