### PR TITLE
Rename abortWriting()/writingAborted → reset()/remoteCanceled & abortReading()/readingAborted → cancel()/remoteReset

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1081,6 +1081,7 @@ queue a task to run the following:
          from.
       1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=].
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
+      1. Perform ! [$WritableStreamStartErroring$](|stream|, |reason|).
       1. [=Resolve=] {{SendStream}}.{{SendStream/remoteCanceled}} with a new
          {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
          |reason|.
@@ -1145,7 +1146,7 @@ queue a task to run the following:
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
       1. Let |reason| be the value from the message from the remote side.
-      1. Error |stream| with |reason| (TODO).
+      1. Perform ! [$ReadableStreamError$](|stream|, |reason|).
 
 The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
      1. Let |stream| be the {{ReceiveStream}} object.

--- a/index.bs
+++ b/index.bs
@@ -1038,46 +1038,67 @@ that can be written to, to transmit data to the remote host.
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
 interface SendStream : WritableStream /* of Uint8Array */ {
-  readonly attribute Promise&lt;StreamAbortInfo&gt; writingAborted;
-  undefined abortWriting(optional StreamAbortInfo abortInfo = {});
+  readonly attribute Promise&lt;StreamAbortInfo&gt; dropped;
+  undefined drop(optional StreamAbortInfo abortInfo = {});
 };
 </pre>
 
-## Overview ##  {#outgoing-stream-overview}
+## Overview ##  {#send-stream-overview}
 
 The {{SendStream}} will be initialized by running the {{WritableStream}}
 initialization steps.
 
-## Attributes ##  {#outgoing-stream-attributes}
+## Attributes ##  {#send-stream-attributes}
 
-: <dfn attribute for="SendStream">writingAborted</dfn>
-:: The `writingAborted` attribute represents a promise that is [=fulfilled=]
+: <dfn attribute for="SendStream">dropped</dfn>
+:: The `dropped` attribute represents a promise that is [=fulfilled=]
     when the a message from the remote side aborting the stream is received.
-    For QUIC, that message is a STOP_SENDING frame. When the stream receives
-    this mesage, the user agent MUST run the following:
-      1. Let |stream| be the {{SendStream}} object.
-      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
-         from.
-      1. Remove the stream from the |transport|'s [=[[OutgoingStreams]]=].
-      1. [=Resolve=] the promise with the resulting {{StreamAbortInfo}} with
-         the {{StreamAbortInfo/errorCode}} set to the value from the aborting
-         message from the remote side.
+    For QUIC, that message is a STOP_SENDING frame.
 
-## Methods ##  {#outgoing-stream-methods}
+## Methods ##  {#send-stream-methods}
 
-: <dfn method for="SendStream">abortWriting()</dfn>
+: <dfn method for="SendStream">drop()</dfn>
 :: A hard shutdown of the {{SendStream}}. It may be called regardless of
    whether the {{SendStream}} was created by the local or remote peer. When
-   the `abortWriting` method is called, the user agent MUST run the following
+   the `drop` method is called, the user agent MUST run the following
    steps:
      1. Let |stream| be the {{SendStream}} object which is about to abort
         writing.
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
-     1. Remove the stream from the transport's [=[[OutgoingStreams]]=].
+     1. Remove |stream| from the transport's [=[[OutgoingStreams]]=].
      1. Let |abortInfo| be the first argument.
-     1. Start the closing procedure by sending a RST_STREAM frame with its
-        error code set to the value of |abortInfo.errorCode|.
+     1. Let |reason| be |abortInfo|.errorCode.
+     1. If it hasn't started already, start the closing procedure by sending a
+        RST_STREAM frame with its error code set to the value of |reason|.
+     1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
+     1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
+
+## Procedures ##  {#send-stream-procedures}
+
+When a {{SendStream}} receives a STOP_SENDING frame from the remote side,
+the user agent MUST queue a task to run the following:
+      1. Let |stream| be the {{SendStream}} object.
+      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
+         from.
+      1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=]
+         internal slot.
+      1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
+      1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
+      1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
+      1. [=Resolve=] {{SendStream}}.{{SendStream/dropped}} with a new
+         {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
+         |reason|.
+
+The {{SendStream}}'s <dfn>abortAlgorithm</dfn> (TODO) is:
+     1. Let |stream| be the {{ReceiveStream}} object.
+     1. Let |transport| be the {{WebTransport}}, which the |stream| was created
+        from.
+     1. Let |reason| be the first argument, if it is numeric, or 0.
+     1. If |stream| was aborted by a STOP_SENDING frame, abort these steps.
+     1. If it hasn't started already, start the closing procedure by sending a
+        STOP_SENDING frame to the remote side, with its error code set to the
+        value of |reason|.
 
 ## `StreamAbortInfo` Dictionary ##  {#stream-abort-info}
 
@@ -1104,47 +1125,42 @@ that can be read from, to consume data received from the remote host.
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
 interface ReceiveStream : ReadableStream /* of Uint8Array */ {
-  readonly attribute Promise&lt;StreamAbortInfo&gt; readingAborted;
-  undefined abortReading(optional StreamAbortInfo abortInfo = {});
+  readonly attribute Promise&lt;StreamAbortInfo&gt; remoteReset;
 };
 </pre>
 
-## Overview ##  {#incoming-stream-overview}
+## Overview ##  {#receive-stream-overview}
 
 The {{ReceiveStream}} will be initialized by running the {{ReadableStream}}
 initialization steps.
 
-## Attributes ##  {#incoming-stream-attributes}
+## Attributes ##  {#receive-stream-attributes}
 
-: <dfn attribute for="ReceiveStream">readingAborted</dfn>
-:: The `readingAborted` attribute represents a promise that is [=fulfilled=]
+:: The `remoteReset` attribute represents a promise that is [=fulfilled=]
     when the a message from the remote side aborting the stream is received.
-    For QUIC, that message is a RST_STREAM frame. When the stream receives
-    this mesage, the user agent MUST run the following:
-      1. Let |stream| be the {{ReceiveStream}} object for which the abort
+    For QUIC, that message is a RST_STREAM frame.
+
+## Procedures ##  {#receive-stream-procedures}
+
+When an {{ReceiveStream}} receives a RST_STREAM frame from the remote side, the
+user agent MUST queue a task to run the following:
+      1. Let |stream| be the {{ReceiveStream}} object for which the reset
          message was received.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
-      1. [=Resolve=] the promise with the resulting {{StreamAbortInfo}} with
-         the {{StreamAbortInfo/errorCode}} set to the value from the aborting
-         message from the remote side.
+      1. Let |reason| be the value from the RST_STREAM frame from the remote side.
+      1. Let |p| be the result of [=ReadableStream/cancel|canceling=] |stream|,
+         with |reason|.
+     1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
 
-## Methods ##  {#incoming-stream-methods}
-
-: <dfn method for="ReceiveStream">abortReading()</dfn>
-:: A hard shutdown of the {{ReceiveStream}}. It may be called regardless of
-   whether the {{ReceiveStream}} was created by the local or remote peer. When
-   the `abortWriting` method is called, the user agent MUST run the following
-   steps:
-     1. Let |stream| be the {{ReceiveStream}} object which is about to abort
-        reading.
+The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> (TODO) is:
+     1. Let |stream| be the {{ReceiveStream}} object.
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
-     1. Let |abortInfo| be the first argument.
-     1. Start the closing procedure by sending a message to the remote side
-        indicating that the stream has been aborted (using a
-        STOP_SENDING frame) with its error code set to the value of
-        |abortInfo.errorCode|.
+     1. Let |reason| be the first argument, if it is numeric, or 0.
+     1. If |stream| was canceled by a RST_STREAM frame, abort these steps.
+     1. Start the closing procedure by sending a STOP_SENDING frame to the
+        remote side, with its error code set to the value of |reason|.
 
 # Interface `BidirectionalStream` #  {#bidirectional-stream}
 
@@ -1182,16 +1198,12 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
     </thead>
     <tbody>
       <tr>
-        <td>{{ReceiveStream/abortReading}}</td>
-        <td>send STOP_SENDING with code</td>
-      </tr>
-      <tr>
-        <td>{{SendStream/abortWriting}}</td>
+        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/drop}}()</td>
         <td>send RESET_STREAM with code</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/writable}}.abort()</td>
