### PR TITLE
Define "queue a network task"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -843,7 +843,7 @@ To <dfn for="WebTransport">cleanup</dfn> a {{WebTransport}} |transport| with |re
 <div algorithm>
 
 To <dfn for="WebTransport">queue a network task</dfn> with a {{WebTransport}} |transport| and a
-seriese of steps |steps|, run these steps:
+series of steps |steps|, run these steps:
 1. [=Queue a global task=] on the [=network task source=] with |transport|'s
    [=relevant global object=] to run |steps|.
 

--- a/index.bs
+++ b/index.bs
@@ -483,8 +483,7 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
   1. Let |promise| be |datagrams|'s [=[[IncomingDatagramsPullPromise]]=].
   1. Set |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] to null.
-  1. [=Queue a global task=] on the [=network task source=] with |transport|'s
-     [=relevant global object=] and a task that runs the following steps:
+  1. [=Queue a network task=] with |transport| to run the following steps:
     1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
     1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|'s [=DatagramDuplexStream/[[Readable]]=].
     1. [=Resolve=] |promise| with undefined.
@@ -838,6 +837,15 @@ To <dfn for="WebTransport">cleanup</dfn> a {{WebTransport}} |transport| with |re
 1. Otherwise:
   1. [=Resolve=] |closed| with |reason|.
   1. Assert: |ready| is [=settled=].
+
+</div>
+
+<div algorithm>
+
+To <dfn for="WebTransport">queue a network task</dfn> with a {{WebTransport}} |transport| and a
+seriese of steps |steps|, run these steps:
+1. [=Queue a global task=] on the [=network task source=] with |transport|'s
+   [=relevant global object=] to run |steps|.
 
 </div>
 


### PR DESCRIPTION
...as a shorthand of "queue a global task on the network task
source". This is an editorial change.

Currently there is only one usage but I expect more in the future.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/274.html" title="Last updated on Jun 14, 2021, 8:24 AM UTC (9da5254)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/274/7b0630a...9da5254.html" title="Last updated on Jun 14, 2021, 8:24 AM UTC (9da5254)">Diff</a>