### PR TITLE
Set up ReceiveStream with proper algorithms

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1354,7 +1354,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.
-  1. [=Resolve=] promise with undefined.
+  1. [=Resolve=] |promise| with undefined.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1354,7 +1354,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. [=Queue a network task=] with |transport| to run these steps:
 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
-   running, this block MAY run immediately.
+   running, the following steps MAY run immediately.
 
   1. If |read| > 0, then perform [=ReadableByteStreamControllerRespond=] with |controller| and
      |read|.

--- a/index.bs
+++ b/index.bs
@@ -1364,7 +1364,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    running, the following steps may run immediately.
 
   1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
-  1. If |read| > 0, then [=ReadableStream/enqueue=] into |stream| with |view|.
+  1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.

--- a/index.bs
+++ b/index.bs
@@ -1333,7 +1333,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
 1. Let |buffer|, |offset|, and |maxBytes| be null.
-1. If |stream|'s [=ReadableStream/current BYOB request view=] for |stream| is not null, then:
+1. If |stream|'s [=ReadableStream/current BYOB request view=] for |stream| is not null:
   1. Set |offset| to |stream|'s [=ReadableStream/current BYOB request view=].\[[ByteOffset]].
   1. Set |maxBytes| to |stream|'s [=ReadableStream/current BYOB request view=]'s
      [=BufferSource/byte length=].
@@ -1364,7 +1364,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
    running, the following steps may run immediately.
 
-  1. If |read| > 0, then:
+  1. If |read| > 0:
     1. Set |view| to a [=new=] {{Uint8Array}} with |buffer|, |offset| and |read|.
     1. [=ReadableStream/Enqueue=] |view| into |stream|.
   1. If |hasReceivedFIN| is true:

--- a/index.bs
+++ b/index.bs
@@ -1361,10 +1361,10 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. [=Queue a network task=] with |transport| to run these steps:
 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
-   running, the following steps MAY run immediately.
+   running, the following steps may run immediately.
 
   1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
-  1. If |read| > 0, then [=ReadableStream/enqueue bytes=] into |stream| with |view|.
+  1. If |read| > 0, then [=ReadableStream/enqueue=] into |stream| with |view|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.

--- a/index.bs
+++ b/index.bs
@@ -1315,10 +1315,11 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
     :: |transport|
 1. Let |pullAlgorithm| be an action that [=pulls bytes=] from |stream|.
 1. Let |cancelAlgorithm| be an action that [=ReceiveStream/cancels=] |stream|.
-1. [=ReadableByteStream/Set up=] |stream| with
-   [=ReadableByteStream/set up/pullAlgorithm=] set to |pullAlgorithm|,
-   [=ReadableByteStream/set up/cancelAlgorithm=] set to |cancelAlgorithm|, and
-   [=ReadableByteStream/set up/highWaterMark=] set to 0.
+1. [=ReadableStream/Set up with byte reading support=] |stream| with
+   [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to |pullAlgorithm| and
+   [=ReadableStream/set up with byte reading support/cancelAlgorithm=] set to |cancelAlgorithm|.
+1. Set |stream|'s [=ReadableByteStream/[[controller]]=]'s
+   [=ReadableStreamController/autoAllocateChunkSize=] to an [=implementation-defined=] integer.
 1. [=set/Add=] |stream| to |transport|'s [=[[ReceiveStreams]]=].
 1. Return |stream|.
 
@@ -1335,6 +1336,9 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. Let |promise| be a new promise.
 1. Let |request| be the result of running [=ReadableByteStreamControllerGetBYOBRequest=] with
    |controller|.
+
+  Note: |request| is not null, because of [=ReadableStreamController/autoAllocateChunkSize=] set in
+  the [=ReceiveStream/create=] procedure.
 1. Let |view| be |request|'s [=ReadableStreamBYOBRequest/view=].
 1. Assert: |view| is not null.
 1. Let |bytes| be the byte sequence |view| represents.

--- a/index.bs
+++ b/index.bs
@@ -1343,7 +1343,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
   1. Set |offset| to 0.
   1. Set |maxBytes| to an [=implementation-defined=] size.
   1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
-     {{Uint8Array}} fails, return a promise [=rejected with=] a {{RangeError}}.
+     {{ArrayBuffer}} fails, return a promise [=rejected with=] a {{RangeError}}.
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=ArrayBuffer/Write=] the bytes that area [=stream/receive|read=] from |internalStream| into
    |buffer| with offset |offset|, up to |maxBytes| bytes. Wait until either at least one byte is

