### PR TITLE
Fixing example script

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1892,7 +1892,7 @@ async function readFromIncomingStream(readable, number) {
     }
     addToEventLog(&#96;Stream #${number} closed&#96;);
   } catch (e) {
-    addToEventLog(&#96;Error while reading from stream #${number"}: ${e}&#96;, 'error');
+    addToEventLog(&#96;Error while reading from stream #${number}: ${e}&#96;, 'error');
     addToEventLog(&#96;    ${e.message}&#96;);
   }
 }


### PR DESCRIPTION
Removing hanging quote from non-normative example script


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Aug 9, 2021, 4:25 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebtransport%2F01e8dbb695caf7d3ea557491deda4de57fa1cd8b%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 6, in 
    cli.main()
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 466, in main
    handleSpec(options, extras)
  File "/sites/api.csswg.org/bikeshed/bikeshed/cli.py", line 515, in handleSpec
    lineNumbers=options.lineNumbers,
  File "/sites/api.csswg.org/bikeshed/bikeshed/Spec.py", line 61, in __init__
    self.inputSource = InputSource(inputFilename, chroot=constants.chroot)
  File "/sites/api.csswg.org/bikeshed/bikeshed/InputSource.py", line 51, in __new__
    return UrlInputSource(sourceName, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'chroot'
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webtransport%23325.)._
</details>