-        <td>send RESET_STREAM</td>
+        <td>send RESET_STREAM with code</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/writable}}.close()</td>
@@ -1207,11 +1219,11 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
       </tr>
       <tr>
         <td>{{BidirectionalStream/writable}}.getWriter().abort()</td>
-        <td>send RESET_STREAM</td>
+        <td>send RESET_STREAM with code</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/readable}}.cancel()</td>
-        <td>send STOP_SENDING</td>
+        <td>send STOP_SENDING with code</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/readable}}.getReader().read()</td>
@@ -1219,7 +1231,7 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
       </tr>
       <tr>
         <td>{{BidirectionalStream/readable}}.getReader().cancel()</td>
-        <td>send STOP_SENDING</td>
+        <td>send STOP_SENDING with code</td>
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -1066,10 +1066,11 @@ initialization steps.
         from.
      1. Remove [=this=] from the transport's [=[[OutgoingStreams]]=].
      1. Let |reason| be |abortInfo|.errorCode.
-     1. If it hasn't started already, start the closing procedure by sending a
-        RESET_STREAM frame with its error code set to the value of |reason|.
      1. Let |p| be the result of [=WritableStream/abort|aborting=] [=this=], with |reason|.
      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
+     1. If it hasn't been done already, [=in parallel=], [=reset=] [=this=]
+        [=WebTransport stream=] with |reason| as the Application Protocol Error
+         Code.
 
 ## Procedures ##  {#send-stream-procedures}
 
