### PR TITLE
[Editorial] Replace "remote host" with "server"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -670,7 +670,7 @@ these steps.
      1. Return [=this=]'s [=[[IncomingBidirectionalStreams]]=].
 : <dfn for="WebTransport" attribute>incomingUnidirectionalStreams</dfn>
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
-   {{ReceiveStream}} object, that have been received from the remote host.
+   {{ReceiveStream}} object, that have been received from the server.
 
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Let |transport| be [=this=].
@@ -999,7 +999,7 @@ The dictionary SHALL have the following attributes:
 # Interface `SendStream` #  {#send-stream}
 
 A <dfn interface>SendStream</dfn> is a {{WritableStream}} of {{Uint8Array}}
-that can be written to, to transmit data to the remote host.
+that can be written to, to transmit data to the server.
 
 <pre class="idl">
 [ Exposed=(Window,Worker) ]
@@ -1113,7 +1113,7 @@ The dictionary SHALL have the following fields:
 # Interface `ReceiveStream` #  {#receive-stream}
 
 A <dfn interface>ReceiveStream</dfn> is a {{ReadableStream}} of {{Uint8Array}}
-that can be read from, to consume data received from the remote host.
+that can be read from, to consume data received from the server.
 
 <pre class="idl">
 [ Exposed=(Window,Worker) ]


### PR DESCRIPTION
This is a follow-up change of #266.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/278.html" title="Last updated on Jun 14, 2021, 10:04 AM UTC (a2c2cb5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/278/dec79ad...a2c2cb5.html" title="Last updated on Jun 14, 2021, 10:04 AM UTC (a2c2cb5)">Diff</a>