### PR TITLE
Deal with the reason string in WebTransport.close()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -194,8 +194,8 @@ There may be multiple [=WebTransport sessions=] on one [=connection=], when pool
 To <dfn for=session>establish</dfn> a [=WebTransport session=], follow [[!WEB-TRANSPORT-HTTP3]]
 [section 3.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.3).
 
-To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an integer |code|,
-follow [[!WEB-TRANSPORT-HTTP3]]
+To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
+|code| and an optional [=byte sequence=] |reason|, follow [[!WEB-TRANSPORT-HTTP3]]
 [section 5](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-5).
 
 A [=WebTransport session=] |session| is <dfn for=session>terminated</dfn>, with optionally
@@ -736,7 +736,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. Assert: |maxDatagramSize| is an integer.
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is not `"connecting"`:
-    1. [=In parallel=], [=session/terminate=] |session| with TBD.
+    1. [=In parallel=], [=session/terminate=] |session|.
     1. Abort these steps.
   1. Set |transport|'s [=[[State]]=] to `"connected"`.
   1. Set |transport|'s [=[[Session]]=] to |session|.
@@ -812,6 +812,8 @@ these steps.
 
 ## Methods ##  {#webtransport-methods}
 
+<div algorithm>
+
 : <dfn for="WebTransport" method>close(closeInfo)</dfn>
 :: Terminates the [=WebTransport session=] associated with the WebTransport object.
 
@@ -823,11 +825,22 @@ these steps.
        1. [=Cleanup=] |transport| with |error|, |error| and true.
        1. Abort these steps.
      1. Let |session| be |transport|'s [=[[Session]]=].
-     1. In parallel, [=session/terminate=] |session| with |closeInfo|.{{WebTransportCloseInfo/errorCode}}.
+     1. Let |reason| be an empty [=byte sequence=].
+     1. If |closeInfo|.{{WebTransportCloseInfo/reason}} exists, set |reason| be
+        |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
+     1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
+        [=byte sequence/prefix=] of |reason| whose length is 1024.
+     1. If |closeInfo|.{{WebTransportCloseInfo/errorCode}} exists:
+       1. [=In parallel=], [=session/terminate=] |session| with
+          |closeInfo|.{{WebTransportCloseInfo/errorCode}} and |reason|.
+     1. Otherwise:
+       1. [=In parallel=], [=session/terminate=] |session|.
 
        Note: This also [=resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in
        |transport|'s [=[[SendStreams]]=] and [=[[ReceiveStreams]]=].
      1. [=Cleanup=] |transport| with |closeInfo|, an {{AbortError}} and false.
+
+</div>
 
 : <dfn for="WebTransport" method>getStats()</dfn>
 :: Gathers stats for this {{WebTransport}}'s HTTP/3
@@ -1074,8 +1087,8 @@ frame.
 
 <pre class="idl">
 dictionary WebTransportCloseInfo {
-  unsigned long long errorCode = 0;
-  DOMString reason = "";
+  unsigned long errorCode;
+  DOMString reason;
 };
 </pre>
 


### PR DESCRIPTION
- Deal with closeInfo.reason in WebTransport.close(closeInfo).
 - Explicitly state the code and reason are optional in
   session/terminate.
 - Change the type of WebTransportCloseInfo.errorCode based
   on [1].
 - Remove default values of errorCode and reason from
   WebTransportCloseInfo, given they are optional.

1: https://mailarchive.ietf.org/arch/msg/webtransport/P6jXBCOwCgqHlmY-DEKDpot6ZII/


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/343.html" title="Last updated on Sep 7, 2021, 2:59 AM UTC (8e03a39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/343/cea6958...8e03a39.html" title="Last updated on Sep 7, 2021, 2:59 AM UTC (8e03a39)">Diff</a>