@@ -1092,9 +1093,9 @@ The {{SendStream}}'s <dfn>abortAlgorithm</dfn> is:
         from.
      1. Let |reason| be the first argument, if it is numeric, or 0.
      1. If |stream| has received a STOP_SENDING frame, abort these steps.
-     1. If it hasn't started already, start the closing procedure by sending a
-        RESET_STREAM frame to the remote side, with its error code set to the
-        value of |reason|.
+     1. If it hasn't been done already, [=in parallel=], [=reset=] |stream|'s
+        [=WebTransport stream=] with |reason| as the Application Protocol Error
+         Code.
 
 ## `StreamAbortInfo` Dictionary ##  {#stream-abort-info}
 
@@ -1153,9 +1154,10 @@ The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
      1. Let |reason| be the first argument, if it is numeric, or 0.
-     1. If |stream| was received a RESET_STREAM frame, abort these steps.
-     1. Start the closing procedure by sending a STOP_SENDING frame to the
-        remote side, with its error code set to the value of |reason|.
+     1. If |stream| has received a RESET_STREAM frame, abort these steps.
+     1. [=In parallel=], [=send STOP_SENDING=] over |stream|'s
+        [=WebTransport stream=] with |reason| as the Application Protocol Error
+         Code.
 
 # Interface `BidirectionalStream` #  {#bidirectional-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -1072,7 +1072,7 @@ initialization steps.
      1. If it hasn't started already, start the closing procedure by sending a
         RST_STREAM frame with its error code set to the value of |reason|.
      1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
-     1. Set |p|.[[PromiseIsHandled]] to true.
+     1. Set |p|.[=[[PromiseIsHandled]]=] to true.
 
 ## Procedures ##  {#send-stream-procedures}
 
@@ -1152,7 +1152,7 @@ queue a task to run the following:
       1. Let |reason| be the value from the message from the remote side.
       1. Let |p| be the result of [=ReadableStream/cancel|canceling=] |stream|,
          with |reason|.
-      1. Set |p|.[[PromiseIsHandled]] to true.
+      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
 
 The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> (TODO) is:
      1. Let |stream| be the {{ReceiveStream}} object.

