### PR TITLE
Remove text on request forgery

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -70,7 +70,6 @@ Boilerplate: omit conformance
 <pre class="link-defaults">
 spec:streams; type:interface; text:ReadableStream
 spec:html; type:dfn; for:/; text:origin
-spec:fetch; type:dfn; for:/; text:origin header
 spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment

--- a/index.bs
+++ b/index.bs
@@ -70,6 +70,7 @@ Boilerplate: omit conformance
 <pre class="link-defaults">
 spec:streams; type:interface; text:ReadableStream
 spec:html; type:dfn; for:/; text:origin
+spec:fetch; type:dfn; for:/; text:origin header
 spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
@@ -1737,15 +1738,16 @@ specification.
 ## Protocol Security ##  {#protocol-security}
 
 WebTransport imposes a set of requirements as described in
-[[!WEB-TRANSPORT-OVERVIEW]], including: 
+[[!WEB-TRANSPORT-OVERVIEW]], including:
 
-1. Ensuring that the remote server is aware that the
-   connection in question originates from a Web application; this is required
-   to prevent cross-protocol attacks. [[WEB-TRANSPORT-HTTP3]] uses a
-   combination of ALPN [[RFC7301]], an HTTP/3 setting and a `:protocol`
-   pseudo-header for this purpose.
-1. Allowing the server to filter connections based on the
-   origin of the resource originating the transport session.
+1. Ensuring that the remote server is aware that the WebTransport protocol is in
+   use and confirming that the remote server is willing to use the WebTransport
+   protocol. [[WEB-TRANSPORT-HTTP3]] uses a combination of ALPN [[RFC7301]], an
+   HTTP/3 setting, and a `:protocol` pseudo-header to identify the WebTransport
+   protocol.
+1. Allowing the server to filter connections based on the origin of the resource
+   originating the transport session.  The [[fetch#origin-header|Origin]] header
+   field on the session establishment request carries this information.
 
 Protocol security considerations related are described in the
 *Security Considerations* sections of [[!WEB-TRANSPORT-HTTP3]].

--- a/index.bs
+++ b/index.bs
@@ -1746,7 +1746,7 @@ WebTransport imposes a set of requirements as described in
    HTTP/3 setting, and a `:protocol` pseudo-header to identify the WebTransport
    protocol.
 1. Allowing the server to filter connections based on the origin of the resource
-   originating the transport session.  The [[fetch#origin-header|Origin]] header
+   originating the transport session.  The <a http-header><code>Origin</code></a> header
    field on the session establishment request carries this information.
 
 Protocol security considerations related are described in the


### PR DESCRIPTION
In looking into this text and the related specifications I decided that
it would be better to address the risk of request forgery in the
protocol specifications.  Right now, they say nothing about this
problem, but they really should.  I'm going to open an issue.

On the assumption that the protocol documents address this problem
adequately, then this document doesn't need to concern itself with the
problem.  It is enough to remove any false claims and defer to the
protocol spec.

This contains a tweak to the adjacent text for the Origin field (#368),
but it doesn't fix that issue.

Closes #175.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/webtransport/pull/369.html" title="Last updated on Nov 23, 2021, 3:30 PM UTC (dd62f07)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/369/a0e5591...martinthomson:dd62f07.html" title="Last updated on Nov 23, 2021, 3:30 PM UTC (dd62f07)">Diff</a>