### PR TITLE
Make WebTransport an EventTarget.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -488,7 +488,7 @@ defined in [[!WEB-TRANSPORT-HTTP3]].
 
 <pre class="idl">
 [Exposed=(Window,Worker)]
-interface WebTransport {
+interface WebTransport : EventTarget {
   constructor(USVString url, optional WebTransportOptions options = {});
 
   Promise&lt;WebTransportStats&gt; getStats();


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/116.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/287.html" title="Last updated on Jun 22, 2021, 10:07 PM UTC (72b1093)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/287/1cb3edc...jan-ivar:72b1093.html" title="Last updated on Jun 22, 2021, 10:07 PM UTC (72b1093)">Diff</a>