--- a/index.bs
+++ b/index.bs
@@ -1143,7 +1143,7 @@ initialization steps.
 ## Procedures ##  {#receive-stream-procedures}
 
 When a {{ReceiveStream}} receives a message from the remote side aborting the
-stream (For QUIC, that message is an RST_STREAM frame), the user agent MUST
+stream (for QUIC, that message is an RST_STREAM frame), the user agent MUST
 queue a task to run the following:
       1. Let |stream| be the {{ReceiveStream}} object for which the reset
          message was received.

--- a/index.bs
+++ b/index.bs
@@ -1082,7 +1082,7 @@ queue a task to run the following:
          from.
       1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=].
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
-      1. Perform ! [$WritableStreamStartErroring$](|stream|, |reason|).
+      1. [=WritableStream/Error=] |stream| with |reason|.
       1. [=Resolve=] {{SendStream}}.{{SendStream/remoteCanceled}} with a new
          {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
          |reason|.
@@ -1147,7 +1147,10 @@ queue a task to run the following:
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
       1. Let |reason| be the value from the message from the remote side.
-      1. Perform ! [$ReadableStreamError$](|stream|, |reason|).
+      1. [=ReadableStream/Error=] |stream| with |reason|.
+      1. [=Resolve=] {{ReceiveStream}}.{{ReceiveStream/remoteReset}} with a new
+         {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
+         |reason|.
 
 The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
      1. Let |stream| be the {{ReceiveStream}} object.

--- a/index.bs
+++ b/index.bs
@@ -1052,7 +1052,7 @@ initialization steps.
 
 : <dfn attribute for="SendStream">dropped</dfn>
 :: The `dropped` attribute represents a promise that is [=fulfilled=]
-    when the a message from the remote side aborting the stream is received.
+    when a message from the remote side aborting the stream is received.
     For QUIC, that message is a STOP_SENDING frame.
 
 ## Methods ##  {#send-stream-methods}
@@ -1072,7 +1072,7 @@ initialization steps.
      1. If it hasn't started already, start the closing procedure by sending a
         RST_STREAM frame with its error code set to the value of |reason|.
      1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
-     1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
+     1. Set |p|.[[PromiseIsHandled]] to true.
 
 ## Procedures ##  {#send-stream-procedures}
 
@@ -1085,7 +1085,7 @@ the user agent MUST queue a task to run the following:
          internal slot.
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
       1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
-      1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
+      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
       1. [=Resolve=] {{SendStream}}.{{SendStream/dropped}} with a new
          {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
          |reason|.
@@ -1142,16 +1142,17 @@ initialization steps.
 
 ## Procedures ##  {#receive-stream-procedures}
 
-When an {{ReceiveStream}} receives a RST_STREAM frame from the remote side, the
-user agent MUST queue a task to run the following:
+When a {{ReceiveStream}} receives a message from the remote side aborting the
+stream (For QUIC, that message is an RST_STREAM frame), the user agent MUST
+queue a task to run the following:
       1. Let |stream| be the {{ReceiveStream}} object for which the reset
          message was received.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
-      1. Let |reason| be the value from the RST_STREAM frame from the remote side.
+      1. Let |reason| be the value from the message from the remote side.
       1. Let |p| be the result of [=ReadableStream/cancel|canceling=] |stream|,
          with |reason|.
-     1. [=Upon fulfillment=] or [=upon rejection|rejection=] of |p|, do nothing.
+      1. Set |p|.[[PromiseIsHandled]] to true.
 
 The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> (TODO) is:
      1. Let |stream| be the {{ReceiveStream}} object.
@@ -1198,12 +1199,12 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
     </thead>
     <tbody>
       <tr>
-        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/drop}}()</td>
-        <td>send RESET_STREAM with code</td>
+        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/drop}}({errorCode})</td>
+        <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.abort()</td>
-        <td>send RESET_STREAM with code</td>
+        <td>{{BidirectionalStream/writable}}.abort(errorCode)</td>
+        <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/writable}}.close()</td>
@@ -1218,20 +1219,20 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
         <td>send STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.getWriter().abort()</td>
