### PR TITLE
Have SendStream's write/close abortable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1114,7 +1114,6 @@ that can be written to, to transmit data to the server.
 <pre class="idl">
 [Exposed=(Window,Worker), SecureContext]
 interface SendStream : WritableStream /* of Uint8Array */ {
-  undefined reset(optional StreamAbortInfo abortInfo = {});
 };
 </pre>
 
@@ -1213,23 +1212,6 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
 1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 
 </div>
-
-## Methods ##  {#send-stream-methods}
-
-: <dfn method for="SendStream">reset(abortInfo)</dfn>
-:: A hard shutdown of the {{SendStream}}. It may be called regardless of
-   whether the {{SendStream}} was created by the local or remote peer. When
-   the `reset` method is called, the user agent MUST run the following
-   steps:
-     1. Let |transport| be the {{WebTransport}}, which [=this=] stream was created
-        from.
-     1. Remove [=this=] from the transport's [=[[OutgoingStreams]]=].
-     1. Let |reason| be |abortInfo|.errorCode.
-     1. Let |p| be the result of [=WritableStream/abort|aborting=] [=this=], with |reason|.
-     1. Set |p|.[=[[PromiseIsHandled]]=] to true.
-     1. If it hasn't been done already, [=in parallel=], [=reset=] [=this=]
-        [=WebTransport stream=] with |reason| as the Application Protocol Error
-         Code.
 
 ## STOP_SENDING signal coming from the server ##  {#send-stream-STOP_SENDING}
 
@@ -1408,10 +1390,6 @@ in this specification, utilizing [[WEB-TRANSPORT-HTTP3]].
       </tr>
     </thead>
     <tbody>
-      <tr>
-        <td>{{BidirectionalStream/writable}}.{{SendStream/reset}}({errorCode})</td>
-        <td>send RESET_STREAM with errorCode</td>
-      </tr>
       <tr>
         <td>{{BidirectionalStream/writable}}.{{WritableStream/abort}}(errorCode)</td>
         <td>send RESET_STREAM with errorCode</td>

--- a/index.bs
+++ b/index.bs
@@ -1135,6 +1135,10 @@ A {{SendStream}} has the following internal slots.
    [=WebTransport stream=].
   </tr>
   <tr>
+   <td><dfn>\[[PendingOperation]]</dfn>
+   <td class="non-normative">A promise representing a pending write or close operation, or null.
+  </tr>
+  <tr>
    <td><dfn>\[[Transport]]</dfn>
    <td class="non-normative">A {{WebTransport}} which owns this {{SendStream}}.
   </tr>
@@ -1152,6 +1156,8 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 1. Let |stream| be a [=new=] {{SendStream}}, with:
     : [=[[InternalStream]]=]
     :: |internalStream|
+    : [=[[PendingOperation]]=]
+    :: null
     : [=[[Transport]]=]
     :: |transport|
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
@@ -1160,6 +1166,12 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 1. [=WritableStream/Set up=] |stream| with [=WritableStream/set up/writeAlgorithm=] set to
    |writeAlgorithm|, [=WritableStream/set up/closeAlgorithm=] set to |closeAlgorithm|,
    [=WritableStream/set up/abortAlgorithm=] set to |abortAlgorithm|.
+1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
+  1. If |stream|'s [=[[PendingOperation]]=] is null, then abort these steps.
+  1. Let |reason| be |stream|'s \[[controller]]'s \[[abortReason]].
+  1. [=Abort=] stream with |reason|.
+  1. [=Reject=] |stream|'s [=[[PendingOperation]]=] with |reason|.
+  1. Set |stream|'s [=[[PendingOperation]]=] to null.
 1. [=set/Append=] |stream| to |transport|'s [=[[SendStreams]]=].
 1. Return |stream|.
 
@@ -1172,10 +1184,13 @@ To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run t
 1. If |chunk| is not a {{Uint8Array}}, return [=a promise rejected with=] a {{TypeError}}.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
+1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=stream/Send=] |bytes| on |stream|'s [=[[InternalStream]]=] and wait for the operation to
    complete.
-1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
+1. [=Queue a network task=] with |transport| to run these steps:
+  1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. [=Resolve=] |promise| with undefined.
 
 Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
 SHOULD have a fixed size, to carry the backpressure information to the user of {{SendStream}}. This
@@ -1192,11 +1207,14 @@ To <dfn for="SendStream">close</dfn> a {{SendStream}} |stream|, run these steps:
 1. Let |transport| be |stream|'s [=[[Transport]]=].
 1. Let |promise| be a new promise.
 1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
+1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=stream/Send=] FIN on |stream|'s [=[[InternalStream]]=] and wait for the operation to
    complete.
 1. Wait for |stream|'s [=[[InternalStream]]=] to enter the "Data Recvd" state. [[!QUIC]]
-1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
+1. [=Queue a network task=] with |transport| to run these steps:
+  1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. [=Resolve=] |promise| with undefined.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1169,9 +1169,11 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
   1. If |stream|'s [=[[PendingOperation]]=] is null, then abort these steps.
   1. Let |reason| be |stream|'s \[[controller]]'s \[[abortReason]].
-  1. [=Abort=] stream with |reason|.
-  1. [=Reject=] |stream|'s [=[[PendingOperation]]=] with |reason|.
+  1. Let |abortPromise| be the result of [=aborting=] stream with |reason|.
+  1. [=Upon fulfillment=] of |abortPromise|, [=reject=] |promise| with |reason|.
+  1. Let |pendingOperation| be |stream|'s [=[[PendingOperation]]=].
   1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. [=Resolve=] |pendingOperation| with |promise|.
 1. [=set/Append=] |stream| to |transport|'s [=[[SendStreams]]=].
 1. Return |stream|.
 


### PR DESCRIPTION
Have SendStream's write and close abortable with
WritableStreamDefaultController.signal.

Remove SendStream.reset as it's now covered by abort().

Fixes #260.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/295.html" title="Last updated on Jun 25, 2021, 3:24 PM UTC (95c2a3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/295/4571dcf...95c2a3b.html" title="Last updated on Jun 25, 2021, 3:24 PM UTC (95c2a3b)">Diff</a>