### PR TITLE
Fix the protocol link of "receiving a bidirectional stream"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -183,7 +183,7 @@ There may be multiple [=WebTransport session=]s on one [=connection=], when pool
   <tr>
    <td><dfn>receive a [=stream/bidirectional=] stream</dfn>
    <td>[[!WEB-TRANSPORT-HTTP3]]
-   [section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.3)
+   [section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.2)
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
This is a follow-up change of #266.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/276.html" title="Last updated on Jun 14, 2021, 6:25 AM UTC (7a58b9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/276/2a0ca65...7a58b9b.html" title="Last updated on Jun 14, 2021, 6:25 AM UTC (7a58b9b)">Diff</a>