-        <td>send RESET_STREAM with code</td>
+        <td>{{BidirectionalStream/writable}}.getWriter().abort(errorCode)</td>
+        <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/readable}}.cancel()</td>
-        <td>send STOP_SENDING with code</td>
+        <td>{{BidirectionalStream/readable}}.cancel(errorCode)</td>
+        <td>send STOP_SENDING with errorCode</td>
       </tr>
       <tr>
         <td>{{BidirectionalStream/readable}}.getReader().read()</td>
         <td>receive STREAM or STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/readable}}.getReader().cancel()</td>
-        <td>send STOP_SENDING with code</td>
+        <td>{{BidirectionalStream/readable}}.getReader().cancel(errorCode)</td>
+        <td>send STOP_SENDING with errorCode</td>
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -1199,39 +1199,39 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
     </thead>
     <tbody>
       <tr>
-        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/reset}}({errorCode})</td>
+        <td>{{BidirectionalStream/writable}}.{{SendStream/reset}}({errorCode})</td>
         <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.abort(errorCode)</td>
+        <td>{{BidirectionalStream/writable}}.{{WritableStream/abort}}(errorCode)</td>
         <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.close()</td>
+        <td>{{BidirectionalStream/writable}}.{{WritableStream/close}}()</td>
         <td>send STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.getWriter().write()</td>
+        <td>{{BidirectionalStream/writable}}.getWriter().{{WritableStreamDefaultWriter/write}}()</td>
         <td>send STREAM</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.getWriter().close()</td>
+        <td>{{BidirectionalStream/writable}}.getWriter().{{WritableStreamDefaultWriter/close}}()</td>
         <td>send STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/writable}}.getWriter().abort(errorCode)</td>
+        <td>{{BidirectionalStream/writable}}.getWriter().{{WritableStreamDefaultWriter/abort}}(errorCode)</td>
         <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/readable}}.cancel(errorCode)</td>
+        <td>{{BidirectionalStream/readable}}.{{ReadableStream/cancel}}(errorCode)</td>
         <td>send STOP_SENDING with errorCode</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/readable}}.getReader().read()</td>
+        <td>{{BidirectionalStream/readable}}.getReader().{{ReadableStreamDefaultReader/read}}()</td>
         <td>receive STREAM or STREAM_FINAL</td>
       </tr>
       <tr>
-        <td>{{BidirectionalStream/readable}}.getReader().cancel(errorCode)</td>
+        <td>{{BidirectionalStream/readable}}.getReader().{{ReadableStreamGenericReader/cancel}}(errorCode)</td>
         <td>send STOP_SENDING with errorCode</td>
       </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -1038,7 +1038,7 @@ that can be written to, to transmit data to the remote host.
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
 interface SendStream : WritableStream /* of Uint8Array */ {
-  readonly attribute Promise&lt;StreamAbortInfo&gt; remoteReset;
+  readonly attribute Promise&lt;StreamAbortInfo&gt; remoteCanceled;
   undefined reset(optional StreamAbortInfo abortInfo = {});
 };
 </pre>
@@ -1050,8 +1050,8 @@ initialization steps.
 
 ## Attributes ##  {#send-stream-attributes}
 
-: <dfn attribute for="SendStream">remoteReset</dfn>
-:: The `remoteReset` attribute represents a promise that is [=fulfilled=]
+: <dfn attribute for="SendStream">remoteCanceled</dfn>
+:: The `remoteCanceled` attribute represents a promise that is [=fulfilled=]
     when a message from the remote side aborting the stream is received.
     For QUIC, that message is a STOP_SENDING frame.
 
@@ -1067,40 +1067,39 @@ initialization steps.
      1. Remove [=this=] from the transport's [=[[OutgoingStreams]]=].
      1. Let |reason| be |abortInfo|.errorCode.
      1. If it hasn't started already, start the closing procedure by sending a
