### PR TITLE
Make "WebTransport session" scoped

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -142,8 +142,8 @@ The terms {{ReadableStream}} and {{WritableStream}} are defined in
 
 # Protocol concepts # {#protocol-concepts}
 
-A <dfn>WebTransport session</dfn> is a session of WebTransport over HTTP/3.
-There may be multiple [=WebTransport session=]s on one [=connection=], when pooling is enabled.
+A <dfn for="protocol">WebTransport session</dfn> is a session of WebTransport over HTTP/3.
+There may be multiple [=WebTransport sessions=] on one [=connection=], when pooling is enabled.
 
 [=WebTransport session=] has the following capabilities defined in [[!WEB-TRANSPORT-HTTP3]].
 


### PR DESCRIPTION
Before this change, #webtransport-session links to
"WebTransport session" and #webtransport-session① links to
"[[Session]]" for="WebTransport.

In order to have a public link to "[[Session]]" at
https://github.com/whatwg/html/pull/6856, add "for=protocol" to
the definition of "WebTransport session".

With this change #protocol-webtransport-session links to
"WebTransport session", and #webtransport-session links to
[[Session]].

This is for #127.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/308.html" title="Last updated on Jul 14, 2021, 5:13 AM UTC (62d9386)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/308/3be0e20...62d9386.html" title="Last updated on Jul 14, 2021, 5:13 AM UTC (62d9386)">Diff</a>