### PR TITLE
Introduce WebTransportError

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1375,7 +1375,7 @@ object |transport|, run these steps.
 <dfn interface>WebTransportError</dfn> is a subclass of {{DOMException}} that represents
 
  - An error coming from the server or the network, or
- - An reason for a client initiated abort operation.
+ - A reason for a client-initiated abort operation.
 
 <pre class="idl">
 [Exposed=(Window,Worker), SecureContext]

--- a/index.bs
+++ b/index.bs
@@ -1444,6 +1444,8 @@ To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| wit
    Note: This name does not have a mapping to a legacy code, so |error|'s {{DOMException/code}}
    is 0.
 
+</div>
+
 ## Configuration ## {#web-transport-error-configuration}
 
 <pre class="idl">

--- a/index.bs
+++ b/index.bs
@@ -73,6 +73,7 @@ spec:html; type:dfn; for:/; text:origin
 spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
+spec:webidl; type:dfn; for:/; text:new DOMException(message, name)
 </pre>
 <pre class="anchors">
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
@@ -1402,7 +1403,6 @@ A {{WebTransportError}} has the following internal slots.
    <td><dfn>\[[ApplicationProtocolCode]]</dfn>
    <td class="non-normative">The application protocol error code for this error.
   </tr>
-  <tr>
  </tbody>
 </table>
 

--- a/index.bs
+++ b/index.bs
@@ -84,7 +84,7 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: settled; url: sec-promise-objects
 urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
   type: dfn
-    text: new DOMException(message, name); for:DOMException; url: ref-for-dom-domexception-domexception
+    text: new DOMException(message, name); for:DOMException; url: dom-domexception-domexception
 </pre>
 
 # Introduction #    {#introduction}

--- a/index.bs
+++ b/index.bs
@@ -1410,7 +1410,8 @@ A {{WebTransportError}} has the following internal slots.
 
 <div algorithm>
 
-The <dfn constructor for="WebTransportError">new
+The <dfn constructor for="WebTransportError"
+lt="WebTransportError(applicationProtocolCode, message)">new
 WebTransportError(applicationProtocolCode, message)</dfn> constructor steps are:
 
 1. Let |error| be [=this=].

--- a/index.bs
+++ b/index.bs
@@ -73,7 +73,6 @@ spec:html; type:dfn; for:/; text:origin
 spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
-spec:webidl; type:dfn; for:/; text:new DOMException(message, name)
 </pre>
 <pre class="anchors">
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
@@ -83,6 +82,9 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: pending; url: sec-promise-objects
     text: resolved; url: sec-promise-objects
     text: settled; url: sec-promise-objects
+urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
+  type: dfn
+    text: new DOMException(message, name); for:DOMException; url: ref-for-dom-domexception-domexception
 </pre>
 
 # Introduction #    {#introduction}
@@ -1432,8 +1434,8 @@ WebTransportError(applicationProtocolCode, message)</dfn> constructor steps are:
 To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| with a DOMString
 |message|, run these steps:
 
-1. Run {{new DOMException(message, name)}} constructor steps with |error|, |message| and
-   `"WebTransportError"`.
+1. Run [=DOMException/new DOMException(message, name)=] constructor steps with |error|, |message|
+   and `"WebTransportError"`.
 
    Note: This name does not have a mapping to a legacy code, so |error|'s {{DOMException/code}}
    is 0.

--- a/index.bs
+++ b/index.bs
@@ -1381,12 +1381,16 @@ object |transport|, run these steps.
  - A reason for a client-initiated abort operation.
 
 <pre class="idl">
-
 [Exposed=(Window,Worker), SecureContext]
 interface WebTransportError : DOMException {
   constructor(optional WebTransportErrorInit init = {});
 
   readonly attribute octet? applicationProtocolCode;
+};
+
+dictionary WebTransportErrorInit {
+  octet applicationProtocolCode;
+  DOMString message;
 };
 </pre>
 
@@ -1426,7 +1430,7 @@ lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps
 
 </div>
 
-## Attributes ## {#web-transport-error-methods}
+## Attributes ## {#web-transport-error-attributes}
 
 : <dfn for="WebTransportError" attribute>applicationProtocolCode</dfn>
 :: The getter steps are to return [=this=]'s [=[[ApplicationProtocolCode]]=].
