### PR TITLE
Fix Web IDL: "bool" -> "boolean"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -561,7 +561,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 <pre class="idl">
 dictionary WebTransportOptions {
-  bool allowPooling;
+  boolean allowPooling;
   sequence&lt;RTCDtlsFingerprint&gt; serverCertificateFingerprints;
 };
 </pre>


### PR DESCRIPTION
Booleans in Web IDL have the type `boolean`. The type `bool` does not exist.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/227.html" title="Last updated on Mar 16, 2021, 8:42 AM UTC (51185e8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/227/02a7570...51185e8.html" title="Last updated on Mar 16, 2021, 8:42 AM UTC (51185e8)">Diff</a>