### PR TITLE
Specify WebTransport initialization in more detail

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -428,7 +428,7 @@ agent MUST run the following steps:
 1. If |parsedURL| [=scheme=] is not `https`, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=fragment=] is not null, [=throw=] a {{SyntaxError}} exception.
 1. Let |dedicated| be {{WebTransport/constructor(url, options)/options}}'s
-   [=WebTransportOptions/dedicated=] if it exists, and true otherwise.
+   {{WebTransportOptions/dedicated}} if it exists, and true otherwise.
 1. Let |transport| be a newly constructed {{WebTransport}} object.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[OutgoingStreams]]</dfn> internal slot

--- a/index.bs
+++ b/index.bs
@@ -425,13 +425,10 @@ agent MUST run the following steps:
 1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
    {{WebTransport/constructor(url, options)/url}}.
 1. If |parsedURL| is a failure, [=throw=] a {{SyntaxError}} exception.
-1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
-   {{WebTransport/constructor(url, options)/url}}.
 1. If |parsedURL| [=scheme=] is not `https`, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=fragment=] is not null, [=throw=] a {{SyntaxError}} exception.
-1. Let |dedicated| be true.
-1. If {{WebTransport/constructor(url, options)/options}}[`"dedicated"`] exists, then set |dedicated|
-   to it.
+1. Let |dedicated| be {{WebTransport/constructor(url, options)/options}}'s
+   [=WebTransportOptions/dedicated=] if it exists, and true otherwise.
 1. Let |transport| be a newly constructed {{WebTransport}} object.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[OutgoingStreams]]</dfn> internal slot
@@ -467,36 +464,42 @@ agent MUST run the following steps:
    and its [=DatagramDuplexStream/create/writable=] set to |transport|.{{[[OutgoingDatagrams]]}}.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[Connection]]</dfn> internal slot initialized to null.
-1. [=Initialize WebTransport over HTTP=], with |transport|, |parsedURL| and |dedicated|.
+1. Let |promise| be the result of [=initialize WebTransport over HTTP|initializing WebTransport
+   over HTTP=], with |transport|, |parsedURL| and |dedicated|.
+1. [=Upon fulfillment=] of |promise|, run these steps:
+   1. If |transport|'s {{[[WebTransportState]]}} internal slot is not `"connecting"`, then abort
+      these steps.
+   1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"connected"`.
+   1. Resolve |transport|'s {{[[Ready]]}} internal slot with {{undefined}}.
+1. [=Upon rejection=] of |promise| with |error|, run these steps:
+   1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"failed"`.
+   1. Reject |transport|'s {{[[Ready]]}} internal slot with |error|.
+   1. Reject |transport|'s {{[[Closed]]}} internal slot with |error|.
 1. Return |transport|.
 
 <div algorithm="initialize WebTransport over HTTP">
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
-<var>transport</var>, a [=URL record=] |url|, a and boolean |dedicated|, run these steps
-[=in parallel=].
+<var>transport</var>, a [=URL record=] |url|, a and boolean |dedicated|, run these steps.
 
+1. Let |promise| be a new promise.
+1. Return |promise| and run the following steps [=in parallel=].
 1. Let |request| be a [=request=]  whose [=request/url=] is |url| and [=request/client=]
    is |transport|'s [=relevant settings object=].
 1. Let |networkPartitionKey| be the result of
    [=determine the network partition key|determining the network partition key=] with |request|.
-1. Let |connection| be the result of the result of [=obtain a connection|obtaining a connection=]
-   with |networkPartitionKey|, |url|'s [=url/origin=], false,
-   [=obtain a connection/http3Only=] set to true, and [=obtain a connection/dedicated=] set to
-   |dedicated|.
-1. If |connection| is failure, set |transport|'s {{[[WebTransportState]]}} internal slot to
-   `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these steps.
+1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
+   |networkPartitionKey|, |url|'s [=url/origin=], false, [=obtain a connection/http3Only=] set to
+   true, and [=obtain a connection/dedicated=] set to |dedicated|.
+1. If |connection| is failure, then reject |promise| with a {{TypeError}} and abort these steps.
 1. Set |transport|'s {{[[Connection]]}} internal slot to |connection|.
 1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
    represents the SETTINGS frame.
 1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't
-   contain H3_DATAGRAM with a value of 1, then set |transport|'s {{[[WebTransportState]]}} internal
-   slot to `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these
-   steps. [[!WEB-TRANSPORT-HTTP3]][[!HTTP3-DATAGRAM]].
+   contain H3_DATAGRAM with a value of 1, then reject |promise| with a {{TypeError}} and abort
+   these steps.
 1. Create a WebTransport session with |connection|, as described in [[!WEB-TRANSPORT-HTTP3]].
