### PR TITLE
Prioritize outgoing datagrams over stream data

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1212,6 +1212,9 @@ To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run t
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
 1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
+1. Wait for |transport|'s [=[[Datagrams]]=]'s [=[[OutgoingDatagramsQueue]]=] to be empty.
+
+   Note: This means outgoing datagrams are prioritized over stream data.
 1. [=stream/Send=] |bytes| on |stream|'s [=[[InternalStream]]=] and wait for the operation to
    complete.
 1. [=Queue a network task=] with |transport| to run these steps:


### PR DESCRIPTION
Discussed at #62. Explicitly state that outgoing datagrams are
prioritized for now. We will introduce a way to change this
default behavior, as part of the prioritization API.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/340.html" title="Last updated on Aug 31, 2021, 11:10 AM UTC (4122fe6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/340/f0d9aa6...4122fe6.html" title="Last updated on Aug 31, 2021, 11:10 AM UTC (4122fe6)">Diff</a>