### PR TITLE
[Editorial] Tidy up "internal slots"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -461,7 +461,7 @@ A {{WebTransport}} object has the following internal slots.
  <tbody>
   <tr>
    <td><dfn>\[[OutgoingStreams]]</dfn>
-   <td class="non-normative">A sequence of {{OutgoingStream}} objects.
+   <td class="non-normative">A sequence of {{SendStream}} objects.
   </tr>
   <tr>
    <td><dfn>\[[ReceivedStreams]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -465,7 +465,7 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>\[[ReceivedStreams]]</dfn>
-   <td class="non-normative">A {{ReadableStream}} consisting of {{IncomingStream}} objects.
+   <td class="non-normative">A {{ReadableStream}} consisting of {{ReceiveStream}} objects.
   </tr>
   <tr>
    <td><dfn>\[[ReceivedBidirectionalStreams]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -527,36 +527,36 @@ agent MUST run the following steps:
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
    {{TypeError}}.
 1. Let |transport| be a newly constructed {{WebTransport}} object, with:
-: [=[[OutgoingStreams]]=]
-:: empty
-: [=[[ReceivedStreams]]=]
-:: a new {{ReadableStream}}
-: [=[[ReceivedBidirectionalStreams]]=]
-:: a new {{ReadableStream}}
-: [=[[State]]=]
-:: `"connecting"`
-: [=[[Ready]]=]
-:: a new promise
-: [=[[Closed]]=]
-:: a new promise
-: [=[[Datagrams]]=]
-:: null
-   <div class="note">
-    <p>This slot cannot be set to null, but this case is fine because we set a value in the
-       subsequent steps.</p>
-   </div>
-: [=[[OutgoingDatagramsQueue]]=]
-:: an empty queue
-: [=[[OutgoingDatagramsHighWaterMark]]=]
-:: an [=implementation-defined=] integer
-   <div class="note">
-    <p>This implementation-defined value should be tuned to ensure decent throughput, without
-       jeopardizing the timeliness of transmitted data.</p>
-   </div>
-: [=[[OutgoingDatagramsExpirationDuration]]=]
-:: null
-: [=[[Connection]]=]
-:: null
+   : [=[[OutgoingStreams]]=]
+   :: empty
+   : [=[[ReceivedStreams]]=]
+   :: a new {{ReadableStream}}
+   : [=[[ReceivedBidirectionalStreams]]=]
+   :: a new {{ReadableStream}}
+   : [=[[State]]=]
+   :: `"connecting"`
+   : [=[[Ready]]=]
+   :: a new promise
+   : [=[[Closed]]=]
+   :: a new promise
+   : [=[[Datagrams]]=]
+   :: null
+      <div class="note">
+       <p>This slot cannot be set to null, but this case is fine because we set a value in the
+          subsequent steps.</p>
+      </div>
+   : [=[[OutgoingDatagramsQueue]]=]
+   :: an empty queue
+   : [=[[OutgoingDatagramsHighWaterMark]]=]
+   :: an [=implementation-defined=] integer
+      <div class="note">
+       <p>This implementation-defined value should be tuned to ensure decent throughput, without
+          jeopardizing the timeliness of transmitted data.</p>
+      </div>
+   : [=[[OutgoingDatagramsExpirationDuration]]=]
+   :: null
+   : [=[[Connection]]=]
+   :: null
 1. Let |outgoingDatagrams| be the result of [=WritableStream/creating=] a {{WritableStream}},
    its [=WritableStream/create/writeAlgorithm=] set to [=writeDatagrams=] given
    |transport| as a parameter.

--- a/index.bs
+++ b/index.bs
@@ -563,7 +563,7 @@ agent MUST run the following steps:
 1. Let |incomingDatagrams| be the result of <a dfn for="ReadableStream">creating</a> a
    {{ReadableStream}}. `transport.[[IncomingDatagrams]]` is provided datagrams
     using the [=readDatagrams=] algorithm given |transport| as a parameter.
-1. Set |transport|'s [=[[Datagrams]]=] be the result of [=DatagramDuplexStream/creating=] a
+1. Set |transport|'s [=[[Datagrams]]=] to the result of [=DatagramDuplexStream/creating=] a
    {{DatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
    |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
 1. Let |promise| be the result of [=initialize WebTransport over HTTP|initializing WebTransport

--- a/index.bs
+++ b/index.bs
@@ -626,9 +626,9 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
    When close is called, the user agent MUST run the following steps:
      1. Let |transport| be the WebTransport on which `close` is invoked.
-     1. If |transport|'s [=[[WebTransportState]]=] is `"closed"` or `"failed"`,
+     1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`,
         then abort these steps.
-     1. Set |transport|'s [=[[WebTransportState]]=] to `"closed"`.
+     1. Set |transport|'s [=[[State]]=] to `"closed"`.
      1. Let `closeInfo` be the first argument.
      1. If the connection is dedicated, start the [=Immediate Close=] procedure
         by sending an CONNECTION_CLOSE frame with its error code value set to the value

--- a/index.bs
+++ b/index.bs
@@ -527,36 +527,36 @@ agent MUST run the following steps:
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
    {{TypeError}}.
 1. Let |transport| be a newly constructed {{WebTransport}} object, with:
-   : [=[[OutgoingStreams]]=]
-   :: empty
-   : [=[[ReceivedStreams]]=]
-   :: a new {{ReadableStream}}
-   : [=[[ReceivedBidirectionalStreams]]=]
-   :: a new {{ReadableStream}}
-   : [=[[State]]=]
-   :: `"connecting"`
-   : [=[[Ready]]=]
-   :: a new promise
-   : [=[[Closed]]=]
-   :: a new promise
-   : [=[[Datagrams]]=]
-   :: null
-      <div class="note">
-       <p>This slot cannot be set to null, but this case is fine because we set a value in the
-          subsequent steps.</p>
-      </div>
-   : [=[[OutgoingDatagramsQueue]]=]
-   :: an empty queue
-   : [=[[OutgoingDatagramsHighWaterMark]]=]
-   :: an [=implementation-defined=] integer
-      <div class="note">
-       <p>This implementation-defined value should be tuned to ensure decent throughput, without
-          jeopardizing the timeliness of transmitted data.</p>
-      </div>
-   : [=[[OutgoingDatagramsExpirationDuration]]=]
-   :: null
-   : [=[[Connection]]=]
-   :: null
+    : [=[[OutgoingStreams]]=]
+    :: empty
+    : [=[[ReceivedStreams]]=]
+    :: a new {{ReadableStream}}
+    : [=[[ReceivedBidirectionalStreams]]=]
+    :: a new {{ReadableStream}}
+    : [=[[State]]=]
+    :: `"connecting"`
+    : [=[[Ready]]=]
+    :: a new promise
+    : [=[[Closed]]=]
+    :: a new promise
+    : [=[[Datagrams]]=]
+    :: null
+       <div class="note">
+        <p>This slot cannot be set to null, but this case is fine because we set a value in the
+           subsequent steps.</p>
+       </div>
+    : [=[[OutgoingDatagramsQueue]]=]
+    :: an empty queue
+    : [=[[OutgoingDatagramsHighWaterMark]]=]
+    :: an [=implementation-defined=] integer
+       <div class="note">
+        <p>This implementation-defined value should be tuned to ensure decent throughput, without
+           jeopardizing the timeliness of transmitted data.</p>
+       </div>
+    : [=[[OutgoingDatagramsExpirationDuration]]=]
+    :: null
+    : [=[[Connection]]=]
+    :: null
 1. Let |outgoingDatagrams| be the result of [=WritableStream/creating=] a {{WritableStream}},
    its [=WritableStream/create/writeAlgorithm=] set to [=writeDatagrams=] given
    |transport| as a parameter.

--- a/index.bs
+++ b/index.bs
@@ -483,7 +483,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>\[[Closed]]</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
-   closed gracefully, and rejected when it is closed abruptly or failed on initialization.
+   closed gracefully, or rejected when it is closed abruptly or failed on initialization.
   </tr>
   <tr>
    <td><dfn>\[[Datagrams]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -478,7 +478,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>\[[Ready]]</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
-   ready to use.
+   ready to use, or rejected if it failed to connect.
   </tr>
   <tr>
    <td><dfn>\[[Closed]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -191,9 +191,9 @@ interface mixin UnidirectionalStreamsTransport {
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Let |transport| be the `UnidirectionalStreamsTransport` on which
         the `incomingUnidirectionalStreams` getter is invoked.
-     1. Return the value of the {{[[ReceivedStreams]]}} internal slot.
+     1. Return |transport|'s [=[[ReceivedStreams]]=].
      1. For each unidirectional stream received, create a corresponding
-        {{ReceiveStream}} and insert it into {{[[ReceivedStreams]]}}. As data
+        {{ReceiveStream}} and insert it into [=[[ReceivedStreams]]=]. As data
         is received over the unidirectional stream, insert that data into the
         corresponding `ReceiveStream` object.  When the remote side closes or
         aborts the stream, close or abort the corresponding `ReceiveStream`.
@@ -212,7 +212,7 @@ steps:
 1. Queue a task to run the following sub-steps:
   1. If |transport|'s state is `"closed"` or `"failed"`, abort these sub-steps.
   1. Let |stream| be a newly created {{SendStream}} for |association|.
-  1. Add |stream| to |transport|'s {{[[OutgoingStreams]]}} slot.
+  1. Add |stream| to |transport|'s [=[[OutgoingStreams]]=].
   1. Resolve |p| with |stream|.
 
 </div>
@@ -279,9 +279,9 @@ interface mixin BidirectionalStreamsTransport {
 
    The getter steps for the `incomingBidirectionalStreams` attribute SHALL be:
 
-     1. Return the value of the {{[[ReceivedBidirectionalStreams]]}} internal slot.
+     1. Return [=[[ReceivedBidirectionalStreams]]=].
      1. For each bidirectional stream received, create a corresponding
-        {{BidirectionalStream}} and insert it into {{[[ReceivedBidirectionalStreams]]}}.
+        {{BidirectionalStream}} and insert it into [=[[ReceivedBidirectionalStreams]]=].
         As data is received over the bidirectional stream, insert that data into the
         corresponding {{BidirectionalStream}}.  When the remote side closes or aborts
         the stream, close or abort the corresponding {{BidirectionalStream}}.
@@ -300,8 +300,8 @@ interface mixin BidirectionalStreamsTransport {
 1. Queue a task to run the following sub-steps:
   1. If |transport|'s state is `"closed"` or `"failed"`, abort these sub-steps.
   1. Let |stream| be a newly created {{BidirectionalStream}} object for |association|.
-  1. Add |stream| to |transport|'s {{[[ReceivedBidirectionalStreams]]}} slot.
-  1. Add |stream| to |transport|'s {{[[OutgoingStreams]]}} slot.
+  1. Add |stream| to |transport|'s [=[[ReceivedBidirectionalStreams]]=].
+  1. Add |stream| to |transport|'s [=[[OutgoingStreams]]=].
   1. Resolve |p| with |stream|.
 
 </div>
@@ -342,7 +342,7 @@ interface mixin DatagramTransport {
    Datagrams written to the returned {{WritableStream}} member will be sent.
 
    The getter steps for the `datagrams` attribute SHALL be:
-     1. Return the value of the {{[[Datagrams]]}} internal slot.
+     1. Return [=this=]'s [=[[Datagrams]]=].
 
 ## Procedures ## {#datagrams-transport-procedures}
 
@@ -358,9 +358,9 @@ The <dfn>writeDatagrams</dfn> algorithm is given a |transport| as parameter and
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of bytes which |data| represents.
 1. Let |chunk| be a tuple of |bytes|, |timestamp| and |promise|.
-1. Enqueue |chunk| to |transport|'s {{[[OutgoingDatagramsQueue]]}}.
-1. If the length of |transport|'s {{[[OutgoingDatagramsQueue]]}} is less than
-   |transport|'s {{[[OutgoingDatagramsHighWaterMark]]}}, then [=resolve=] |promise| with undefined.
+1. Enqueue |chunk| to |transport|'s [=[[OutgoingDatagramsQueue]]=].
+1. If the length of |transport|'s [=[[OutgoingDatagramsQueue]]=] is less than
+   |transport|'s [=[[OutgoingDatagramsHighWaterMark]]=], then [=resolve=] |promise| with undefined.
 1. Return |promise|.
 
 Note: The associated {{WritableStream}} calls [=writeDatagrams=] only when all the promises that
@@ -369,8 +369,8 @@ duration work well only when the web developer pays attention to
 {{WritableStreamDefaultWriter/ready|WritableStreamDefaultWriter.ready}}.
 
 To <dfn>sendDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
-1. Let |queue| be |transport|'s {{[[OutgoingDatagramsQueue]]}}.
-1. Let |duration| be |transport|'s {{[[OutgoingDatagramsExpirationDuration]]}}.
+1. Let |queue| be |transport|'s [=[[OutgoingDatagramsQueue]]=].
+1. Let |duration| be |transport|'s [=[[OutgoingDatagramsExpirationDuration]]=].
 1. If |duration| is null, then set |duration| to an [=implementation-defined=] value.
 1. While |queue| is not empty:
   1. Let |bytes|, |timestamp| and |promise| be |queue|'s first element.
@@ -386,8 +386,8 @@ To <dfn>sendDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
   1. Remove the first element from |queue|.
 
 The user agent SHOULD run [=sendDatagrams=] for any {{WebTransport}} object whose
-{{[[WebTransportState]]}} is `"connected"` as soon as reasonably possible whenever
-the algorithm can make progress.
+[=[[State]]=] is `"connected"` as soon as reasonably possible whenever the algorithm can make
+progress.
 
 # `DatagramDuplexStream` Interface #  {#duplex-stream}
 
@@ -447,6 +447,69 @@ WebTransport includes BidirectionalStreamsTransport;
 WebTransport includes DatagramTransport;
 </pre>
 
+## Internal slots ## {#webtransport-internal-slots}
+
+A {{WebTransport}} object has the following internal slots.
+
+<table class="data" dfn-for="WebTransport">
+ <thead>
+  <tr>
+   <th>Internal Slot
+   <th>Description (<em>non-normative</em>)
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>\[[OutgoingStreams]]</dfn>
+   <td class="non-normative">A sequence of {{OutgoingStream}} objects.
+  </tr>
+  <tr>
+   <td><dfn>\[[ReceivedStreams]]</dfn>
+   <td class="non-normative">A {{ReadableStream}} consisting of {{IncomingStream}} objects.
+  </tr>
+  <tr>
+   <td><dfn>\[[ReceivedBidirectionalStreams]]</dfn>
+   <td class="non-normative">A {{ReadableStream}} consisting of {{BidirectionalStream}} objects.
+  </tr>
+  <tr>
+   <td><dfn>\[[State]]</dfn>
+   <td class="non-normative">A {{WebTransportState}}.
+  </tr>
+  <tr>
+   <td><dfn>\[[Ready]]</dfn>
+   <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
+   ready to use.
+  </tr>
+  <tr>
+   <td><dfn>\[[Closed]]</dfn>
+   <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
+   closed gracefully, and rejected when it is closed abruptly or failed on initialization.
+  </tr>
+  <tr>
+   <td><dfn>\[[Datagrams]]</dfn>
+   <td class="non-normative">A {{DatagramDuplexStream}}.
+  </tr>
+  <tr>
+   <td><dfn>\[[OutgoingDatagramsQueue]]</dfn>
+   <td class="non-normative">A queue of tuples of an outgoing datagram, a timestamp and a promise
+   which is resolved when the datagram is sent or discarded.
+  </tr>
+  <tr>
+   <td><dfn>\[[OutgoingDatagramsHighWaterMark]]</dfn>
+   <td class="non-normative">An integer representing the [=high water mark=] of the outgoing
+   datagrams.
+  </tr>
+  <tr>
+   <td><dfn>\[[OutgoingDatagramsExpirationDuration]]</dfn>
+   <td class="non-normative">A {{double}} value representing the expiration duration for outgoing
+   datagrams (in seconds), or null.
+  </tr>
+  <tr>
+   <td><dfn>\[[Connection]]</dfn>
+   <td class="non-normative">A [=connection=] for this {{WebTransport}} object, or null.
+  </tr>
+</table>
+
 ## Constructor ##  {#webtransport-constructor}
 
 When the {{WebTransport/constructor()}} constructor is invoked, the user
@@ -463,67 +526,56 @@ agent MUST run the following steps:
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
    {{TypeError}}.
-1. Let |transport| be a newly constructed {{WebTransport}} object.
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[OutgoingStreams]]</dfn> internal slot
-   representing a sequence of {{OutgoingStream}} objects, initialized to empty.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[ReceivedStreams]]</dfn> internal slot
-   representing a {{ReadableStream}} of {{IncomingStream}} objects, initialized
-   to empty.
-1. Let |transport| have a
-  <dfn attribute for="WebTransport">\[[ReceivedBidirectionalStreams]]</dfn>
-  internal slot representing a {{ReadableStream}} of {{BidirectionalStream}}
-  objects, initialized to empty.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[WebTransportState]]</dfn> internal
-   slot, initialized to `"connecting"`.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[Ready]]</dfn> internal
-   slot, initialized to a promise.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[Closed]]</dfn> internal
-   slot, initialized to a promise.
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[OutgoingDatagrams]]</dfn> internal slot
-   initialized to the result of [=WritableStream/creating=] a {{WritableStream}},
+1. Let |transport| be a newly constructed {{WebTransport}} object, with:
+: [=[[OutgoingStreams]]=]
+:: empty
+: [=[[ReceivedStreams]]=]
+:: a new {{ReadableStream}}
+: [=[[ReceivedBidirectionalStreams]]=]
+:: a new {{ReadableStream}}
+: [=[[State]]=]
+:: `"connecting"`
+: [=[[Ready]]=]
+:: a new promise
+: [=[[Closed]]=]
+:: a new promise
+: [=[[Datagrams]]=]
+:: null
+   <div class="note">
+    <p>This slot cannot be set to null, but this case is fine because we set a value in the
+       subsequent steps.</p>
+   </div>
+: [=[[OutgoingDatagramsQueue]]=]
+:: an empty queue
+: [=[[OutgoingDatagramsHighWaterMark]]=]
+:: an [=implementation-defined=] integer
+   <div class="note">
+    <p>This implementation-defined value should be tuned to ensure decent throughput, without
+       jeopardizing the timeliness of transmitted data.</p>
+   </div>
+: [=[[OutgoingDatagramsExpirationDuration]]=]
+:: null
+: [=[[Connection]]=]
+:: null
+1. Let |outgoingDatagrams| be the result of [=WritableStream/creating=] a {{WritableStream}},
    its [=WritableStream/create/writeAlgorithm=] set to [=writeDatagrams=] given
    |transport| as a parameter.
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[OutgoingDatagramsQueue]]</dfn> internal slot
-   initialized to an empty queue.
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[OutgoingDatagramsHighWaterMark]]</dfn> internal slot
-   initialized to an [=implementation-defined=] value.
-   <div class="note">
-     <p>This implementation-defined value should be tuned to ensure decent throughput, without jeopardizing the timeliness of transmitted data.</p>
-    </div>
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[IncomingDatagrams]]</dfn> internal
-   slot initialized to the result of <a dfn for="ReadableStream">creating</a> a
+1. Let |incomingDatagrams| be the result of <a dfn for="ReadableStream">creating</a> a
    {{ReadableStream}}. `transport.[[IncomingDatagrams]]` is provided datagrams
     using the [=readDatagrams=] algorithm given |transport| as a parameter.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[Datagrams]]</dfn> internal slot
-   initialized to the result of [=DatagramDuplexStream/creating=] a {{DatagramDuplexStream}},
-   its [=DatagramDuplexStream/create/readable=] set to |transport|.{{[[IncomingDatagrams]]}},
-   and its [=DatagramDuplexStream/create/writable=] set to |transport|.{{[[OutgoingDatagrams]]}}.
-1. Let |transport| have an
-   <dfn attribute for="WebTransport">\[[OutgoingDatagramsExpirationDuration]]</dfn> internal slot
-   initialized to null.
-1. Let |transport| have a
-   <dfn attribute for="WebTransport">\[[Connection]]</dfn> internal slot initialized to null.
+1. Set |transport|'s [=[[Datagrams]]=] be the result of [=DatagramDuplexStream/creating=] a
+   {{DatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
+   |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
 1. Let |promise| be the result of [=initialize WebTransport over HTTP|initializing WebTransport
    over HTTP=], with |transport|, |parsedURL| and |dedicated|.
 1. [=Upon fulfillment=] of |promise|, run these steps:
-   1. If |transport|'s {{[[WebTransportState]]}} internal slot is not `"connecting"`, then abort
-      these steps.
-   1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"connected"`.
-   1. Resolve |transport|'s {{[[Ready]]}} internal slot with {{undefined}}.
+   1. If |transport|'s [=[[State]]=] is not `"connecting"`, then abort these steps.
+   1. Set |transport|'s [=[[State]]=] to `"connected"`.
+   1. Resolve |transport|'s [=[[Ready]]=] with {{undefined}}.
 1. [=Upon rejection=] of |promise| with |error|, run these steps:
-   1. Set |transport|'s {{[[WebTransportState]]}} internal slot to `"failed"`.
-   1. Reject |transport|'s {{[[Ready]]}} internal slot with |error|.
-   1. Reject |transport|'s {{[[Closed]]}} internal slot with |error|.
+   1. Set |transport|'s [=[[State]]=] to `"failed"`.
+   1. Reject |transport|'s [=[[Ready]]=] with |error|.
+   1. Reject |transport|'s [=[[Closed]]=] with |error|.
 1. Return |transport|.
 
 <div algorithm="initialize WebTransport over HTTP">
@@ -538,7 +590,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    |networkPartitionKey|, |url|'s [=url/origin=], false, [=obtain a connection/http3Only=] set to
    true, and [=obtain a connection/dedicated=] set to |dedicated|.
 1. If |connection| is failure, then reject |promise| with a {{TypeError}} and abort these steps.
-1. Set |transport|'s {{[[Connection]]}} internal slot to |connection|.
+1. Set |transport|'s [=[[Connection]]=] to |connection|.
 1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
    represents the SETTINGS frame.
 1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't
@@ -553,18 +605,17 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 ## Attributes ##  {#webtransport-attributes}
 
 : <dfn for="WebTransport" attribute>state</dfn>
-:: The current state of the transport. On getting, it MUST return the value of
-   the {{[[WebTransportState]]}} internal slot.
+:: The current state of the transport. On getting, it MUST return [=this=]'s [=[[State]]=].
 : <dfn for="WebTransport" attribute>ready</dfn>
-:: On getting, it MUST return the value of the {{[[Ready]]}} internal slot.
+:: On getting, it MUST return [=this=]'s [=[[Ready]]=].
 : <dfn for="WebTransport" attribute>closed</dfn>
-:: On getting, it MUST return the value of the {{[[Closed]]}} internal slot.
+:: On getting, it MUST return [=this=]'s [=[[Closed]]=].
 :: This promise MUST be [=resolved=] when the transport is closed; an
    implementation SHOULD include error information in the `reason` and
    `errorCode` fields of {{WebTransportCloseInfo}}.
 : <dfn for="WebTransport" attribute>onstatechange</dfn>
 :: This event handler, of event handler event type `statechange`, MUST be fired
-   any time the {{[[WebTransportState]]}} slot changes, unless the state changes
+   any time the [=[[State]]=] changes, unless the state changes
    due to calling {{WebTransport/close}}.
 
 ## Methods ##  {#webtransport-methods}
@@ -575,9 +626,9 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
    When close is called, the user agent MUST run the following steps:
      1. Let |transport| be the WebTransport on which `close` is invoked.
-     1. If |transport|'s {{[[WebTransportState]]}} is `"closed"` or `"failed"`,
+     1. If |transport|'s [=[[WebTransportState]]=] is `"closed"` or `"failed"`,
         then abort these steps.
-     1. Set |transport|'s {{[[WebTransportState]]}} to `"closed"`.
+     1. Set |transport|'s [=[[WebTransportState]]=] to `"closed"`.
      1. Let `closeInfo` be the first argument.
      1. If the connection is dedicated, start the [=Immediate Close=] procedure
         by sending an CONNECTION_CLOSE frame with its error code value set to the value
@@ -683,34 +734,31 @@ enum WebTransportState {
 : <dfn for="WebTransportState" enum-value>"closed"</dfn>
 :: The transport has been closed intentionally via a call to
    {{WebTransport/close()}} or receipt of a closing message from the remote
-   side.  When the {{WebTransport}}'s internal {{[[WebTransportState]]}} slot
+   side.  When the {{WebTransport}}'s [=[[State]]=]
    transitions to `closed` the user agent MUST run the following steps:
 
    1. Let |transport| be the {{WebTransport}}.
-   1. Close the {{ReadableStream}} in |transport|'s {{[[ReceivedStreams]]}} internal slot.
+   1. Close the {{ReadableStream}} in |transport|'s [=[[ReceivedStreams]]=].
    1. Close the {{ReadableStream}} in |transport|'s
-      {{[[ReceivedBidirectionalStreams]]}} internal slot.
-   1. For each {{OutgoingStream}} in |transport|'s {{[[OutgoingStreams]]}}
-      internal slot run the following:
+      [=[[ReceivedBidirectionalStreams]]=].
+   1. For each {{OutgoingStream}} in |transport|'s [=[[OutgoingStreams]]=]
+      run the following:
 
      1. Let |stream| be the {{OutgoingStream}}.
-     1. Remove the |stream| from the |transport|'s {{[[OutgoingStreams]]}}
-        internal slot.
+     1. Remove the |stream| from the |transport|'s [=[[OutgoingStreams]]=].
 
 : <dfn for="WebTransportState" enum-value>"failed"</dfn>
 :: The transport has been closed as the result of an error (such as receipt of
-   an error alert). When the WebTransport's internal {{[[WebTransportState]]}}
-   slot transitions to `failed` the user agent MUST run the following steps:
+   an error alert). When the WebTransport's [=[[State]]=] transitions to
+   `failed` the user agent MUST run the following steps:
 
-   1. Close the {{ReadableStream}} in |transport|'s {{[[ReceivedStreams]]}}
-      internal slot.
+   1. Close the {{ReadableStream}} in |transport|'s [=[[ReceivedStreams]]=].
    1. Close the {{ReadableStream}} in |transport|'s
-      {{[[ReceivedBidirectionalStreams]]}} internal slot.
-   1. For each {{OutgoingStream}} in |transport|'s {{[[OutgoingStreams]]}}
-      internal slot run the following:
+      [=[[ReceivedBidirectionalStreams]]=].
+   1. For each {{OutgoingStream}} in |transport|'s [=[[OutgoingStreams]]=]
+      run the following:
 
-     1. Remove the |stream| from the |transport|'s {{[[OutgoingStreams]]}}
-        internal slot.
+     1. Remove the |stream| from the |transport|'s [=[[OutgoingStreams]]=].
 
 ## `WebTransportCloseInfo` Dictionary ##  {#web-transport-close-info}
 
@@ -813,8 +861,7 @@ initialization steps.
       1. Let |stream| be the {{OutgoingStream}} object.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
-      1. Remove the stream from the |transport|'s {{[[OutgoingStreams]]}}
-         internal slot.
+      1. Remove the stream from the |transport|'s [=[[OutgoingStreams]]=].
       1. [=Resolve=] the promise with the resulting {{StreamAbortInfo}} with
          the {{StreamAbortInfo/errorCode}} set to the value from the aborting
          message from the remote side.
@@ -830,8 +877,7 @@ initialization steps.
         writing.
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
-     1. Remove the stream from the transport's {{[[OutgoingStreams]]}} internal
-        slot.
+     1. Remove the stream from the transport's [=[[OutgoingStreams]]=].
      1. Let |abortInfo| be the first argument.
      1. Start the closing procedure by sending a RST_STREAM frame with its
         error code set to the value of |abortInfo.errorCode|.


### PR DESCRIPTION
- Stop defining internal slots in the constructor and have tables
   for internal slots instead.
 - Remove "internal slots" words as they are redundant.
 - Replace \{{[[slot]]}} with \[=[[slot]]=].

Fixes #222 
Fixes #223


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/244.html" title="Last updated on Apr 13, 2021, 9:10 PM UTC (5887633)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/244/87bcbf1...5887633.html" title="Last updated on Apr 13, 2021, 9:10 PM UTC (5887633)">Diff</a>