### PR TITLE
Remove "SendStream" Web IDL interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1122,7 +1122,7 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 {{SendStream}}, with an [=outgoing unidirectional=] or [=bidirectional=] [=WebTransport stream=]
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
-1. Let |stream| be a [=new=] {{SendStream}}, with:
+1. Let |stream| be a [=new=] {{WritableStream}}, with:
     : [=[[InternalStream]]=]
     :: |internalStream|
     : [=[[PendingOperation]]=]

--- a/index.bs
+++ b/index.bs
@@ -1078,7 +1078,7 @@ The dictionary SHALL have the following attributes:
 :: The number of datagrams that were dropped, due to too many datagrams buffered
    between calls to {{DatagramTransport/datagrams}}' {{DatagramDuplexStream/readable}}.
 
-# Interface `SendStream` #  {#send-stream}
+# `SendStream` #  {#send-stream}
 
 In this spec, we call a {{WritableStream}} providing outgoing streaming features with an [=outgoing
 unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn>SendStream</dfn>.

--- a/index.bs
+++ b/index.bs
@@ -552,7 +552,7 @@ interface WebTransport {
   /* a ReadableStream of BidirectionalStream objects */
   readonly attribute ReadableStream incomingBidirectionalStreams;
 
-  Promise&lt;SendStream&gt; createUnidirectionalStream();
+  Promise&lt;WritableStream&gt; createUnidirectionalStream();
   /* a ReadableStream of ReceiveStream objects */
   readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
@@ -573,7 +573,7 @@ A {{WebTransport}} object has the following internal slots.
  <tbody>
   <tr>
    <td><dfn>\[[SendStreams]]</dfn>
-   <td class="non-normative">An [=ordered set=] of {{SendStream}} objects owned by this {{WebTransport}}.
+   <td class="non-normative">An [=ordered set=] of {{SendStreams}} owned by this {{WebTransport}}.
   </tr>
   <tr>
    <td><dfn>\[[ReceiveStreams]]</dfn>
@@ -846,7 +846,7 @@ these steps.
 
 : <dfn for="WebTransport" method>createUnidirectionalStream()</dfn>
 
-:: Creates a {{SendStream}} object for an outgoing unidirectional stream.  Note
+:: Creates a {{SendStream}} for an outgoing unidirectional stream.  Note
    that the mere creation of a stream is not immediately visible to the server until it is used
    to send data.
 
@@ -1080,14 +1080,11 @@ The dictionary SHALL have the following attributes:
 
 # Interface `SendStream` #  {#send-stream}
 
-A <dfn interface>SendStream</dfn> is a {{WritableStream}} of {{Uint8Array}}
-that can be written to, to transmit data to the server.
+In this spec, we call a {{WritableStream}} providing outgoing streaming features with an [=outgoing
+unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn>SendStream</dfn>.
 
-<pre class="idl">
-[Exposed=(Window,Worker), SecureContext]
-interface SendStream : WritableStream /* of Uint8Array */ {
-};
-</pre>
+Note: {{SendStream}} is not a Web IDL type. A {{SendStream}} is always created by the
+[=SendStream/create=] procedure.
 
 ## Internal Slots ## {#send-stream-internal-slots}
 

--- a/index.bs
+++ b/index.bs
@@ -1310,7 +1310,7 @@ The {{ReceiveStream}}'s <dfn>cancelAlgorithm</dfn> is:
 [Exposed=(Window,Worker), SecureContext]
 interface BidirectionalStream {
   readonly attribute ReceiveStream readable;
-  readonly attribute SendStream writable;
+  readonly attribute WritableStream writable;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1115,9 +1115,9 @@ A {{SendStream}} has the following internal slots.
 </table>
 
 Note: These internal slots need to be attached to {{SendStream}} (which is a kind of
-{{WritableStream}}) conceptually, not physically. For example, implementers may have a weak hash
-map whose key is {{SendStream}} and value is the set of these internal slots, to implement the
-internal slots.
+{{WritableStream}}) conceptually, not physically. For example, an implementation could place them on
+an object which is referenced from |writeAlgorithm|, |closeAlgorithm| and |abortAlgorithm| in the
+[=SendStream/create=] procedure.
 
 ## Procedures ##  {#send-stream-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -1081,7 +1081,7 @@ The dictionary SHALL have the following attributes:
 # `SendStream` #  {#send-stream}
 
 In this spec, we call a {{WritableStream}} providing outgoing streaming features with an [=outgoing
-unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn>SendStream</dfn>.
+unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn interface>SendStream</dfn>.
 
 Note: {{SendStream}} is not a Web IDL type. A {{SendStream}} is always created by the
 [=SendStream/create=] procedure.
@@ -1113,6 +1113,11 @@ A {{SendStream}} has the following internal slots.
   </tr>
  <tbody>
 </table>
+
+Note: These internal slots need to be attached to {{SendStream}} (which is a kind of
+{{WritableStream}}s) conceptually, not phisically. For example, implementers MAY have a weak hash
+map whose key is {{SendStream}} and value is the set of these internal slots, to implement the
+internal slots.
 
 ## Procedures ##  {#send-stream-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -1115,7 +1115,7 @@ A {{SendStream}} has the following internal slots.
 </table>
 
 Note: These internal slots need to be attached to {{SendStream}} (which is a kind of
-{{WritableStream}}s) conceptually, not phisically. For example, implementers MAY have a weak hash
+{{WritableStream}}) conceptually, not physically. For example, implementers may have a weak hash
 map whose key is {{SendStream}} and value is the set of these internal slots, to implement the
 internal slots.
 


### PR DESCRIPTION
Have it a spec-only concept for streams created by the
"create a SendStream" procedure.

This is for #306.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/307.html" title="Last updated on Jul 16, 2021, 8:07 AM UTC (d6b9c09)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/307/3be0e20...d6b9c09.html" title="Last updated on Jul 16, 2021, 8:07 AM UTC (d6b9c09)">Diff</a>