### PR TITLE
Terminate WebTransport sessions when unloading page

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Abstract:
   specification developed by the IETF WEBTRANS Working Group.
 Repository: w3c/webtransport
 Indent: 2
-Munloarkup Shorthands: markdown yes
+Markup Shorthands: markdown yes
 Boilerplate: omit conformance
 </pre>
 <pre class="biblio">

--- a/index.bs
+++ b/index.bs
@@ -958,12 +958,12 @@ This specification defines [=unloading document cleanup steps=] as the following
 1. Let |window| be |document|'s [=relevent global object=].
 1. For each {{WebTransport}} |transport| whose [=relevent global object=] is |window|:
   1. If |transport|'s [=[[State]]=] is `"connected"`, set |transport|'s [=[[State]]=] to `"failed"`
-     and |terminate| |transport|'s [=[[Session]]=] [=in parallel=].
+     and [=session/terminate=] |transport|'s [=[[Session]]=] [=in parallel=].
   1. If |transport|'s [=[[State]]=] is `"connecting"`, set |transport|'s [=[[State]]=] to
-     `"failed"`. w3c/webtransport#127
+     `"failed"`.
 
   Issue: This needs to be done in workers too. See
-  <a href="https://www.gihub.com/w3c/webtransport/127">#127</a> and
+  <a href="https://www.github.com/w3c/webtransport/issues/127">#127</a> and
   <a href="https://www.github.com/whatwg/html/issues/6831">whatwg/html#6731</a>.
 
 ## Configuration ##  {#web-transport-configuration}

--- a/index.bs
+++ b/index.bs
@@ -18,7 +18,7 @@ Abstract:
   specification developed by the IETF WEBTRANS Working Group.
 Repository: w3c/webtransport
 Indent: 2
-Markup Shorthands: markdown yes
+Munloarkup Shorthands: markdown yes
 Boilerplate: omit conformance
 </pre>
 <pre class="biblio">
@@ -949,6 +949,22 @@ run these steps:
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 
 </div>
+
+## Context cleanup steps ##  {#web-transport-context-cleanup-steps}
+
+This specification defines [=unloading document cleanup steps=] as the following steps, given a
+{{Document}} document:
+
+1. Let |window| be |document|'s [=relevent global object=].
+1. For each {{WebTransport}} |transport| whose [=relevent global object=] is |window|:
+  1. If |transport|'s [=[[State]]=] is `"connected"`, set |transport|'s [=[[State]]=] to `"failed"`
+     and |terminate| |transport|'s [=[[Session]]=] [=in parallel=].
+  1. If |transport|'s [=[[State]]=] is `"connecting"`, set |transport|'s [=[[State]]=] to
+     `"failed"`. w3c/webtransport#127
+
+  Issue: This needs to be done in workers too. See
+  <a href="https://www.gihub.com/w3c/webtransport/127">#127</a> and
+  <a href="https://www.github.com/whatwg/html/issues/6831">whatwg/html#6731</a>.
 
 ## Configuration ##  {#web-transport-configuration}
 


### PR DESCRIPTION
This is for #127.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/309.html" title="Last updated on Jul 14, 2021, 11:14 AM UTC (1f1f818)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/309/f87c99e...1f1f818.html" title="Last updated on Jul 14, 2021, 11:14 AM UTC (1f1f818)">Diff</a>