### PR TITLE
Use [Clamp] for WebTransportErrorInit.applicationProtocolCode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1475,7 +1475,7 @@ interface WebTransportError : DOMException {
 };
 
 dictionary WebTransportErrorInit {
-  octet applicationProtocolCode;
+  [Clamp] octet applicationProtocolCode;
   DOMString message;
 };
 </pre>


### PR DESCRIPTION
Fixes #214.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/323.html" title="Last updated on Aug 17, 2021, 11:41 AM UTC (e4ee7a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/323/2fe564d...e4ee7a5.html" title="Last updated on Aug 17, 2021, 11:41 AM UTC (e4ee7a5)">Diff</a>