-        RST_STREAM frame with its error code set to the value of |reason|.
+        RESET_STREAM frame with its error code set to the value of |reason|.
      1. Let |p| be the result of [=WritableStream/abort|aborting=] [=this=], with |reason|.
      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
 
 ## Procedures ##  {#send-stream-procedures}
 
-When a {{SendStream}} receives a STOP_SENDING frame from the remote side,
-the user agent MUST queue a task to run the following:
+When a {{SendStream}} receives a message from the remote side aborting the
+stream (for QUIC, that message is a STOP_SENDING frame), the user agent MUST
+queue a task to run the following:
       1. Let |stream| be the {{SendStream}} object.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
       1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=].
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
-      1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
-      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
-      1. [=Resolve=] {{SendStream}}.{{SendStream/remoteReset}} with a new
+      1. [=Resolve=] {{SendStream}}.{{SendStream/remoteCanceled}} with a new
          {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
          |reason|.
 
-The {{SendStream}}'s <dfn>abortAlgorithm</dfn> (TODO) is:
-     1. Let |stream| be the {{ReceiveStream}} object.
+The {{SendStream}}'s <dfn>abortAlgorithm</dfn> is:
+     1. Let |stream| be the {{SendStream}} object.
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
      1. Let |reason| be the first argument, if it is numeric, or 0.
-     1. If |stream| was aborted by a STOP_SENDING frame, abort these steps.
+     1. If |stream| has received a STOP_SENDING frame, abort these steps.
      1. If it hasn't started already, start the closing procedure by sending a
-        STOP_SENDING frame to the remote side, with its error code set to the
+        RESET_STREAM frame to the remote side, with its error code set to the
         value of |reason|.
 
 ## `StreamAbortInfo` Dictionary ##  {#stream-abort-info}
 
 The <dfn dictionary>StreamAbortInfo</dfn> dictionary includes information
 relating to the error code for aborting an incoming or outgoing stream (
-in either a RST_STREAM frame or a STOP_SENDING frame).
+in either a RESET_STREAM frame or a STOP_SENDING frame).
 
 <pre class="idl">
 dictionary StreamAbortInfo {
@@ -1134,28 +1133,26 @@ initialization steps.
 
 :: The `remoteReset` attribute represents a promise that is [=fulfilled=]
     when the a message from the remote side aborting the stream is received.
-    For QUIC, that message is a RST_STREAM frame.
+    For QUIC, that message is a RESET_STREAM frame.
 
 ## Procedures ##  {#receive-stream-procedures}
 
 When a {{ReceiveStream}} receives a message from the remote side aborting the
-stream (for QUIC, that message is an RST_STREAM frame), the user agent MUST
+stream (for QUIC, that message is an RESET_STREAM frame), the user agent MUST
 queue a task to run the following:
       1. Let |stream| be the {{ReceiveStream}} object for which the reset
          message was received.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
       1. Let |reason| be the value from the message from the remote side.
-      1. Let |p| be the result of [=ReadableStream/cancel|canceling=] |stream|,
-         with |reason|.
-      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
+      1. Error |stream| with |reason| (TODO).
 
-The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> (TODO) is:
+The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
      1. Let |stream| be the {{ReceiveStream}} object.
      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
         from.
      1. Let |reason| be the first argument, if it is numeric, or 0.
-     1. If |stream| was canceled by a RST_STREAM frame, abort these steps.
+     1. If |stream| was received a RESET_STREAM frame, abort these steps.
      1. Start the closing procedure by sending a STOP_SENDING frame to the
         remote side, with its error code set to the value of |reason|.
 

--- a/index.bs
+++ b/index.bs
@@ -1057,21 +1057,18 @@ initialization steps.
 
 ## Methods ##  {#send-stream-methods}
 
-: <dfn method for="SendStream">reset()</dfn>
+: <dfn method for="SendStream">reset(abortInfo)</dfn>
 :: A hard shutdown of the {{SendStream}}. It may be called regardless of
    whether the {{SendStream}} was created by the local or remote peer. When
    the `reset` method is called, the user agent MUST run the following
    steps:
-     1. Let |stream| be the {{SendStream}} object which is about to abort
-        writing.
-     1. Let |transport| be the {{WebTransport}}, which the |stream| was created
+     1. Let |transport| be the {{WebTransport}}, which [=this=] stream was created
         from.
-     1. Remove |stream| from the transport's [=[[OutgoingStreams]]=].
-     1. Let |abortInfo| be the first argument.
+     1. Remove [=this=] from the transport's [=[[OutgoingStreams]]=].
      1. Let |reason| be |abortInfo|.errorCode.
      1. If it hasn't started already, start the closing procedure by sending a
         RST_STREAM frame with its error code set to the value of |reason|.
-     1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
+     1. Let |p| be the result of [=WritableStream/abort|aborting=] [=this=], with |reason|.
      1. Set |p|.[=[[PromiseIsHandled]]=] to true.
 
 ## Procedures ##  {#send-stream-procedures}
@@ -1081,8 +1078,7 @@ the user agent MUST queue a task to run the following:
       1. Let |stream| be the {{SendStream}} object.
       1. Let |transport| be the {{WebTransport}}, which the |stream| was created
          from.
-      1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=]
-         internal slot.
+      1. Remove |stream| from the |transport|'s [=[[OutgoingStreams]]=].
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
       1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
       1. Set |p|.[=[[PromiseIsHandled]]=] to true.

