### PR TITLE
Active WebTransport must not be collected

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -969,6 +969,11 @@ This specification defines [=unloading document cleanup steps=] as the following
   <a href="https://www.github.com/w3c/webtransport/issues/127">#127</a> and
   <a href="https://www.github.com/whatwg/html/issues/6831">whatwg/html#6731</a>.
 
+## Garbage Collection ## {#web-transport-gc}
+
+The user agent MUST NOT garbage collect a {{WebTransport}} object whose [=[[State]]=] is either
+`"connecting"` or `"connected"`.
+
 ## Configuration ##  {#web-transport-configuration}
 
 <pre class="idl">


### PR DESCRIPTION
Fixes #225.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/321.html" title="Last updated on Aug 4, 2021, 4:18 AM UTC (c91f1ac)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/321/7bfb7ca...c91f1ac.html" title="Last updated on Aug 4, 2021, 4:18 AM UTC (c91f1ac)">Diff</a>