### PR TITLE
Replace IETF spec links

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -38,7 +38,7 @@ Boilerplate: omit conformance
   },
     "http3-datagram": {
     "authors": ["David Schinazi", "Lucas Pardue"],
-    "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram/",
+    "href": "https://tools.ietf.org/html/draft-ietf-masque-h3-datagram",
     "title": "Using QUIC Datagrams with HTTP/3",
     "status": "Internet-Draft",
     "publisher": "IETF"

--- a/index.bs
+++ b/index.bs
@@ -38,7 +38,7 @@ Boilerplate: omit conformance
   },
     "http3-datagram": {
     "authors": ["David Schinazi", "Lucas Pardue"],
-    "href": "https://tools.ietf.org/html/draft-ietf-masque-h3-datagram",
+    "href": "https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/",
     "title": "Using QUIC Datagrams with HTTP/3",
     "status": "Internet-Draft",
     "publisher": "IETF"
@@ -59,7 +59,7 @@ Boilerplate: omit conformance
   },
   "web-transport-http3": {
     "authors": ["Victor Vasiliev"],
-    "href": "https://tools.ietf.org/html/draft-ietf-webtrans-http3",
+    "href": "https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/",
     "title": "WebTransport over HTTP/3",
     "status": "Internet-Draft",
     "publisher": "IETF"

--- a/index.bs
+++ b/index.bs
@@ -31,7 +31,7 @@ Boilerplate: omit conformance
   },
   "quic-datagram": {
     "authors": ["Tommy Pauly", "Eric Kinnear", "David Schinazi"],
-    "href": "https://tools.ietf.org/html/draft-ietf-quic-datagram",
+    "href": "https://datatracker.ietf.org/doc/html/draft-ietf-quic-datagram/",
     "title": "An Unreliable Datagram Extension to QUIC",
     "status": "Internet-Draft",
     "publisher": "IETF"

--- a/index.bs
+++ b/index.bs
@@ -38,7 +38,7 @@ Boilerplate: omit conformance
   },
     "http3-datagram": {
     "authors": ["David Schinazi", "Lucas Pardue"],
-    "href": "https://datatracker.ietf.org/doc/draft-ietf-masque-h3-datagram/",
+    "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram/",
     "title": "Using QUIC Datagrams with HTTP/3",
     "status": "Internet-Draft",
     "publisher": "IETF"
@@ -59,7 +59,7 @@ Boilerplate: omit conformance
   },
   "web-transport-http3": {
     "authors": ["Victor Vasiliev"],
-    "href": "https://datatracker.ietf.org/doc/draft-ietf-webtrans-http3/",
+    "href": "https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/",
     "title": "WebTransport over HTTP/3",
     "status": "Internet-Draft",
     "publisher": "IETF"


### PR DESCRIPTION
https://tools.ietf.org/html/... links for  QUIC-DATAGRAM and
WEBTRANSPORT-HTTPS sometimes return 404 and that makes
buildbots  unhappy (see
https://github.com/w3c/webtransport/pull/220/checks?check_run_id=2055921327
for example). Use https://datatracker.ietf.org/doc/... links instead
to mitigate the problem.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/224.html" title="Last updated on Mar 10, 2021, 7:35 AM UTC (6b85afe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/224/4ebe916...6b85afe.html" title="Last updated on Mar 10, 2021, 7:35 AM UTC (6b85afe)">Diff</a>