### PR TITLE
Allow BufferSources for outgoing bytes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -485,7 +485,7 @@ progress.
 The <dfn>writeDatagrams</dfn> algorithm is given a |transport| as parameter and
 |data| as input. It is defined by running the following steps:
 1. Let |timestamp| be a timestamp representing now.
-1. If |data| is not a {{Uint8Array}} object, then return [=a promise rejected with=] a {{TypeError}}.
+1. If |data| is not a {{BufferSource}} object, then return [=a promise rejected with=] a {{TypeError}}.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of bytes which |data| represents.
 1. Let |chunk| be a tuple of |bytes|, |timestamp| and |promise|.
@@ -1183,7 +1183,7 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run these steps:
 
 1. Let |transport| be |stream|'s [=[[Transport]]=].
-1. If |chunk| is not a {{Uint8Array}}, return [=a promise rejected with=] a {{TypeError}}.
+1. If |chunk| is not a {{BufferSource}}, return [=a promise rejected with=] a {{TypeError}}.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
 1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.


### PR DESCRIPTION
Fixes #284.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/322.html" title="Last updated on Aug 4, 2021, 5:06 AM UTC (fe051d5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/322/7bfb7ca...fe051d5.html" title="Last updated on Aug 4, 2021, 5:06 AM UTC (fe051d5)">Diff</a>