### PR TITLE
Remove StreamAbortInfo and a step for remoteCancelled

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1224,27 +1224,8 @@ Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| get
   1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
   1. Let |error| be TBD.
   1. [=WritableStream/Error=] |stream| with |error|.
-  1. [=Resolve=] {{SendStream}}.{{SendStream/remoteCanceled}} with a new
-     {{StreamAbortInfo}} with the {{StreamAbortInfo/errorCode}} set to |code|.
 
 </div>
-
-## `StreamAbortInfo` Dictionary ##  {#stream-abort-info}
-
-The <dfn dictionary>StreamAbortInfo</dfn> dictionary includes information
-relating to the error code for aborting an incoming or outgoing stream (
-in either a RESET_STREAM frame or a STOP_SENDING frame).
-
-<pre class="idl">
-dictionary StreamAbortInfo {
-  [EnforceRange] octet errorCode = 0;
-};
-</pre>
-
-The dictionary SHALL have the following fields:
-
-: <dfn for="StreamAbortInfo" dict-member>errorCode</dfn>
-:: The error code. The default value of 0 means "CLOSING."
 
 # Interface `ReceiveStream` #  {#receive-stream}
 


### PR DESCRIPTION
SendStream.remoteCancelled has been removed. Remove the now
unused interface and a step that were for the property.

Related to #260.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/310.html" title="Last updated on Jul 15, 2021, 4:45 AM UTC (ef8fdba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/310/f87c99e...ef8fdba.html" title="Last updated on Jul 15, 2021, 4:45 AM UTC (ef8fdba)">Diff</a>