--- a/index.bs
+++ b/index.bs
@@ -1329,8 +1329,6 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 
 To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, run these steps.
 
-1. Let |controller| be |stream|'s [=ReadableStream/[[controller]]=].
-1. Assert: |controller| is a {{ReadableByteStreamController}}.
 1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
@@ -1340,13 +1338,11 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    {{RangeError}}.
 1. Let |bytes| be the byte sequence |view| represents.
 1. Assert: |bytes|'s length equals to |view|.\[[ByteLength]].
-1. Let |arrayBuffer| be |view|.\[[ViewedArrayBuffer]].
-1. Let |offset| be |view|.\[[ByteOffset]].
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/receive|Read bytes=] into |bytes|, from |internalStream|. Wait until either at least one
-   byte is read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN|
-   be whether FIN was accompanied.
-
+1. [=ArrayBufferView/Write=] the bytes that area [=stream/receive|read=] from |internalStream| into
+   |view|, up to |bytes|'s length bytes. Wait until either at least one byte is read or FIN is
+   received. Let |read| be the number of read bytes, and let |hasReceivedFIN| be whether FIN was
+   accompanied.
 
    Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
    SHOULD have a fixed size, to carry the backpressure information to the server.
@@ -1363,8 +1359,13 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
    running, the following steps may run immediately.
 
-  1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
-  1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream|.
+  1. If [=ReadableStream/current BYOB request view=] for |stream| is null:
+    1. Let |arrayBuffer| be |view|.\[[ViewedArrayBuffer]].
+    1. Let |offset| be |view|.\[[ByteOffset]].
+    1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
+    1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream|.
+  1. Otherwise:
+    1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream| with |read|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.

--- a/index.bs
+++ b/index.bs
@@ -1318,8 +1318,6 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 1. [=ReadableStream/Set up with byte reading support=] |stream| with
    [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to |pullAlgorithm| and
    [=ReadableStream/set up with byte reading support/cancelAlgorithm=] set to |cancelAlgorithm|.
-1. Set |stream|'s [=ReadableByteStream/[[controller]]=]'s
-   [=ReadableStreamController/autoAllocateChunkSize=] to an [=implementation-defined=] integer.
 1. [=set/Add=] |stream| to |transport|'s [=[[ReceiveStreams]]=].
 1. Return |stream|.
 
@@ -1334,21 +1332,30 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
-1. Let |request| be the result of running [=ReadableByteStreamControllerGetBYOBRequest=] with
-   |controller|.
-
-  Note: |request| is not null, because of [=ReadableStreamController/autoAllocateChunkSize=] set in
-  the [=ReceiveStream/create=] procedure.
-1. Let |view| be |request|'s [=ReadableStreamBYOBRequest/view=].
+1. **TBD, fix here this before merging**
 1. Assert: |view| is not null.
 1. Let |bytes| be the byte sequence |view| represents.
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/receive|Read bytes=] into |bytes|, from |internalStream|. Let |read| be the number of
-   read bytes, and let |hasReceivedFIN| be whether FIN was accompanied.
+1. [=stream/receive|Read bytes=] into |bytes|, from |internalStream|. Wait until either at least one
+   byte is read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN|
+   be whether FIN was accompanied.
 
-  Note: This operation may return before filling up all of |bytes|.
+
+   Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
+   SHOULD have a fixed size, to carry the backpressure information to the server.
+
+   Note: This operation may return before filling up all of |bytes|.
+
+1. If the previous step failed, abort the remaining steps.
+
+  Note: We don't reject |promise| here because we handle network errors elsewhere, and those logic
+  error |stream| and reject the result of this read operation.
 
 1. [=Queue a network task=] with |transport| to run these steps:
+
+   Note: If the buffer described above is available in the [=event loop=] where this procedure is
+   running, this block MAY run immediately.
+
   1. If |read| > 0, then perform [=ReadableByteStreamControllerRespond=] with |controller| and
      |read|.
   1. If |hasReceivedFIN| is true:
@@ -1368,7 +1375,6 @@ To <dfn for="ReceiveStream">cancel</dfn> a {{ReceiveStream}} |stream|, run these
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=Send STOP_SENDING=] with |internalStream|.
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
   1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
   1. [=Resolve=] |promise| with undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -1384,6 +1384,10 @@ To <dfn for="ReceiveStream">cancel</dfn> a {{ReceiveStream}} |stream|, run these
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=Send STOP_SENDING=] with |internalStream|.
 1. [=Queue a network task=] with |transport| to run these steps:
