### PR TITLE
Update explainer

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -68,31 +68,31 @@ encrypted and congestion-controlled communication.
    [an HTTP/3 based protocol](https://tools.ietf.org/html/draft-vvv-webtransport-http3)
    that allows web developers to reuse HTTP/3 connections (sharing a congestion control context).
 
-## Example of sending unreliable game state to server using QUIC datagrams
+## Example of sending unreliable game state to server using datagrams
 
 ```javascript
 // The app provides a way to get a serialized state to send to the server
 function getSerializedGameState() { ... }
 
-const transport = new WebTransport('quic-transport://example.com:10001/path');
-const datagramWriter = transport.datagramWritable.getWriter();
+const wt = new WebTransport('https://example.com:10001/path');
+const writer = wt.datagrams.writable.getWriter();
 setInterval(() => {
   const message = getSerializedGameState();
-  datagramWriter.write(message);
+  writer.write(message);
 }, 100);
 ```
 
-## Example of sending reliable game state to server using a QUIC unidirectional send stream
+## Example of sending reliable game state to server using a unidirectional send stream
 
 ```javascript
 // The app provides a way to get a serialized state to send to the server.
 function getSerializedGameState() { ... }
 
-const transport = new WebTransport('quic-transport://example.com:10001/path');
+const wt = new WebTransport('https://example.com:10001/path');
 setInterval(async () => {
   const message = getSerializedGameState();
-  const stream = await transport.createUnidirectionalStream();
-  const writer = stream.writable.getWriter();
+  const stream = await wt.createUnidirectionalStream();
+  const writer = stream.getWriter();
   writer.write(message);
   writer.close();
 }, 100);
@@ -104,7 +104,7 @@ setInterval(async () => {
 // The app provides a way to get a serialized media request to send to the server
 function getSerializedMediaRequest() { ... }
 
-const transport = new WebTransport('quic-transport://example.com:10001/path');
+const wt = new WebTransport('https://example.com:10001/path');
 
 const mediaSource = new MediaSource();
 await new Promise(resolve => mediaSource.addEventListener('sourceopen', resolve, {once: true}));
@@ -112,14 +112,14 @@ const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="opus, vp09
 
 // App-specific request
 const mediaRequest = getSerializedMediaRequest();
-const requestStream = await transport.createUnidirectionalStream();
-const requestWriter = requestStream.writable.getWriter();
+const requestStream = await wt.createUnidirectionalStream();
+const requestWriter = requestStream.getWriter();
 requestWriter.write(mediaRequest);
 requestWriter.close();
 
 // Receive the responses.
-for await (const receiveStream of transport.incomingUnidirectionalStreams) {
-  for await (const buffer of receiveStream.readable) {
+for await (const receiveStream of wt.incomingUnidirectionalStreams) {
+  for await (const buffer of receiveStream) {
     sourceBuffer.appendBuffer(buffer);
   }
   await new Promise(resolve => sourceBuffer.addEventListener('update', resolve, {once: true}));
@@ -134,10 +134,10 @@ function deserializeNotification(serializedNotification) { ... }
 // The app also provides a way to serialize a "clicked" message to send to the server.
 function serializeClickedMessage(notification) { ... }
 
-const transport = new WebTransport('quic-transport://example.com:10001/path');
-for await (const stream of transport.incomingBidirectionalStreams) {
+const wt = new WebTransport('https://example.com:10001/path');
+for await (const stream of wt.incomingBidirectionalStreams) {
   const buffers = []
-  for await (const buffer of stream.readable) {
+  for await (const buffer of stream) {
     buffers.push(buffer)
   }
   const notification = new Notification(deserializeNotification(buffers));
@@ -156,9 +156,9 @@ for await (const stream of transport.incomingBidirectionalStreams) {
 const mediaSource = new MediaSource();
 await new Promise(resolve => mediaSource.addEventListener('sourceopen', resolve, {once: true}));
 const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="opus, vp09.00.10.08"');
-const transport = new WebTransport('/video');
+const wt = new WebTransport('/video');
 await fetch('https://example.com/babyshark');
-for await (const datagram of transport.datagramReadable) {
+for await (const datagram of wt.datagrams.readable) {
   sourceBuffer.appendBuffer(datagram);
   await new Promise(resolve => sourceBuffer.addEventListener('update', resolve, {once: true}));
 }
@@ -170,9 +170,9 @@ for await (const datagram of transport.datagramReadable) {
 const mediaSource = new MediaSource();
 await new Promise(resolve => mediaSource.addEventListener('sourceopen', () => resolve(), {once: true}));
 const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="opus, vp09.00.10.08"');
-const transport = new WebTransport('https://example.com/video');
+const wt = new WebTransport('https://example.com/video');
 for await (const receiveStream of transport.incomingUnidirectionalStreams) {
-  for await (const buffer of receiveStream.readable) {
+  for await (const buffer of receiveStream) {
     sourceBuffer.appendBuffer(buffer);
   }
   await new Promise(resolve => sourceBuffer.addEventListener('update', resolve, {once: true}));

--- a/explainer.md
+++ b/explainer.md
@@ -135,15 +135,15 @@ function deserializeNotification(serializedNotification) { ... }
 function serializeClickedMessage(notification) { ... }
 
 const wt = new WebTransport('https://example.com:10001/path');
-for await (const stream of wt.incomingBidirectionalStreams) {
+for await (const {readable, writable} of wt.incomingBidirectionalStreams) {
   const buffers = []
-  for await (const buffer of stream) {
+  for await (const buffer of readable) {
     buffers.push(buffer)
   }
   const notification = new Notification(deserializeNotification(buffers));
   notification.addEventListener('onclick', () => {
     const clickMessage = encodeClickMessage(notification);
-    const writer = stream.writable.getWriter();
+    const writer = writable.getWriter();
     writer.write(clickMessage);
     writer.close();
   });

--- a/explainer.md
+++ b/explainer.md
@@ -116,7 +116,7 @@ const requestStream = await wt.createUnidirectionalStream();
 const requestWriter = requestStream.getWriter();
 requestWriter.write(mediaRequest);
 requestWriter.close();
-
+b
 // Receive the responses.
 for await (const receiveStream of wt.incomingUnidirectionalStreams) {
   for await (const buffer of receiveStream) {
@@ -156,7 +156,7 @@ for await (const {readable, writable} of wt.incomingBidirectionalStreams) {
 const mediaSource = new MediaSource();
 await new Promise(resolve => mediaSource.addEventListener('sourceopen', resolve, {once: true}));
 const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="opus, vp09.00.10.08"');
-const wt = new WebTransport('/video');
+const wt = new WebTransport('/video', {allowPooling: true});
 await fetch('https://example.com/babyshark');
 for await (const datagram of wt.datagrams.readable) {
   sourceBuffer.appendBuffer(datagram);

--- a/explainer.md
+++ b/explainer.md
@@ -181,7 +181,7 @@ for await (const receiveStream of transport.incomingUnidirectionalStreams) {
 
 ## Detailed design discussion
 
-WebTransport supports multiple protocols, each of which provide some of the
+WebTransport can support multiple protocols, each of which provide some of the
 following capabilities.
 
 - Unidirectional streams are indefinitely long streams of bytes in one direction
@@ -199,17 +199,11 @@ following capabilities.
   sending messages with less API complexity
   and less network overhead than streams.
 
-[QuicTransport](https://tools.ietf.org/html/draft-vvv-webtransport-quic)
-is a WebTransport protocol that maps directly to QUIC streams and datagrams,
-which makes it easy to connect to servers that speak QUIC with minimal overhead.
-It supports all of these capabilities.
-
-[Http3Transport](https://tools.ietf.org/html/draft-vvv-webtransport-http3) is a
-WebTransport protocol that provides QUIC streams and datagrams with slightly
-more overhead vs. a QuicTransport.  It has the advantage that HTTP and non-HTTP
-traffic can share the same network port and congestion control context, and it
-may be pooled with other transports such that the transport may be connected
-more quickly (by reusing an existing HTTP/3 connection).
+[WebTransport over
+HTTP/3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3)
+is a WebTransport protocol built on top of HTTP/3. It is the only protocol supported
+by WebTransport as of now. More protocols such as WebTransport over HTTP/2 may be
+supported in the future.
 
 ## Alternative designs considered
 


### PR DESCRIPTION
Examples in the explainer is based on old interfaces, so let's
update them.

 - Replace "quic-transport" scheme with "https".
 - Replace "transport" variable name with "wt".
 - Remove "QUIC" terms (e.g. "QUIC datagrams" => "datagrams").
 - Update properties (e.g. datagramReadable => datagrams.readable).

Fixes #353.