### PR TITLE
Reference QUIC as legend for the terms in the Protocol Mappings table.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -873,7 +873,7 @@ ReceiveStream includes IncomingStream;
 
 *This section is non-normative.*
 
-This section describes the QUIC protocol behavior of methods defined
+This section describes the [[!QUIC]] protocol behavior of methods defined
 in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
 
   <table class="data">

--- a/index.bs
+++ b/index.bs
@@ -873,7 +873,7 @@ ReceiveStream includes IncomingStream;
 
 *This section is non-normative.*
 
-This section describes the [[!QUIC]] protocol behavior of methods defined
+This section describes the [[QUIC]] protocol behavior of methods defined
 in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
 
   <table class="data">


### PR DESCRIPTION
I couldn't find mention of the terms in the [Protocol Mappings table](https://w3c.github.io/webtransport/#protocol-mapping) in the referenced [WEB-TRANSPORT-HTTP3], so I added one to [[QUIC]] where they seem defined. @aboba PTAL.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/215.html" title="Last updated on Mar 3, 2021, 3:38 AM UTC (14cb4aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/215/4ebe916...jan-ivar:14cb4aa.html" title="Last updated on Mar 3, 2021, 3:38 AM UTC (14cb4aa)">Diff</a>