### PR TITLE
Add Content Security Policy check on request

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -708,6 +708,17 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 1. Let |client| be |transport|'s [=relevant settings object=].
 1. Let |origin| be |client|'s [=environment settings object/origin=].
+1. Let |request| be a new [=request=] whose [=request/URL=] is |url|, [=request/client=] is
+   |client|, [=request/policy container=] is |client|'s
+   [=environment settings object/policy container=], [=request/destination=] is an empty string,
+   and [=request/origin=] is |origin|.
+1. Run <a>report Content Security Policy violations for |request|</a>.
+1. If [=should request be blocked by Content Security Policy?=] with |request| returns
+   <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
+   to run these steps:
+  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
+  1. Let |error| be a {{SecurityError}}.
+  1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
    |transport|'s [=relevant settings object=].
 1. Run the remaining steps [=in parallel=], but abort them whenever |transport|'s


### PR DESCRIPTION
We only need the pre-request check. We don't need the post-request
check given there is no redirects on WebTransport.

This is for #59.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/367.html" title="Last updated on Oct 20, 2021, 7:50 AM UTC (e1a7f10)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/367/0a62f0c...e1a7f10.html" title="Last updated on Oct 20, 2021, 7:50 AM UTC (e1a7f10)">Diff</a>