-1. If the previous steps fails, then set |transport|'s {{[[WebTransportState]]}} internal slot to
-   `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these steps.
-1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"connected"`.
-1. Resolve |transport|'s {{[[Ready]]}} with {{undefined}}.
+1. If the previous step fails, then reject |promise| with a {{TypeError}} and abort these steps.
+1. Resolve |promise| with {{undefined}}.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -487,12 +487,12 @@ agent MUST run the following steps:
 
 <div algorithm="initialize WebTransport over HTTP">
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
-<var>transport</var>, a [=URL record=] |url|, a and boolean |dedicated|, run these steps.
+<var>transport</var>, a [=URL record=] |url|, and a boolean |dedicated|, run these steps.
 
 1. Let |promise| be a new promise.
-1. Return |promise| and run the following steps [=in parallel=].
 1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
    |transport|'s [=relevant settings object=].
+1. Return |promise| and run the following steps [=in parallel=].
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
    |networkPartitionKey|, |url|'s [=url/origin=], false, [=obtain a connection/http3Only=] set to
    true, and [=obtain a connection/dedicated=] set to |dedicated|.

--- a/index.bs
+++ b/index.bs
@@ -427,8 +427,13 @@ agent MUST run the following steps:
 1. If |parsedURL| is a failure, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=scheme=] is not `https`, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=fragment=] is not null, [=throw=] a {{SyntaxError}} exception.
-1. Let |dedicated| be {{WebTransport/constructor(url, options)/options}}'s
-   {{WebTransportOptions/dedicated}} if it exists, and true otherwise.
+1. Let |allowPooling| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/allowPooling}} if it exists, and false otherwise.
+1. Let |dedicated| be the negation of |allowPooling|.
+1. Let |serverCertificateFingerprints| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
+1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
+   {{TypeError}}.
 1. Let |transport| be a newly constructed {{WebTransport}} object.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[OutgoingStreams]]</dfn> internal slot
@@ -465,7 +470,7 @@ agent MUST run the following steps:
    initialized to the result of [=DatagramDuplexStream/creating=] a {{DatagramDuplexStream}},
    its [=DatagramDuplexStream/create/readable=] set to |transport|.{{[[IncomingDatagrams]]}},
    and its [=DatagramDuplexStream/create/writable=] set to |transport|.{{[[OutgoingDatagrams]]}}.
-1. Let |transport| have an
+1. Let |transport| have a
    <dfn attribute for="WebTransport">\[[Connection]]</dfn> internal slot initialized to null.
 1. Let |promise| be the result of [=initialize WebTransport over HTTP|initializing WebTransport
    over HTTP=], with |transport|, |parsedURL| and |dedicated|.
@@ -558,7 +563,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 <pre class="idl">
 dictionary WebTransportOptions {
-  bool dedicated;
+  bool allowPooling;
   sequence&lt;RTCDtlsFingerprint&gt; serverCertificateFingerprints;
 };
 </pre>
