### PR TITLE
Fetch's obtain a connection changed slightly

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -707,9 +707,10 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    |transport|'s [=relevant settings object=].
 1. Run the remaining steps [=in parallel=], but abort them whenever |transport|'s
    [=[[State]]=] becomes `"closed"` or `"failed"`.
+1. Let |newConnection| be "`no`" if |dedicated| is false; otherwise "`yes-and-dedicated`".
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
-   |networkPartitionKey|, |url|'s [=url/origin=], false, [=obtain a connection/http3Only=] set to
-   true, and [=obtain a connection/dedicated=] set to |dedicated|.
+   |networkPartitionKey|, |url|, false, |newConnection|, and with [=obtain a connection/http3Only=]
+   set to true.
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.


### PR DESCRIPTION
See https://github.com/whatwg/fetch/pull/1259 for context. This change should be a no-op.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/annevk/webtransport/pull/351.html" title="Last updated on Sep 8, 2021, 4:56 PM UTC (b254896)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/351/54ea041...annevk:b254896.html" title="Last updated on Sep 8, 2021, 4:56 PM UTC (b254896)">Diff</a>