### PR TITLE
Replace TypeError with WebTransportError

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -955,6 +955,8 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
 1. Let |cleanly| be a boolean representing whether the HTTP/3 stream associated with the CONNECT
    request that initiated |transport|'s [=[[Session]]=] is in the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
+  1. Let |code| be TBD.
+  1. Let |reasonString| be TBD.
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.

--- a/index.bs
+++ b/index.bs
@@ -653,7 +653,7 @@ agent MUST run the following steps:
 1. Let |serverCertificateFingerprints| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=]
-   the result of [=WebTransportError/creating=] a {{WebTransportError}} with `"session"`.
+   a {{TypeError}}.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a

--- a/index.bs
+++ b/index.bs
@@ -652,8 +652,8 @@ agent MUST run the following steps:
 1. Let |dedicated| be the negation of |allowPooling|.
 1. Let |serverCertificateFingerprints| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
-1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=]
-   a {{TypeError}}.
+1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
+   {{TypeError}}.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a

--- a/index.bs
+++ b/index.bs
@@ -955,8 +955,6 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
 1. Let |cleanly| be a boolean representing whether the HTTP/3 stream associated with the CONNECT
    request that initiated |transport|'s [=[[Session]]=] is in the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. Let |code| be TBD.
-  1. Let |reasonString| be TBD.
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.

--- a/index.bs
+++ b/index.bs
@@ -652,8 +652,8 @@ agent MUST run the following steps:
 1. Let |dedicated| be the negation of |allowPooling|.
 1. Let |serverCertificateFingerprints| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/serverCertificateFingerprints}} if it exists, and null otherwise.
-1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=] a
-   {{TypeError}}.
+1. If |dedicated| is false and |serverCertificateFingerprints| is non-null, then [=throw=]
+   the result of [=WebTransportError/creating=] a {{WebTransportError}} with `"session"`.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
@@ -713,7 +713,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be a {{TypeError}}.
+  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
+     `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
    represents the SETTINGS frame.
@@ -721,7 +722,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    contain H3_DATAGRAM with a value of 1, then abort the remaining steps and [=queue a network
    task=] with |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be a {{TypeError}}.
+  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
+     `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. [=session/Establish=] a [=WebTransport session=] on |connection|.
 
@@ -730,7 +732,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. If the previous step fails, abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be a {{TypeError}}.
+  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
+     `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Let |session| be the established [=WebTransport session=].
 1. Assert: |maxDatagramSize| is an integer.
@@ -819,7 +822,8 @@ these steps.
      1. Let |transport| be [=this=].
      1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
      1. If |transport|'s [=[[State]]=] is `"connecting"`:
-       1. Let |error| be a {{TypeError}}.
+       1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
+          `"session"`.
        1. [=Cleanup=] |transport| with |error|, |error| and true.
        1. Abort these steps.
      1. Let |session| be |transport|'s [=[[Session]]=].


### PR DESCRIPTION
Replace some TypeError occurences with WebTransportError. I didn't
replace type related errors such as the case where writeDatagrams is
called with a value that is not a BufferSource.

Fixes #344.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/346.html" title="Last updated on Sep 6, 2021, 5:13 AM UTC (1a7b710)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/346/bf1ec50...1a7b710.html" title="Last updated on Sep 6, 2021, 5:13 AM UTC (1a7b710)">Diff</a>