### PR TITLE
Replace applicationProtocolCode with streamErrorCode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1594,10 +1594,10 @@ lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps
 
 ## Attributes ## {#web-transport-error-attributes}
 
-: <dfn for="WebTransportError" attribute>streamErrorCode</dfn>
-:: The getter steps are to return [=this=]'s [=[[StreamErrorCode]]=].
 : <dfn for="WebTransportError" attribute>source</dfn>
 :: The getter steps are to return [=this=]'s [=WebTransportError/[[Source]]=].
+: <dfn for="WebTransportError" attribute>streamErrorCode</dfn>
+:: The getter steps are to return [=this=]'s [=[[StreamErrorCode]]=].
 
 ## Procedures ## {#web-transport-error-procedures}
 

--- a/index.bs
+++ b/index.bs
@@ -1267,8 +1267,8 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
 1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
-1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[ApplicationProtocolCode]]=] is not
-   null, then set |code| to |reason|'s [=[[ApplicationProtocolCode]]=].
+1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[StreamErrorCode]]=] is not
+   null, then set |code| to |reason|'s [=[[StreamErrorCode]]=].
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
 
@@ -1298,7 +1298,7 @@ Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| get
   1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"stream"`.
-  1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |code|.
+  1. Set |error|'s [=[[StreamErrorCode]]=] to |code|.
   1. [=WritableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1425,8 +1425,8 @@ steps.
 1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
-1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[ApplicationProtocolCode]]=] is not
-   null, then set |code| to |reason|'s [=[[ApplicationProtocolCode]]=].
+1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[StreamErrorCode]]=] is not
+   null, then set |code| to |reason|'s [=[[StreamErrorCode]]=].
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
 
@@ -1463,7 +1463,7 @@ Whenever a [=WebTransport stream=] associated with a {{ReceiveStream}} |stream| 
   1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"stream"`.
-  1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |code|.
+  1. Set |error|'s [=[[StreamErrorCode]]=] to |code|.
   1. [=ReadableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1539,12 +1539,12 @@ object |transport|, run these steps.
 interface WebTransportError : DOMException {
   constructor(optional WebTransportErrorInit init = {});
 
-  readonly attribute octet? applicationProtocolCode;
   readonly attribute WebTransportErrorSource source;
+  readonly attribute octet? streamErrorCode;
 };
 
 dictionary WebTransportErrorInit {
-  [Clamp] octet applicationProtocolCode;
+  [Clamp] octet streamErrorCode;
   DOMString message;
 };
 
@@ -1567,12 +1567,12 @@ A {{WebTransportError}} has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[ApplicationProtocolCode]]</dfn>
-   <td class="non-normative">The application protocol error code for this error, or null.
-  </tr>
-  <tr>
    <td><dfn>\[[Source]]</dfn>
    <td class="non-normative">A {{WebTransportErrorSource}} indicating the source of this error.
+  </tr>
+  <tr>
+   <td><dfn>\[[StreamErrorCode]]</dfn>
+   <td class="non-normative">The application protocol error code for this error, or null.
   </tr>
  </tbody>
 </table>
@@ -1587,15 +1587,15 @@ lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps
 1. Let |error| be [=this=].
 1. Let |message| be |init|'s {{WebTransportErrorInit/message}} if it exists, and `""` otherwise.
 1. [=WebTransportError/Set up=] |error| with |message| and `"stream"`.
-1. Set |error|'s [=[[ApplicationProtocolCode]]=] to |init|'s
-   {{WebTransportErrorInit/applicationProtocolCode}} if it exists.
+1. Set |error|'s [=[[StreamErrorCode]]=] to |init|'s
+   {{WebTransportErrorInit/streamErrorCode}} if it exists.
 
 </div>
 
 ## Attributes ## {#web-transport-error-attributes}
 
-: <dfn for="WebTransportError" attribute>applicationProtocolCode</dfn>
-:: The getter steps are to return [=this=]'s [=[[ApplicationProtocolCode]]=].
+: <dfn for="WebTransportError" attribute>streamErrorCode</dfn>
+:: The getter steps are to return [=this=]'s [=[[StreamErrorCode]]=].
 : <dfn for="WebTransportError" attribute>source</dfn>
 :: The getter steps are to return [=this=]'s [=WebTransportError/[[Source]]=].
 
@@ -1618,7 +1618,7 @@ To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| wit
 |message| and a {{WebTransportErrorSource}} |source|, run these steps:
 
 1. Set |error|'s internal slots as:
-    : [=[[ApplicationProtocolCode]]=]
+    : [=[[StreamErrorCode]]=]
     :: null
     : [=WebTransportError/[[Source]]=]
     :: |source|


### PR DESCRIPTION
Mostly mechanical. Some manual edits to maintain the alphabetical
ordering.

Fixes #328.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/348.html" title="Last updated on Sep 3, 2021, 1:28 PM UTC (29a0484)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/348/bf1ec50...29a0484.html" title="Last updated on Sep 3, 2021, 1:28 PM UTC (29a0484)">Diff</a>