### PR TITLE
Define datagram backpressure control attributes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -368,7 +368,7 @@ A {{DatagramDuplexStream}} object has the following internal slots.
      1. Return [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=].
 :: The setter steps are:
      1. Let |value| be the given value.
-     1. If |value| > 0:
+     1. If |value| is null or |value| > 0:
        1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>outgoingMaxAge</dfn>
@@ -376,7 +376,7 @@ A {{DatagramDuplexStream}} object has the following internal slots.
      1. Return [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=].
 :: The setter steps are:
      1. Let |value| be the given value.
-     1. If |value| > 0:
+     1. If |value| is null or |value| > 0:
        1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>incomingHighWaterMark</dfn>

--- a/index.bs
+++ b/index.bs
@@ -367,25 +367,33 @@ A {{DatagramDuplexStream}} object has the following internal slots.
 :: The getter steps are:
      1. Return [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=].
 :: The setter steps are:
-     1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to the given value.
+     1. Let |value| be the given value.
+     1. If |value| > 0:
+       1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>outgoingMaxAge</dfn>
 :: The getter steps are:
      1. Return [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=].
 :: The setter steps are:
-     1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to the given value.
+     1. Let |value| be the given value.
+     1. If |value| > 0:
+       1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>incomingHighWaterMark</dfn>
 :: The getter steps are:
      1. Return [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=].
 :: The setter steps are:
-     1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to the given value.
+     1. Let |value| be the given value.
+     1. If |value| >= 0:
+       1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>outgoingHighWaterMark</dfn>
 :: The getter steps are:
      1. Return [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=].
 :: The setter steps are:
-     1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to the given value.
+     1. Let |value| be the given value.
+     1. If |value| >= 0:
+       1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to |value|.
 
 ## Procedures ## {#datagram-duplex-stream-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -258,6 +258,11 @@ A <dfn interface>DatagramDuplexStream</dfn> is a generic duplex stream.
 interface DatagramDuplexStream {
   readonly attribute ReadableStream readable;
   readonly attribute WritableStream writable;
+
+  undefined setIncomingExpirationDuration(double ms);
+  undefined setOutgoingExpirationDuration(double ms);
+  undefined setIncomingHighWaterMark(long highWaterMark);
+  undefined setOutgoingHighWaterMark(long highWaterMark);
 };
 </pre>
 
@@ -357,6 +362,33 @@ A {{DatagramDuplexStream}} object has the following internal slots.
 : <dfn for="DatagramDuplexStream" attribute>writable</dfn>
 :: The getter steps are:
      1. Return [=this=].`[[Writable]]`.
+
+
+## Methods ##  {#datagram-duplex-stream-attributes}
+
+: <dfn for="DatagramDuplexStream" method>setIncomingExpirationDuration(ms)</dfn>
+:: Sets the expiration duration (in milliseconds) for incoming datagrams.
+
+   When the method is called, the user agent MUST run the following step:
+     1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |ms|.
+
+: <dfn for="DatagramDuplexStream" method>setOutgoingExpirationDuration(ms)</dfn>
+:: Sets the expiration duration (in milliseconds) for outgoing datagrams.
+
+   When the method is called, the user agent MUST run the following step:
+     1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to |ms|.
+
+: <dfn for="DatagramDuplexStream" method>setIncomingHighWaterMark(highWaterMark)</dfn>
+:: Sets the high water mark for incoming datagrams.
+
+   When the method is called, the user agent MUST run the following step:
+     1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to |highWaterMark|.
+
+: <dfn for="DatagramDuplexStream" method>setOutgoingHighWaterMark(highWaterMark)</dfn>
+:: Sets the high water mark for outgoing datagrams.
+
+   When the method is called, the user agent MUST run the following step:
+     1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to |highWaterMark|.
 
 ## Procedures ## {#datagram-duplex-stream-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -259,10 +259,10 @@ interface DatagramDuplexStream {
   readonly attribute ReadableStream readable;
   readonly attribute WritableStream writable;
 