@@ -1445,22 +1449,6 @@ To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| wit
    is 0.
 
 </div>
-
-## Configuration ## {#web-transport-error-configuration}
-
-<pre class="idl">
-
-dictionary WebTransportErrorInit {
-  octet applicationProtocolCode;
-  DOMString message;
-};
-
-</pre>
-
-: <dfn for="WebTransportErrorInit" dict-member>applicationProtocolCode</dfn>
-:: Used to set {{WebTransportError/applicationProtocolCode}}.
-: <dfn for="WebTransportErrorInit" dict-member>message</dfn>
-:: Used to set {{DOMException/message}}.
 
 # Protocol Mappings # {#protocol-mapping}
 

--- a/index.bs
+++ b/index.bs
@@ -1381,9 +1381,10 @@ object |transport|, run these steps.
  - A reason for a client-initiated abort operation.
 
 <pre class="idl">
+
 [Exposed=(Window,Worker), SecureContext]
 interface WebTransportError : DOMException {
-  constructor(WebTransportErrorInit init, optional DOMString message = "");
+  constructor(optional WebTransportErrorInit init = {});
 
   readonly attribute octet? applicationProtocolCode;
 };
@@ -1403,7 +1404,7 @@ A {{WebTransportError}} has the following internal slots.
  <tbody>
   <tr>
    <td><dfn>\[[ApplicationProtocolCode]]</dfn>
-   <td class="non-normative">The application protocol error code for this error.
+   <td class="non-normative">The application protocol error code for this error, or null.
   </tr>
  </tbody>
 </table>
@@ -1413,12 +1414,15 @@ A {{WebTransportError}} has the following internal slots.
 <div algorithm>
 
 The <dfn constructor for="WebTransportError"
-lt="WebTransportError(applicationProtocolCode, message)">new
-WebTransportError(applicationProtocolCode, message)</dfn> constructor steps are:
+lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps are:
 
 1. Let |error| be [=this=].
+1. Let |message| be `""`.
+1. If |init|'s {{WebTransportErrorInit/message}} exists, set |message| to |init|'s
+   {{WebTransportErrorInit/message}}.
 1. [=WebTransportError/Set up=] |error| with |message|.
-1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |applicationProtocolCode|.
+1. If |init|'s {{WebTransportErrorInit/applicationProtocolCode}} exists, set |error|'s
+   [=[[ApplicationProtocolCode]]=] to |init|'s {{WebTransportErrorInit/applicationProtocolCode}}.
 
 </div>
 
@@ -1439,6 +1443,22 @@ To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| wit
 
    Note: This name does not have a mapping to a legacy code, so |error|'s {{DOMException/code}}
    is 0.
+
+## Configuration ## {#web-transport-error-configuration}
+
+<pre class="idl">
+
+dictionary WebTransportErrorInit {
+  octet applicationProtocolCode;
+  DOMString message;
+};
+
+</pre>
+
+: <dfn for="WebTransportErrorInit" dict-member>applicationProtocolCode</dfn>
+:: Used to set {{WebTransportError/applicationProtocolCode}}.
+: <dfn for="WebTransportErrorInit" dict-member>message</dfn>
+:: Used to set {{DOMException/message}}.
 
 # Protocol Mappings # {#protocol-mapping}
 

--- a/index.bs
+++ b/index.bs
@@ -1429,7 +1429,7 @@ WebTransportError(applicationProtocolCode, message)</dfn> constructor steps are:
 
 <div algorithm>
 
-To <dfn for="WebTransportError">set up</dfn> a {{WebTranspoerError}} |error| with a DOMString
+To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| with a DOMString
 |message|, run these steps:
 
 1. Run {{new DOMException(message, name)}} constructor steps with |error|, |message| and