@@ -566,9 +571,9 @@ dictionary WebTransportOptions {
 <dfn dictionary>WebTransportOptions</dfn> is a dictionary of parameters
 that determine how WebTransport connection is established and used.
 
-: <dfn for="WebTransportOptions" dict-member>dedicated</dfn>
-:: Represents whether the transport should use a dedicated connection or not. When this member is
-   not specified, WebTransport will be created with a dedicated connection.
+: <dfn for="WebTransportOptions" dict-member>allowPooling</dfn>
+:: When set to true, the WebTransport connection can be pooled, that is, the network connection for
+   the WebTransport session can be shared with other HTTP/3 sessions.
 
 : <dfn for="WebTransportOptions" dict-member>serverCertificateFingerprints</dfn>
 :: This option is only supported for transports using dedicated connections.
@@ -582,6 +587,7 @@ that determine how WebTransport connection is established and used.
    or has a malformed {{RTCDtlsFingerprint/value}}.  If empty, the user agent
    SHALL use certificate verification procedures it would use for normal
    [=fetch=] operations.
+:: This cannot be used with {{WebTransportOptions/allowPooling}}.
 
 <div algorithm="compute a certificate fingerprint">
 To <dfn>compute a certificate fingerprint</dfn>, do the following:

--- a/index.bs
+++ b/index.bs
@@ -447,6 +447,9 @@ agent MUST run the following steps:
 1. Let |transport| have a
    <dfn attribute for="WebTransport">\[[Ready]]</dfn> internal
    slot, initialized to a promise.
+1. Let |transport| have a
+   <dfn attribute for="WebTransport">\[[Closed]]</dfn> internal
+   slot, initialized to a promise.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[OutgoingDatagrams]]</dfn> internal slot
    initialized to the result of [=WritableStream/creating=] a {{WritableStream}},
@@ -511,6 +514,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 : <dfn for="WebTransport" attribute>ready</dfn>
 :: On getting, it MUST return the value of the {{[[Ready]]}} internal slot.
 : <dfn for="WebTransport" attribute>closed</dfn>
+:: On getting, it MUST return the value of the {{[[Closed]]}} internal slot.
 :: This promise MUST be [=resolved=] when the transport is closed; an
    implementation SHOULD include error information in the `reason` and
    `errorCode` fields of {{WebTransportCloseInfo}}.

--- a/index.bs
+++ b/index.bs
@@ -425,8 +425,13 @@ agent MUST run the following steps:
 1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
    {{WebTransport/constructor(url, options)/url}}.
 1. If |parsedURL| is a failure, [=throw=] a {{SyntaxError}} exception.
+1. Let |parsedURL| be the [=URL record=] resulting from [=URL parser|parsing=]
+   {{WebTransport/constructor(url, options)/url}}.
 1. If |parsedURL| [=scheme=] is not `https`, [=throw=] a {{SyntaxError}} exception.
 1. If |parsedURL| [=fragment=] is not null, [=throw=] a {{SyntaxError}} exception.
+1. Let |dedicated| be true.
+1. If {{WebTransport/constructor(url, options)/options}}[`"dedicated"`] exists, then set |dedicated|
+   to it.
 1. Let |transport| be a newly constructed {{WebTransport}} object.
 1. Let |transport| have an
    <dfn attribute for="WebTransport">\[[OutgoingStreams]]</dfn> internal slot
@@ -460,23 +465,38 @@ agent MUST run the following steps:
    initialized to the result of [=DatagramDuplexStream/creating=] a {{DatagramDuplexStream}},
    its [=DatagramDuplexStream/create/readable=] set to |transport|.{{[[IncomingDatagrams]]}},
    and its [=DatagramDuplexStream/create/writable=] set to |transport|.{{[[OutgoingDatagrams]]}}.
-1. If the scheme of |parsedURL| is `https`, [=in parallel=],
-   [=initialize WebTransport over HTTP=].
+1. Let |transport| have an
+   <dfn attribute for="WebTransport">\[[Connection]]</dfn> internal slot initialized to null.
+1. [=Initialize WebTransport over HTTP=], with |transport|, |parsedURL| and |dedicated|.
 1. Return |transport|.
 
 <div algorithm="initialize WebTransport over HTTP">
-To <dfn>initialize WebTransport over HTTP</dfn> for a given |transport| and
-|parsedURL|, do the following:
+To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
+<var>transport</var>, a [=URL record=] |url|, a and boolean |dedicated|, run these steps
+[=in parallel=].
 