+
+  Note: If the buffer described above is available in the [=event loop=] where this procedure is
+  running, the following steps may run immediately.
+
   1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
   1. [=Resolve=] |promise| with undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -1179,8 +1179,8 @@ To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run t
 1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 
 Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
-SHOULD have a fixed size, to carry the backpressure information to the user of {{SendStream}}. This
-also means the [=fulfillment=] of the promise returned from this algorithm (or,
+SHOULD have a fixed upper limit, to carry the backpressure information to the user of
+{{SendStream}}. This also means the [=fulfillment=] of the promise returned from this algorithm (or,
 {{WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
 the chunk arrives at the server, use an application-level protocol.
@@ -1350,13 +1350,13 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN| be
    whether FIN was accompanied.
    Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
-   SHOULD have a fixed size, to carry the backpressure information to the server.
+   SHOULD have a fixed upper limit, to carry the backpressure information to the server.
 
    Note: This operation may return before filling up all of |bytes|.
 
 1. If the previous step failed, abort the remaining steps.
 
-  Note: We don't reject |promise| here because we handle network errors elsewhere, and those logic
+  Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps
   error |stream| and reject the result of this read operation.
 
 1. [=Queue a network task=] with |transport| to run these steps:
@@ -1365,7 +1365,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    running, the following steps may run immediately.
 
   1. If |read| > 0:
-    1. Set |view| to a [=new=] {{Uint8Array}} with |buffer|, |offset| and |read|.
+    1. Set |view| to a new {{Uint8Array}} with |buffer|, |offset| and |read|.
     1. [=ReadableStream/Enqueue=] |view| into |stream|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].

--- a/index.bs
+++ b/index.bs
@@ -1332,18 +1332,23 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
-1. Let |view| be [=ReadableStream/current BYOB request view=] for |stream|.
-1. If |view| is null, set |view| to a [=new=] {{Uint8Array}} with an [=implementation-defined=]
-   size. If allocating the {{Uint8Array}} fails, return a promise [=rejected with=] a
-   {{RangeError}}.
-1. Let |bytes| be the byte sequence |view| represents.
-1. Assert: |bytes|'s length equals to |view|.\[[ByteLength]].
+1. Let |buffer|, |offset|, and |maxBytes| be null.
+1. If |stream|'s [=ReadableStream/current BYOB request view=] for |stream| is not null, then:
+  1. Set |offset| to |stream|'s [=ReadableStream/current BYOB request view=].\[[ByteOffset]].
+  1. Set |maxBytes| to |stream|'s [=ReadableStream/current BYOB request view=]'s
+     [=BufferSource/byte length=].
+  1. Set |buffer| to |stream|'s [=ReadableStream/current BYOB request view=]'s
+     [=BufferSource/underlying buffer=].
+1. Otherwise:
+  1. Set |offset| to 0.
+  1. Set |maxBytes| to an [=implementation-defined=] size.
+  1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
+     {{Uint8Array}} fails, return a promise [=rejected with=] a {{RangeError}}.
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=ArrayBufferView/Write=] the bytes that area [=stream/receive|read=] from |internalStream| into
-   |view|, up to |bytes|'s length bytes. Wait until either at least one byte is read or FIN is
-   received. Let |read| be the number of read bytes, and let |hasReceivedFIN| be whether FIN was
-   accompanied.
-
+1. [=ArrayBuffer/Write=] the bytes that area [=stream/receive|read=] from |internalStream| into
+   |buffer| with offset |offset|, up to |maxBytes| bytes. Wait until either at least one byte is
+   read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN| be
+   whether FIN was accompanied.
    Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
    SHOULD have a fixed size, to carry the backpressure information to the server.
 
@@ -1359,13 +1364,9 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
    running, the following steps may run immediately.
 
-  1. If [=ReadableStream/current BYOB request view=] for |stream| is null:
-    1. Let |arrayBuffer| be |view|.\[[ViewedArrayBuffer]].
-    1. Let |offset| be |view|.\[[ByteOffset]].
-    1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
-    1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream|.
-  1. Otherwise:
-    1. If |read| > 0, then [=ReadableStream/enqueue=] |view| into |stream| with |read|.
+  1. If |read| > 0, then:
+    1. Set |view| to a [=new=] {{Uint8Array}} with |buffer|, |offset| and |read|.
+    1. [=ReadableStream/Enqueue=] |view| into |stream|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.

--- a/index.bs
+++ b/index.bs
@@ -255,7 +255,7 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
 
 [=WebTransport stream=] has the following signals:
 
-<table class="data" dfn-for="stream-event">
+<table class="data" dfn-for="stream-signal">
  <thead>
   <tr>
    <th>event
@@ -1235,7 +1235,7 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
 
 <div algorithm="STOP_SENDING signal">
 Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| gets a
-[=stream-event/STOP_SENDING=] signal from the server, run these steps:
+[=stream-signal/STOP_SENDING=] signal from the server, run these steps:
 
 1. Let |transport| be |stream|'s [=[[Transport]]=].
 1. Let |code| be the application protocol error code attached to the STOP_SENDING frame. [[!QUIC]]
@@ -1294,44 +1294,97 @@ A {{ReceiveStream}} has the following internal slots.
    <td class="non-normative">An [=incoming unidirectional=] or [=bidirectional=]
    [=WebTransport stream=].
   </tr>
+  <tr>
+   <td><dfn>\[[Transport]]</dfn>
+   <td class="non-normative">The {{WebTransport}} object owning this {{ReceiveStream}}.
+  </tr>
 </table>
 
 ## Procedures ##  {#receive-stream-procedures}
 
-<div algorithm="create a ReceiveStream">
+<div algorithm>
 
 To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 {{ReceiveStream}}, with an [=incoming unidirectional=] or [=bidirectional=] [=WebTransport stream=]
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
 1. Let |stream| be a [=new=] {{ReceiveStream}}, with:
-    : [=[[InternalStream]]=]
+    : [=ReceiveStream/[[InternalStream]]=]
     :: |internalStream|
-1. [=ReadableStream/Set up=] |stream| with TBD.
+    : [=ReceiveStream/[[Transport]]=]
+    :: |transport|
+1. Let |pullAlgorithm| be an action that [=pulls bytes=] from |stream|.
+1. Let |cancelAlgorithm| be an action that [=ReceiveStream/cancels=] |stream|.
+1. [=ReadableByteStream/Set up=] |stream| with
+   [=ReadableByteStream/set up/pullAlgorithm=] set to |pullAlgorithm|,
+   [=ReadableByteStream/set up/cancelAlgorithm=] set to |cancelAlgorithm|, and
+   [=ReadableByteStream/set up/highWaterMark=] set to 0.
 1. [=set/Add=] |stream| to |transport|'s [=[[ReceiveStreams]]=].
 1. Return |stream|.
 
 </div>
 
-When a {{ReceiveStream}} receives a message from the remote side aborting the
-stream (for QUIC, that message is an RESET_STREAM frame), the user agent MUST
-queue a task to run the following:
-      1. Let |stream| be the {{ReceiveStream}} object for which the reset
-         message was received.
-      1. Let |transport| be the {{WebTransport}}, which the |stream| was created
-         from.
-      1. Let |reason| be the value from the message from the remote side.
-      1. [=ReadableStream/Error=] |stream| with |reason|.
+<div algorithm>
 
-The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
-     1. Let |stream| be the {{ReceiveStream}} object.
-     1. Let |transport| be the {{WebTransport}}, which the |stream| was created
-        from.
-     1. Let |reason| be the first argument, if it is numeric, or 0.
-     1. If |stream| has received a RESET_STREAM frame, abort these steps.
-     1. [=In parallel=], [=send STOP_SENDING=] over |stream|'s
-        [=WebTransport stream=] with |reason| as the Application Protocol Error
-         Code.
+To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, run these steps.
+
+1. Let |controller| be |stream|'s [=ReadableStream/[[controller]]=].
+1. Assert: |controller| is a {{ReadableByteStreamController}}.
+1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
+1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
+1. Let |promise| be a new promise.
+1. Let |request| be the result of running [=ReadableByteStreamControllerGetBYOBRequest=] with
+   |controller|.
+1. Let |view| be |request|'s [=ReadableStreamBYOBRequest/view=].
+1. Assert: |view| is not null.
+1. Let |bytes| be the byte sequence |view| represents.
+1. Return |promise| and run the remaining steps [=in parallel=].
+1. [=stream/receive|Read bytes=] into |bytes|, from |internalStream|. Let |read| be the number of
+   read bytes, and let |hasReceivedFIN| be whether FIN was accompanied.
+
+  Note: This operation may return before filling up all of |bytes|.
+
+1. [=Queue a network task=] with |transport| to run these steps:
+  1. If |read| > 0, then perform [=ReadableByteStreamControllerRespond=] with |controller| and
+     |read|.
+  1. If |hasReceivedFIN| is true:
+    1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+    1. [=ReadableStream/Close=] |stream|.
+  1. [=Resolve=] promise with undefined.
+
+</div>
+
+<div algorithm>
+
+To <dfn for="ReceiveStream">cancel</dfn> a {{ReceiveStream}} |stream|, run these steps.
+
+1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
+1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
+1. Let |promise| be a new promise.
+1. Return |promise| and run the remaining steps [=in parallel=].
+1. [=Send STOP_SENDING=] with |internalStream|.
+1. [=Queue a network task=] with |transport| to run these steps:
+  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
+  1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+  1. [=Resolve=] |promise| with undefined.
+
+</div>
+
+## Reset signal coming from the server ##  {#receive-stream-RESET_STREAM}
+
+<div algorithm="reset signal">
+Whenever a [=WebTransport stream=] associated with a {{ReceiveStream}} |stream| gets a
+[=stream-signal/reset=] signal from the server, run these steps:
+
+1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
+1. Let |code| be the application protocol error code attached to the RESET_STREAM frame. [[!QUIC]]
+1. [=Queue a network task=] with |transport| to run these steps:
+  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
+  1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+  1. Let |error| be TBD.
+  1. [=ReadableStream/Error=] |stream| with |error|.
+
+</div>
 
 # Interface `BidirectionalStream` #  {#bidirectional-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -1334,9 +1334,14 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
-1. **TBD, fix here this before merging**
-1. Assert: |view| is not null.
+1. Let |view| be [=ReadableStream/current BYOB request view=] for |stream|.
+1. If |view| is null, set |view| to a [=new=] {{Uint8Array}} with an [=implementation-defined=]
+   size. If allocating the {{Uint8Array}} fails, return a promise [=rejected with=] a
+   {{RangeError}}.
 1. Let |bytes| be the byte sequence |view| represents.
+1. Assert: |bytes|'s length equals to |view|.\[[ByteLength]].
+1. Let |arrayBuffer| be |view|.\[[ViewedArrayBuffer]].
+1. Let |offset| be |view|.\[[ByteOffset]].
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=stream/receive|Read bytes=] into |bytes|, from |internalStream|. Wait until either at least one
    byte is read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN|
@@ -1358,8 +1363,8 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
    Note: If the buffer described above is available in the [=event loop=] where this procedure is
    running, the following steps MAY run immediately.
 
-  1. If |read| > 0, then perform [=ReadableByteStreamControllerRespond=] with |controller| and
-     |read|.
+  1. Set |view| to a [=new=] {{Uint8Array}} with |arrayBuffer|, |offset| and |read|.
+  1. If |read| > 0, then [=ReadableStream/enqueue bytes=] into |stream| with |view|.
   1. If |hasReceivedFIN| is true:
     1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
     1. [=ReadableStream/Close=] |stream|.

--- a/index.bs
+++ b/index.bs
@@ -1269,7 +1269,9 @@ The dictionary SHALL have the following fields:
 # Interface `ReceiveStream` #  {#receive-stream}
 
 A <dfn interface>ReceiveStream</dfn> is a {{ReadableStream}} of {{Uint8Array}}
-that can be read from, to consume data received from the server.
+that can be read from, to consume data received from the server. {{ReceiveStream}} is a
+[=readable byte stream=], and hence it allows its consumers to use a [=BYOB reader=]
+as well as a [=default reader=].
 
 <pre class="idl">
 [Exposed=(Window,Worker), SecureContext]


### PR DESCRIPTION
Define pullAlgorithm and cancelAlgorithm, and set up ReceiveStream
with them.

This relies on https://github.com/whatwg/streams/pull/1130.

Fixes #185.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 29, 2021, 2:42 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebtransport%2Fe23c9c325fb45ba758701e943a496e25da6e8867%2Findex.bs&md-warning=not%20ready)

```
<html><body><p><strong>WARNING: </strong>mysqli_connect(): (HY000/2002): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111)</p></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webtransport%23297.)._
</details>