--- a/index.bs
+++ b/index.bs
@@ -1038,8 +1038,8 @@ that can be written to, to transmit data to the remote host.
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
 interface SendStream : WritableStream /* of Uint8Array */ {
-  readonly attribute Promise&lt;StreamAbortInfo&gt; dropped;
-  undefined drop(optional StreamAbortInfo abortInfo = {});
+  readonly attribute Promise&lt;StreamAbortInfo&gt; remoteReset;
+  undefined reset(optional StreamAbortInfo abortInfo = {});
 };
 </pre>
 
@@ -1050,17 +1050,17 @@ initialization steps.
 
 ## Attributes ##  {#send-stream-attributes}
 
-: <dfn attribute for="SendStream">dropped</dfn>
-:: The `dropped` attribute represents a promise that is [=fulfilled=]
+: <dfn attribute for="SendStream">remoteReset</dfn>
+:: The `remoteReset` attribute represents a promise that is [=fulfilled=]
     when a message from the remote side aborting the stream is received.
     For QUIC, that message is a STOP_SENDING frame.
 
 ## Methods ##  {#send-stream-methods}
 
-: <dfn method for="SendStream">drop()</dfn>
+: <dfn method for="SendStream">reset()</dfn>
 :: A hard shutdown of the {{SendStream}}. It may be called regardless of
    whether the {{SendStream}} was created by the local or remote peer. When
-   the `drop` method is called, the user agent MUST run the following
+   the `reset` method is called, the user agent MUST run the following
    steps:
      1. Let |stream| be the {{SendStream}} object which is about to abort
         writing.
@@ -1086,7 +1086,7 @@ the user agent MUST queue a task to run the following:
       1. Let |reason| be the value from the STOP_SENDING frame from the remote side.
       1. Let |p| be the result of [=WritableStream/abort|aborting=] |stream|, with |reason|.
       1. Set |p|.[=[[PromiseIsHandled]]=] to true.
-      1. [=Resolve=] {{SendStream}}.{{SendStream/dropped}} with a new
+      1. [=Resolve=] {{SendStream}}.{{SendStream/remoteReset}} with a new
          {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to
          |reason|.
 
@@ -1199,7 +1199,7 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
     </thead>
     <tbody>
       <tr>
-        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/drop}}({errorCode})</td>
+        <td>{{BidirectionalStream/writable}}.{{OutgoingStream/reset}}({errorCode})</td>
         <td>send RESET_STREAM with errorCode</td>
       </tr>
       <tr>


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/242.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/248.html" title="Last updated on May 13, 2021, 11:49 PM UTC (dc1790c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/248/a19a918...jan-ivar:dc1790c.html" title="Last updated on May 13, 2021, 11:49 PM UTC (dc1790c)">Diff</a>