-1. If {{WebTransportOptions/serverCertificateFingerprints}} is specified, throw
-   a {{NotSupportedError}} exception.
-1. Establish an HTTP/3 WebTransport session to the address identified by
-   |parsedURL| following the procedures in [[!WEB-TRANSPORT-HTTP3]].
-1. If the session establishment fails, set |transport|'s {{[[WebTransportState]]}}
-   internal slot to `"failed"`, reject |transport|'s {{[[Ready]]}} with a
-   {{TypeError}} and abort these steps.
+1. Let |request| be a [=request=]  whose [=request/url=] is |url| and [=request/client=]
+   is |transport|'s [=relevant settings object=].
+1. Let |networkPartitionKey| be the result of
+   [=determine the network partition key|determining the network partition key=] with |request|.
+1. Let |connection| be the result of the result of [=obtain a connection|obtaining a connection=]
+   with |networkPartitionKey|, |url|'s [=url/origin=], false,
+   [=obtain a connection/http3Only=] set to true, and [=obtain a connection/dedicated=] set to
+   |dedicated|.
+1. If |connection| is failure, set |transport|'s {{[[WebTransportState]]}} internal slot to
+   `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these steps.
+1. Set |transport|'s {{[[Connection]]}} internal slot to |connection|.
+1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
+   represents the SETTINGS frame.
+1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't
+   contain H3_DATAGRAM with a value of 1, then set |transport|'s {{[[WebTransportState]]}} internal
+   slot to `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these
+   steps. [[!WEB-TRANSPORT-HTTP3]][[!HTTP3-DATAGRAM]].
+1. Create a WebTransport session with |connection|, as described in [[!WEB-TRANSPORT-HTTP3]].
+1. If the previous steps fails, then set |transport|'s {{[[WebTransportState]]}} internal slot to
+   `"failed"`, reject |transport|'s {{[[Ready]]}} with a {{TypeError}} and abort these steps.
 1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"connected"`.
-1. Resolve |transport|'s {{[[Ready]]}} internal slot with {{undefined}}.
+1. Resolve |transport|'s {{[[Ready]]}} with {{undefined}}.
 
 </div>
 
@@ -531,12 +551,17 @@ To <dfn>initialize WebTransport over HTTP</dfn> for a given |transport| and
 
 <pre class="idl">
 dictionary WebTransportOptions {
+  bool dedicated;
   sequence&lt;RTCDtlsFingerprint&gt; serverCertificateFingerprints;
 };
 </pre>
 
 <dfn dictionary>WebTransportOptions</dfn> is a dictionary of parameters
 that determine how WebTransport connection is established and used.
+
+: <dfn for="WebTransportOptions" dict-member>dedicated</dfn>
+:: Represents whether the transport should use a dedicated connection or not. When this member is
+   not specified, WebTransport will be created with a dedicated connection.
 
 : <dfn for="WebTransportOptions" dict-member>serverCertificateFingerprints</dfn>
 :: This option is only supported for transports using dedicated connections.

--- a/index.bs
+++ b/index.bs
@@ -491,10 +491,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 1. Let |promise| be a new promise.
 1. Return |promise| and run the following steps [=in parallel=].
-1. Let |request| be a [=request=]  whose [=request/url=] is |url| and [=request/client=]
-   is |transport|'s [=relevant settings object=].
-1. Let |networkPartitionKey| be the result of
-   [=determine the network partition key|determining the network partition key=] with |request|.
+1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
+   |transport|'s [=relevant settings object=].
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
    |networkPartitionKey|, |url|'s [=url/origin=], false, [=obtain a connection/http3Only=] set to
    true, and [=obtain a connection/dedicated=] set to |dedicated|.


### PR DESCRIPTION
This is for #128.

 - Introduce WebTransportOptions.dedicated.
 - Initialize a connection with
    https://fetch.spec.whatwg.org/#concept-connection-obtain.
- (Bonus) Introduce WebTransport.Closed and reject it when the connection establishment fails.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/217.html" title="Last updated on Mar 9, 2021, 12:39 PM UTC (60dd39d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/217/4ebe916...60dd39d.html" title="Last updated on Mar 9, 2021, 12:39 PM UTC (60dd39d)">Diff</a>