-  undefined setIncomingExpirationDuration(double ms);
-  undefined setOutgoingExpirationDuration(double ms);
-  undefined setIncomingHighWaterMark(long highWaterMark);
-  undefined setOutgoingHighWaterMark(long highWaterMark);
+  attribute double? incomingMaxAge;
+  attribute double? outgoingMaxAge;
+  attribute long incomingHighWaterMark;
+  attribute long outgoingHighWaterMark;
 };
 </pre>
 
@@ -363,32 +363,29 @@ A {{DatagramDuplexStream}} object has the following internal slots.
 :: The getter steps are:
      1. Return [=this=].`[[Writable]]`.
 
+: <dfn for="DatagramDuplexStream" attribute>incomingMaxAge</dfn>
+:: The getter steps are:
+     1. Return [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=].
+:: The setter steps are:
+     1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to the given value.
 
-## Methods ##  {#datagram-duplex-stream-attributes}
+: <dfn for="DatagramDuplexStream" attribute>outgoingMaxAge</dfn>
+:: The getter steps are:
+     1. Return [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=].
+:: The setter steps are:
+     1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to the given value.
 
-: <dfn for="DatagramDuplexStream" method>setIncomingExpirationDuration(ms)</dfn>
-:: Sets the expiration duration (in milliseconds) for incoming datagrams.
+: <dfn for="DatagramDuplexStream" attribute>incomingHighWaterMark</dfn>
+:: The getter steps are:
+     1. Return [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=].
+:: The setter steps are:
+     1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to the given value.
 
-   When the method is called, the user agent MUST run the following step:
-     1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |ms|.
-
-: <dfn for="DatagramDuplexStream" method>setOutgoingExpirationDuration(ms)</dfn>
-:: Sets the expiration duration (in milliseconds) for outgoing datagrams.
-
-   When the method is called, the user agent MUST run the following step:
-     1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to |ms|.
-
-: <dfn for="DatagramDuplexStream" method>setIncomingHighWaterMark(highWaterMark)</dfn>
-:: Sets the high water mark for incoming datagrams.
-
-   When the method is called, the user agent MUST run the following step:
-     1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to |highWaterMark|.
-
-: <dfn for="DatagramDuplexStream" method>setOutgoingHighWaterMark(highWaterMark)</dfn>
-:: Sets the high water mark for outgoing datagrams.
-
-   When the method is called, the user agent MUST run the following step:
-     1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to |highWaterMark|.
+: <dfn for="DatagramDuplexStream" attribute>outgoingHighWaterMark</dfn>
+:: The getter steps are:
+     1. Return [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=].
+:: The setter steps are:
+     1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to the given value.
 
 ## Procedures ## {#datagram-duplex-stream-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -384,7 +384,7 @@ A {{DatagramDuplexStream}} object has the following internal slots.
      1. Return [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=].
 :: The setter steps are:
      1. Let |value| be the given value.
-     1. If |value| >= 0:
+     1. If |value| ≥ 0:
        1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to |value|.
 
 : <dfn for="DatagramDuplexStream" attribute>outgoingHighWaterMark</dfn>
@@ -392,7 +392,7 @@ A {{DatagramDuplexStream}} object has the following internal slots.
      1. Return [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=].
 :: The setter steps are:
      1. Let |value| be the given value.
-     1. If |value| >= 0:
+     1. If |value| ≥ 0:
        1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to |value|.
 
 ## Procedures ## {#datagram-duplex-stream-procedures}


### PR DESCRIPTION
Define the following attributes on DatagramDuplexStream.

 - incomingMaxAge
 - outgoingMaxAge
 - incomingHighWaterMark
 - outgoingHighWaterMark

Fixes #251, #221, #152


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/267.html" title="Last updated on Jun 16, 2021, 4:59 AM UTC (4c11ddc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/267/dec79ad...4c11ddc.html" title="Last updated on Jun 16, 2021, 4:59 AM UTC (4c11ddc)">Diff</a>