### PR TITLE
Incoming streams' pull algorithms should work even when unready

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -710,8 +710,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 To <dfn>pullBidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
-1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of [=reacting=] to
-   |transport|'s [=[[Ready]]=] with the following step:
+1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of performing the
+   following steps [=upon fulfillment=] of |transport|'s [=[[Ready]]=]:
   1. Return the result of [=pullBidirectionalStream=] with |transport|.
 1. Let |session| be |transport|'s [=[[Session]]=].
 1. Let |p| be a new promise.
@@ -731,8 +731,8 @@ these steps.
 To <dfn>pullUnidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
-1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of [=reacting=] to
-   |transport|'s [=[[Ready]]=] with the following step:
+1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of performing the
+   following steps [=upon fulfillment=] of |transport|'s [=[[Ready]]=]:
   1. Return the result of [=pullUnidirectionalStream=] with |transport|.
 1. Let |session| be |transport|'s [=[[Session]]=].
 1. Let |p| be a new promise.

--- a/index.bs
+++ b/index.bs
@@ -710,6 +710,9 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 To <dfn>pullBidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
+1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of [=reacting=] to
+   |transport|'s [=[[Ready]]=] with the following step:
+  1. Return the result of [=pullBidirectionalStream=] with |transport|.
 1. Let |session| be |transport|'s [=[[Session]]=].
 1. Let |p| be a new promise.
 1. Return |p| and run the remaining steps [=in parallel=].
@@ -728,6 +731,9 @@ these steps.
 To <dfn>pullUnidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
+1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of [=reacting=] to
+   |transport|'s [=[[Ready]]=] with the following step:
+  1. Return the result of [=pullBidirectionalStream=] with |transport|.
 1. Let |session| be |transport|'s [=[[Session]]=].
 1. Let |p| be a new promise.
 1. Return |p| and run the remaining steps [=in parallel=].

--- a/index.bs
+++ b/index.bs
@@ -733,7 +733,7 @@ these steps.
 
 1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of [=reacting=] to
    |transport|'s [=[[Ready]]=] with the following step:
-  1. Return the result of [=pullBidirectionalStream=] with |transport|.
+  1. Return the result of [=pullUnidirectionalStream=] with |transport|.
 1. Let |session| be |transport|'s [=[[Session]]=].
 1. Let |p| be a new promise.
 1. Return |p| and run the remaining steps [=in parallel=].


### PR DESCRIPTION
pullBidirectionalStream and pullUnidirectionalStream can be called
when transport's state is "connecting". In that case we need to
wait for transport's ready promise.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/304.html" title="Last updated on Jul 7, 2021, 4:27 AM UTC (52de6ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/304/da0b77e...52de6ea.html" title="Last updated on Jul 7, 2021, 4:27 AM UTC (52de6ea)">Diff</a>