### PR TITLE
Acknowledgements section is wrong

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1257,8 +1257,8 @@ function addToEventLog(text, severity = 'info') {
 </pre>
 
 # Acknowledgements #  {#acknowledgements}
-The editors wish to thank the Working Group chairs and Team Contact, Jan-Ivar Bruaroey, Will Law and Dominique
-Haza&euml;l-Massieux, for their support. Contributions to this specification
+The editors wish to thank the Working Group chairs and Team Contact, Jan-Ivar Bruaroey, Will Law
+and Yves Lafon, for their support. Contributions to this specification
 were provided by Robin Raymond.
 
 The {{WebTransport}} interface is based on the `QuicTransport` interface

--- a/index.bs
+++ b/index.bs
@@ -1258,8 +1258,7 @@ function addToEventLog(text, severity = 'info') {
 
 # Acknowledgements #  {#acknowledgements}
 The editors wish to thank the Working Group chairs and Team Contact, Jan-Ivar Bruaroey, Will Law
-and Yves Lafon, for their support. Contributions to this specification
-were provided by Robin Raymond.
+and Yves Lafon, for their support.
 
 The {{WebTransport}} interface is based on the `QuicTransport` interface
 initially described in the [W3C ORTC CG](https://www.w3.org/community/ortc/),

--- a/index.bs
+++ b/index.bs
@@ -1257,8 +1257,7 @@ function addToEventLog(text, severity = 'info') {
 </pre>
 
 # Acknowledgements #  {#acknowledgements}
-The editors wish to thank the Working Group chairs and Team Contact, Harald
-Alvestrand, Stefan H&aring;kansson, Bernard Aboba and Dominique
+The editors wish to thank the Working Group chairs and Team Contact, Jan-Ivar Bruaroey, Will Law and Dominique
 Haza&euml;l-Massieux, for their support. Contributions to this specification
 were provided by Robin Raymond.
 


### PR DESCRIPTION
Fixes Issue https://github.com/w3c/webtransport/issues/200


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/aboba/webtransport/pull/207.html" title="Last updated on Mar 3, 2021, 12:21 AM UTC (2f6f507)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/207/a813b4c...aboba:2f6f507.html" title="Last updated on Mar 3, 2021, 12:21 AM UTC (2f6f507)">Diff</a>