--- a/index.bs
+++ b/index.bs
@@ -1382,7 +1382,7 @@ object |transport|, run these steps.
 interface WebTransportError : DOMException {
   constructor(octet applicationProtocolCode, DOMString message);
 
-  readonly attribute octet applicationProtocolCode;
+  readonly attribute octet? applicationProtocolCode;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1421,12 +1421,14 @@ The <dfn constructor for="WebTransportError"
 lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps are:
 
 1. Let |error| be [=this=].
+1. Set |error|'s internal slots as:
+    : [=[[ApplicationProtocolCode]]=]
+    :: null
 1. Let |message| be `""`.
-1. If |init|'s {{WebTransportErrorInit/message}} exists, set |message| to |init|'s
-   {{WebTransportErrorInit/message}}.
+1. Set |message| to |init|'s {{WebTransportErrorInit/message}} if it exists.
 1. [=WebTransportError/Set up=] |error| with |message|.
-1. If |init|'s {{WebTransportErrorInit/applicationProtocolCode}} exists, set |error|'s
-   [=[[ApplicationProtocolCode]]=] to |init|'s {{WebTransportErrorInit/applicationProtocolCode}}.
+1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |init|'s
+   {{WebTransportErrorInit/applicationProtocolCode}} if it exists.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1380,7 +1380,7 @@ object |transport|, run these steps.
 <pre class="idl">
 [Exposed=(Window,Worker), SecureContext]
 interface WebTransportError : DOMException {
-  constructor(octet applicationProtocolCode, DOMString message);
+  constructor(WebTransportErrorInit init, optional DOMString message = "");
 
   readonly attribute octet? applicationProtocolCode;
 };

--- a/index.bs
+++ b/index.bs
@@ -1370,6 +1370,73 @@ object |transport|, run these steps.
 
 </div>
 
+# `WebTransportError` Interface #  {#web-transport-error-interface}
+
+<dfn interface>WebTransportError</dfn> is a subclass of {{DOMException}} that represents
+
+ - An error coming from the server or the network, or
+ - An reason for a client initiated abort operation.
+
+<pre class="idl">
+[Exposed=(Window,Worker), SecureContext]
+interface WebTransportError : DOMException {
+  constructor(octet applicationProtocolCode, DOMString message);
+
+  readonly attribute octet applicationProtocolCode;
+};
+</pre>
+
+## Internal slots  ## {#web-transport-error-internal-slots}
+
+A {{WebTransportError}} has the following internal slots.
+
+<table class="data" dfn-for="WebTransportError">
+ <thead>
+  <tr>
+   <th>Internal Slot
+   <th>Description (<em>non-normative</em>)
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>\[[ApplicationProtocolCode]]</dfn>
+   <td class="non-normative">The application protocol error code for this error.
+  </tr>
+  <tr>
+ </tbody>
+</table>
+
+## Constructor ##  {#web-transport-error-constructor1}
+
+<div algorithm>
+
+The <dfn constructor for="WebTransportError">new
+WebTransportError(applicationProtocolCode, message)</dfn> constructor steps are:
+
+1. Let |error| be [=this=].
+1. [=WebTransportError/Set up=] |error| with |message|.
+1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |applicationProtocolCode|.
+
+</div>
+
+## Attributes ## {#web-transport-error-methods}
+
+: <dfn for="WebTransportError" attribute>applicationProtocolCode</dfn>
+:: The getter steps are to return [=this=]'s [=[[ApplicationProtocolCode]]=].
+
+## Procedures ## {#web-transport-error-procedures}
+
+<div algorithm>
+
+To <dfn for="WebTransportError">set up</dfn> a {{WebTranspoerError}} |error| with a DOMString
+|message|, run these steps:
+
+1. Run {{new DOMException(message, name)}} constructor steps with |error|, |message| and
+   `"WebTransportError"`.
+
+   Note: This name does not have a mapping to a legacy code, so |error|'s {{DOMException/code}}
+   is 0.
+
 # Protocol Mappings # {#protocol-mapping}
 
 *This section is non-normative.*


### PR DESCRIPTION
Introduce WebTransportError, an interface for error information
related to WebTransport.

This is related to #252. This is based on #288. This PR is aiming to land
a minimal change in order to unblock other issues. For example, we're
 talking about `errorSource` in #288. This PR doesn't contain it.

In the last WG meeting, no one was against introducing this interface, and
people prefered having one interface and multiple properties to having
multiple error interfaces and fewer properties. Hence the contents
of this shouldn't be super controversial I believe.

This change addresses most of comments made by @ricea at #288. One exception
is how to handle out-of-range value. I think it is the same problem as #214, and
should be solved altogether.

I want to merge this PR at the next WG meeting (8/3), but comments
before the meeting are welcomed.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/316.html" title="Last updated on Jul 30, 2021, 12:26 PM UTC (7499229)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/316/723a113...7499229.html" title="Last updated on Jul 30, 2021, 12:26 PM UTC (7499229)">Diff</a>