### PR TITLE
Specify incoming datagrams in more detail

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -346,10 +346,47 @@ interface mixin DatagramTransport {
 
 ## Procedures ## {#datagrams-transport-procedures}
 
-The <dfn>readDatagrams</dfn> algorithm is given a |transport| as parameter. It
-is defined by running the following steps:
-1. TODO
-1. [=ReadableStream/enqueue=] |data| in |transport|.`[[IncomingDatagrams]]`.
+To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
+1. Let |queue| be |transport|'s [=[[IncomingDatagramsQueue]]=].
+1. If |queue| is empty, then:
+  1. Assert: |transport|'s [=[[IncomingDatagramsPullPromise]]=] is null.
+  1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to a new promise.
+  1. Return |transport|'s [=[[IncomingDatagramsPullPromise]]=].
+1. Let |bytes| and |timestamp| be |queue|'s first element.
+1. Remove the first element from |queue|.
+1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
+1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[IncomingDatagrams]]=].
+1. Return [=a promise resolved with=] undefined.
+
+To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
+1. Let |timestamp| be a timestamp representing now.
+1. Let |queue| be |transport|'s [=[[IncomingDatagramsQueue]]=].
+1. Let |duration| be |transport|'s [=[[IncomingDatagramsExpirationDuration]]=].
+1. If |duration| is null, then set |duration| to an [=implementation-defined=] value.
+1. Let |connection| be |transport|'s [=[[Connection]]=].
+1. While there are available incoming datagrams on |connection|: [[!WEB-TRANSPORT-HTTP3]]
+
+  Issue: We should probably use "session" instead of "connection", to support pooling.
+
+  1. Let |datagram| be the first datagram, and remove it from |connection|.
+  1. Let |timestamp| be a timestamp representing now.
+  1. Let |chunk| be a pair of |datagram| and |timestamp|.
+  1. Enqueue |chunk| to |transort|'s [=[[IncomingDatagramsQueue]]=].
+1. Let |toBeRemoved| be the length of |queue| minus |transport|'s
+  [=[[IncomingDatagramsHighWaterMark]]=].
+1. If |toBeRemoved| is positive, remove first |toBeRemoved| elements from |queue|.
+1. While |queue| is not empty:
+  1. Let |bytes| and |timestamp| be |queue|'s first element.
+  1. If more than |duration| seconds have passed since |timestamp|, then remove the first element
+     from |queue|.
+  1. Otherwise, break this loop.
+1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then:
+   1. [=resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with undefined.
+   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
+
+The user agent SHOULD run [=receiveDatagrams=] for any {{WebTransport}} object whose
+[=[[State]]=] is `"connected"` as soon as reasonably possible whenever the algorithm can make
+progress.
 
 The <dfn>writeDatagrams</dfn> algorithm is given a |transport| as parameter and
 |data| as input. It is defined by running the following steps:
@@ -490,6 +527,25 @@ A {{WebTransport}} object has the following internal slots.
    <td class="non-normative">A {{DatagramDuplexStream}}.
   </tr>
   <tr>
+   <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
+   <td class="non-normative">A queue of tuples of an incoming datagram and a timestamp.
+  </tr>
+  <tr>
+   <td><dfn>\[[IncomingDatagramsPullPromise]]</dfn>
+   <td class="non-normative">A promise returned by [=pullDatagrams=], fulfilled when a new
+   datagram arrives.
+  </tr>
+  <tr>
+   <td><dfn>\[[IncomingDatagramsHighWaterMark]]</dfn>
+   <td class="non-normative">An integer representing the [=high water mark=] of the incoming
+   datagrams.
+  </tr>
+  <tr>
+   <td><dfn>\[[IncomingDatagramsExpirationDuration]]</dfn>
+   <td class="non-normative">A {{double}} value representing the expiration duration for incoming
+   datagrams (in seconds), or null.
+  </tr>
+  <tr>
    <td><dfn>\[[OutgoingDatagramsQueue]]</dfn>
    <td class="non-normative">A queue of tuples of an outgoing datagram, a timestamp and a promise
    which is resolved when the datagram is sent or discarded.
@@ -526,6 +582,11 @@ agent MUST run the following steps:
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
    {{TypeError}}.
+1. Let |incomingDatagrams| be a new {{ReadableStream}}.
+1. Let |outgoingDatagrams| be a new {{WritableStream}}.
+1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
+   {{DatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
+   |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
 1. Let |transport| be a newly constructed {{WebTransport}} object, with:
     : [=[[OutgoingStreams]]=]
     :: empty
@@ -540,11 +601,15 @@ agent MUST run the following steps:
     : [=[[Closed]]=]
     :: a new promise
     : [=[[Datagrams]]=]
+    :: |datagrams|
+    : [=[[IncomingDatagramsQueue]]=]
+    :: an empty queue
+    : [=[[IncomingDatagramsPullPromise]]=]
     :: null
-       <div class="note">
-        <p>This slot cannot be set to null, but this case is fine because we set a value in the
-           subsequent steps.</p>
-       </div>
+    : [=[[IncomingDatagramsHighWaterMark]]=]
+    :: an [=implementation-defined=] integer
+    : [=[[IncomingDatagramsExpirationDuration]]=]
+    :: null
     : [=[[OutgoingDatagramsQueue]]=]
     :: an empty queue
     : [=[[OutgoingDatagramsHighWaterMark]]=]
@@ -557,15 +622,12 @@ agent MUST run the following steps:
     :: null
     : [=[[Connection]]=]
     :: null
-1. Let |outgoingDatagrams| be the result of [=WritableStream/creating=] a {{WritableStream}},
-   its [=WritableStream/create/writeAlgorithm=] set to [=writeDatagrams=] given
-   |transport| as a parameter.
-1. Let |incomingDatagrams| be the result of <a dfn for="ReadableStream">creating</a> a
-   {{ReadableStream}}. `transport.[[IncomingDatagrams]]` is provided datagrams
-    using the [=readDatagrams=] algorithm given |transport| as a parameter.
-1. Set |transport|'s [=[[Datagrams]]=] to the result of [=DatagramDuplexStream/creating=] a
-   {{DatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
-   |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
+1. Let |pullAlgorithm| be an action that runs [=pullDatagrams=] with |transport|.
+1. Let |writeAlgorithm| be an action that runs [=writeDatagrams=] with |transport|.
+1. [=ReadableStream/Set up=] |incomingDatagrams| with [=ReadableStream/set up/pullAlgorithm=]
+   set to |pullAlgorithm|, and [=ReadableStream/set up/highWaterMark=] set to 0.
+1. [=WritableStream/Set up=] |outgoingDatagrams| with [=WritableStream/set up/writeAlgorithm=]
+   set to |writeAlgorithm|.
 1. Let |promise| be the result of [=initialize WebTransport over HTTP|initializing WebTransport
    over HTTP=], with |transport|, |parsedURL| and |dedicated|.
 1. [=Upon fulfillment=] of |promise|, run these steps:

--- a/index.bs
+++ b/index.bs
@@ -562,7 +562,7 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
-   <td class="non-normative">A queue of pairs of an incoming datagram and a timestamp.
+   <td class="non-normative">A queue of [=pairs=] of an incoming datagram and a timestamp.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsPullPromise]]</dfn>

--- a/index.bs
+++ b/index.bs
@@ -359,8 +359,7 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
        [=DatagramDuplexStream/[[Readable]]=].
     1. [=Resolve=] |promise| with undefined.
   1. Return |promise|.
-1. Let |bytes| and |timestamp| be |queue|'s first element.
-1. Remove the first element from |queue|.
+1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
 1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'
    [=DatagramDuplexStream/[[Readable]]=].
@@ -385,14 +384,12 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
 1. If |toBeRemoved| is positive, remove first |toBeRemoved| elements from |queue|.
 1. While |queue| is not empty:
   1. Let |bytes| and |timestamp| be |queue|'s first element.
-  1. If more than |duration| milliseconds have passed since |timestamp|, then remove the first
-     element from |queue|.
+  1. If more than |duration| milliseconds have passed since |timestamp|, then [=dequeue=] |queue|.
   1. Otherwise, [=break=] this loop.
 1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then
   [=queue a global task=] on the [=network task source=] with |transport|'s
   [=relevant global object=] and a task that runs the following steps:
-  1. Let |bytes| and |timestamp| be |queue|'s first element.
-  1. Remove the first element from |queue|.
+  1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
   1. [=Resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|.
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
 

--- a/index.bs
+++ b/index.bs
@@ -350,15 +350,8 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
 1. Assert: |transport|'s [=[[IncomingDatagramsPullPromise]]=] is null.
 1. Let |queue| be |transport|'s [=[[IncomingDatagramsQueue]]=].
 1. If |queue| is empty, then:
-  1. Let |promise| be a new promise.
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to a new promise.
-  1. [=Upon fulfillment=] of |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|, run
-     these steps:
-    1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
-       [=DatagramDuplexStream/[[Readable]]=].
-    1. [=Resolve=] |promise| with undefined.
-  1. Return |promise|.
+  1. Return |transport|'s [=[[IncomingDatagramsPullPromise]]=].
 1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
 1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
@@ -386,12 +379,16 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Let |bytes| and |timestamp| be |queue|'s first element.
   1. If more than |duration| milliseconds have passed since |timestamp|, then [=dequeue=] |queue|.
   1. Otherwise, [=break=] this loop.
-1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then
-   [=queue a global task=] on the [=network task source=] with |transport|'s
-   [=relevant global object=] and a task that runs the following steps:
+1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then:
   1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
-  1. [=Resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|.
+  1. Let |promise| be |transport|'s [=[[IncomingDatagramsPullPromise]]=].
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
+  1. [=queue a global task=] on the [=network task source=] with |transport|'s
+     [=relevant global object=] and a task that runs the following steps:
+    1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
+    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
+       [=DatagramDuplexStream/[[Readable]]=].
+    1. [=Resolve=] |promise| with undefined.
 
 The user agent SHOULD run [=receiveDatagrams=] for any {{WebTransport}} object whose
 [=[[State]]=] is `"connected"` as soon as reasonably possible whenever the algorithm can make

--- a/index.bs
+++ b/index.bs
@@ -371,7 +371,7 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Let |datagram| be the first datagram, and remove it from |connection|.
   1. Let |timestamp| be a timestamp representing now.
   1. Let |chunk| be a pair of |datagram| and |timestamp|.
-  1. Enqueue |chunk| to |transort|'s [=[[IncomingDatagramsQueue]]=].
+  1. Enqueue |chunk| to |queue|.
 1. Let |toBeRemoved| be the length of |queue| minus |transport|'s
   [=[[IncomingDatagramsHighWaterMark]]=].
 1. If |toBeRemoved| is positive, remove first |toBeRemoved| elements from |queue|.

--- a/index.bs
+++ b/index.bs
@@ -355,13 +355,13 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
   1. [=Upon fulfillment=] of |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|, run
      these steps:
     1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'
+    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
        [=DatagramDuplexStream/[[Readable]]=].
     1. [=Resolve=] |promise| with undefined.
   1. Return |promise|.
 1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'
+1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
    [=DatagramDuplexStream/[[Readable]]=].
 1. Return [=a promise resolved with=] undefined.
 
@@ -380,15 +380,15 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Let |chunk| be a [=pair=] of |datagram| and |timestamp|.
   1. [=Enqueue=] |chunk| to |queue|.
 1. Let |toBeRemoved| be the length of |queue| minus |transport|'s
-  [=[[IncomingDatagramsHighWaterMark]]=].
-1. If |toBeRemoved| is positive, remove first |toBeRemoved| elements from |queue|.
+   [=[[IncomingDatagramsHighWaterMark]]=].
+1. If |toBeRemoved| is positive, Repeat [=dequeuing=] |queue| |toBeRemoved| times.
 1. While |queue| is not empty:
   1. Let |bytes| and |timestamp| be |queue|'s first element.
   1. If more than |duration| milliseconds have passed since |timestamp|, then [=dequeue=] |queue|.
   1. Otherwise, [=break=] this loop.
 1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then
-  [=queue a global task=] on the [=network task source=] with |transport|'s
-  [=relevant global object=] and a task that runs the following steps:
+   [=queue a global task=] on the [=network task source=] with |transport|'s
+   [=relevant global object=] and a task that runs the following steps:
   1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
   1. [=Resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|.
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.

--- a/index.bs
+++ b/index.bs
@@ -383,10 +383,10 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
   1. Let |promise| be |transport|'s [=[[IncomingDatagramsPullPromise]]=].
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
-  1. [=queue a global task=] on the [=network task source=] with |transport|'s
+  1. [=Queue a global task=] on the [=network task source=] with |transport|'s
      [=relevant global object=] and a task that runs the following steps:
     1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
+    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'s
        [=DatagramDuplexStream/[[Readable]]=].
     1. [=Resolve=] |promise| with undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -381,7 +381,7 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. [=Enqueue=] |chunk| to |queue|.
 1. Let |toBeRemoved| be the length of |queue| minus |transport|'s
    [=[[IncomingDatagramsHighWaterMark]]=].
-1. If |toBeRemoved| is positive, Repeat [=dequeuing=] |queue| |toBeRemoved| times.
+1. If |toBeRemoved| is positive, repeat [=dequeuing=] |queue| |toBeRemoved| times.
 1. While |queue| is not empty:
   1. Let |bytes| and |timestamp| be |queue|'s first element.
   1. If more than |duration| milliseconds have passed since |timestamp|, then [=dequeue=] |queue|.

--- a/index.bs
+++ b/index.bs
@@ -347,15 +347,23 @@ interface mixin DatagramTransport {
 ## Procedures ## {#datagrams-transport-procedures}
 
 To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
+1. Assert: |transport|'s [=[[IncomingDatagramsPullPromise]]=] is null.
 1. Let |queue| be |transport|'s [=[[IncomingDatagramsQueue]]=].
 1. If |queue| is empty, then:
-  1. Assert: |transport|'s [=[[IncomingDatagramsPullPromise]]=] is null.
+  1. Let |promise| be a new promise.
   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to a new promise.
-  1. Return |transport|'s [=[[IncomingDatagramsPullPromise]]=].
+  1. [=Upon fulfillment=] of |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|, run
+     these steps:
+    1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
+    1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'
+       [=DatagramDuplexStream/[[Readable]]=].
+    1. [=Resolve=] |promise| with undefined.
+  1. Return |promise|.
 1. Let |bytes| and |timestamp| be |queue|'s first element.
 1. Remove the first element from |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[IncomingDatagrams]]=].
+1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]'
+   [=DatagramDuplexStream/[[Readable]]=].
 1. Return [=a promise resolved with=] undefined.
 
 To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
@@ -370,19 +378,23 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
 
   1. Let |datagram| be the first datagram, and remove it from |connection|.
   1. Let |timestamp| be a timestamp representing now.
-  1. Let |chunk| be a pair of |datagram| and |timestamp|.
-  1. Enqueue |chunk| to |queue|.
+  1. Let |chunk| be a [=pair=] of |datagram| and |timestamp|.
+  1. [=Enqueue=] |chunk| to |queue|.
 1. Let |toBeRemoved| be the length of |queue| minus |transport|'s
   [=[[IncomingDatagramsHighWaterMark]]=].
 1. If |toBeRemoved| is positive, remove first |toBeRemoved| elements from |queue|.
 1. While |queue| is not empty:
   1. Let |bytes| and |timestamp| be |queue|'s first element.
-  1. If more than |duration| seconds have passed since |timestamp|, then remove the first element
-     from |queue|.
-  1. Otherwise, break this loop.
-1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then:
-   1. [=resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with undefined.
-   1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
+  1. If more than |duration| milliseconds have passed since |timestamp|, then remove the first
+     element from |queue|.
+  1. Otherwise, [=break=] this loop.
+1. If |queue| is not empty and |transport|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then
+  [=queue a global task=] on the [=network task source=] with |transport|'s
+  [=relevant global object=] and a task that runs the following steps:
+  1. Let |bytes| and |timestamp| be |queue|'s first element.
+  1. Remove the first element from |queue|.
+  1. [=Resolve=] |transport|'s [=[[IncomingDatagramsPullPromise]]=] with |bytes|.
+  1. Set |transport|'s [=[[IncomingDatagramsPullPromise]]=] to null.
 
 The user agent SHOULD run [=receiveDatagrams=] for any {{WebTransport}} object whose
 [=[[State]]=] is `"connected"` as soon as reasonably possible whenever the algorithm can make
@@ -438,26 +450,51 @@ interface DatagramDuplexStream {
 };
 </pre>
 
+## Internal slots ## {#datagramduplexstream-internal-slots}
+
+A {{DatagramDuplexStream}} object has the following internal slots.
+
+<table class="data" dfn-for="DatagramDuplexStream">
+ <thead>
+  <tr>
+   <th>Internal Slot
+   <th>Description (<em>non-normative</em>)
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>\[[Readable]]</dfn>
+   <td class="non-normative">A {{ReadableStream}} for incoming datagrams.
+  </tr>
+  <tr>
+   <td><dfn>\[[Writable]]</dfn>
+   <td class="non-normative">A {{WritableStream}} for outgoing datagrams.
+  </tr>
+ </tbody>
+</table>
+
  To <dfn export for="DatagramDuplexStream" lt="create|creating">create</dfn> a
  {{DatagramDuplexStream}} given a
  <dfn export for="DatagramDuplexStream/create"><var>readable</var></dfn>, and
  a <dfn export for="DatagramDuplexStream/create"><var>writable</var></dfn>,
  perform the following steps.
 
- 1. Let |stream| be a [=new=] {{DatagramDuplexStream}}.
- 1. Initialize |stream|.`[[readable]]` to |readable|.
- 1. Initialize |stream|.`[[writable]]` to |writable|.
+ 1. Let |stream| be a [=new=] {{DatagramDuplexStream}}, with:
+    : [=[[Readable]]=]
+    :: |readable|
+    : [=[[Writable]]=]
+    :: |writable|
  1. Return |stream|.
 
 ## Attributes ##  {#duplex-stream-attributes}
 
 : <dfn for="DatagramDuplexStream" attribute>readable</dfn>
 :: The getter steps are:
-     1. Return [=this=].`[[readable]]`.
+     1. Return [=this=].`[[Readable]]`.
 
 : <dfn for="DatagramDuplexStream" attribute>writable</dfn>
 :: The getter steps are:
-     1. Return [=this=].`[[writable]]`.
+     1. Return [=this=].`[[Writable]]`.
 
 # `WebTransport` Interface #  {#web-transport}
 
@@ -528,12 +565,11 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
-   <td class="non-normative">A queue of tuples of an incoming datagram and a timestamp.
+   <td class="non-normative">A queue of pairs of an incoming datagram and a timestamp.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsPullPromise]]</dfn>
-   <td class="non-normative">A promise returned by [=pullDatagrams=], fulfilled when a new
-   datagram arrives.
+   <td class="non-normative">A promise set by [=pullDatagrams=], to wait for an incoming datagram.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsHighWaterMark]]</dfn>
@@ -543,7 +579,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>\[[IncomingDatagramsExpirationDuration]]</dfn>
    <td class="non-normative">A {{double}} value representing the expiration duration for incoming
-   datagrams (in seconds), or null.
+   datagrams (in milliseconds), or null.
   </tr>
   <tr>
    <td><dfn>\[[OutgoingDatagramsQueue]]</dfn>
@@ -558,7 +594,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>\[[OutgoingDatagramsExpirationDuration]]</dfn>
    <td class="non-normative">A {{double}} value representing the expiration duration for outgoing
-   datagrams (in seconds), or null.
+   datagrams (in milliseconds), or null.
   </tr>
   <tr>
    <td><dfn>\[[Connection]]</dfn>
@@ -582,8 +618,8 @@ agent MUST run the following steps:
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
    {{TypeError}}.
-1. Let |incomingDatagrams| be a new {{ReadableStream}}.
-1. Let |outgoingDatagrams| be a new {{WritableStream}}.
+1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
+1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
    {{DatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
    |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.


### PR DESCRIPTION
- Define readDatagrams that can be called at any time.
 - Rename receiveDatagrams with pullDatagrams as now incoming
   datagrams are a pull source rather than a push source.
 - Fix creation of incomingDatagrams and outgoingDatagrams (#247).
 - Add IncomingDatagramsHighWaterMark and
   IncomingDatagramsExpirationDuration (#221).

Fixes #247.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/249.html" title="Last updated on Apr 28, 2021, 8:22 AM UTC (b2e268f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/249/8795cb1...b2e268f.html" title="Last updated on Apr 28, 2021, 8:22 AM UTC (b2e268f)">Diff</a>