### PR TITLE
Elaborate requirements on custom certificate hashes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1794,7 +1794,7 @@ Normally, a user agent authenticates a TLS connection between itself and a
 remote endpoint by verifying the validity of the TLS server certificate
 provided against the server name in the URL.  This is accomplished by chaining
 server certificates to one of the trust anchors maintained by the browser; the
-trust anchors in question are responisble for authenticating the server names
+trust anchors in question are responsible for authenticating the server names
 in the certificates.  We will refer to this system as Web PKI.
 
 This API provides web applications with a capability to connect to a remote
@@ -1821,19 +1821,25 @@ certificate used is ephemeral, such a mechanism is not necessary.  In other
 cases, the Web application has to consider the mechanism by which the
 certificate hashes are provisioned; for instance, if the hash is provided as a
 cached HTTP resource, the cache needs to be invalidated if the corresponding
-certificate has been rotated due to compromise.
+certificate has been rotated due to compromise.  Another security feature
+provided by the Web PKI are safeguards against certain issues with key
+generation, such as rejecting certificates with well-known weak keys; while
+this specification does not provide any specific guidance, browsers MAY reject
+those as a part of implementation-defined behavior.
 
 Web PKI enforces an expiry period requirement on the certificates.  This
 requirement limits the scope of potential key compromise; it also forces server
 operators to design systems that support and actively perform key rotation.
 For this reason, WebTransport imposes a similar expiry requirement; as the
 certificates are expected to be ephemeral or short-lived, the expiry period is
-limited to two weeks.
+limited to two weeks.  The two weeks limit is a balance between setting the
+expiry limit as low as possible to minimize consequences of a key compromise,
+and maintaining it sufficiently high to lower the operational costs of
+provisioning certificates.
 
-The WebTransport API
-lets the application specify multiple certificate hashes at once, allowing
-the client to accept multiple certificates for a period in which a new
-certificate is being rolled out.
+The WebTransport API lets the application specify multiple certificate
+hashes at once, allowing the client to accept multiple certificates for a
+period in which a new certificate is being rolled out.
 
 Unlike a similar mechanism in WebRTC, the server certificate hash API in
 WebTransport does not provide any means of authenticating the client; the fact

--- a/index.bs
+++ b/index.bs
@@ -1101,7 +1101,7 @@ period MUST NOT exceed two weeks.  The user agent MAY impose additional
 
 The exact list of <dfn>allowed public key algorithms</dfn> used in the Subject
 Public Key Info field (and, as a consequence, in the TLS CertificateVerify
-message) is [=implementation-defined=]; however, it SHOULD include ECDSA with
+message) is [=implementation-defined=]; however, it MUST include ECDSA with the
 secp256r1 (NIST P-256) named group ([[!RFC3279]], Section 2.3.5; [[!RFC8422]])
 to provide an interoperable default.  It MUST NOT contain RSA keys
 ([[!RFC3279]], Section 2.3.1).
@@ -1828,15 +1828,15 @@ requirement limits the scope of potential key compromise; it also forces server
 operators to design systems that support and actively perform key rotation.
 For this reason, WebTransport imposes a similar expiry requirement; as the
 certificates are expected to be ephemeral or short-lived, the expiry period is
-limited to two weeks.  This also improves the cryptographic agility of the
-system, as the keys in the Subject Public Key Info field can be upgraded to a
-different algorithm as a part of the key rotation process.  WebTransport API
+limited to two weeks.
+
+The WebTransport API
 lets the application to specify multiple certificate hashes at once, allowing
-the client to accept multiple certificates for a perioid in which a new
+the client to accept multiple certificates for a period in which a new
 certificate is being rolled out.
 
 Unlike a similar mechanism in WebRTC, the server certificate hash API in
-WebTransport does not provide any form of authenticating the client; the fact
+WebTransport does not provide any means of authenticating the client; the fact
 that the client knows what the server certificate is or how to contact it is
 not sufficient.  The application has to establish the identity of the client
 in-band if necessary.

--- a/index.bs
+++ b/index.bs
@@ -1817,7 +1817,7 @@ algorithm-hash pairs to be specified.
 It is important to note that Web PKI provides additional security
 mechanisms in addition to simply establishing a chain of trust for a server
 name.  One of them is handling certificate revocation.  In cases where the
-certificate used is ephemeral, such mechanism is not necessary.  In other
+certificate used is ephemeral, such a mechanism is not necessary.  In other
 cases, the Web application has to consider the mechanism by which the
 certificate hashes are provisioned; for instance, if the hash is provided as a
 cached HTTP resource, the cache needs to be invalidated if the corresponding
@@ -1831,7 +1831,7 @@ certificates are expected to be ephemeral or short-lived, the expiry period is
 limited to two weeks.
 
 The WebTransport API
-lets the application to specify multiple certificate hashes at once, allowing
+lets the application specify multiple certificate hashes at once, allowing
 the client to accept multiple certificates for a period in which a new
 certificate is being rolled out.
 

--- a/index.bs
+++ b/index.bs
@@ -1795,14 +1795,14 @@ between itself and a remote endpoint by verifying the validity of the TLS
 server certificate provided against the server name in the URL; this approach
 will be further referred to as Web PKI.  The full details of how the Web PKI
 functions are implementation-defined, and go far beyond the scope of this
-docuement; in practice, those tend to be fairly complex, and involve
+document; in practice, those tend to be fairly complex, and involve
 procedures for maintaining roots of trust, handling revocations of previously
 issued certificates, as well as defending against key compromise, certificate
 mis-issuance, and numerous other security risks.
 
 This API provides web applications with a capability to connect to a remote
 network endpoint authenticated by the hash of its server certificate, rather
-than its server name.  This enables connections to the endpoints that are not
+than its server name.  This enables connections to endpoints that are not
 capable of getting long-term certificates, including hosts that are ephemeral
 in nature (e.g. short-lived virtual machines), or that are not publicly
 routable.  Since this mechanism substitutes Web PKI-based authentication for an

--- a/index.bs
+++ b/index.bs
@@ -1823,7 +1823,7 @@ certificate hashes are provisioned; for instance, if the hash is provided as a
 cached HTTP resource, the cache needs to be invalidated if the corresponding
 certificate has been rotated due to compromise.  Another security feature
 provided by the Web PKI are safeguards against certain issues with key
-generation, such as rejecting certificates with well-known weak keys; while
+generation, such as rejecting certificates with known weak keys; while
 this specification does not provide any specific guidance, browsers MAY reject
 those as a part of implementation-defined behavior.
 

--- a/index.bs
+++ b/index.bs
@@ -1790,21 +1790,21 @@ willing to accept connections from the Web.
 
 ## Authentication using Certificate Hashes {#certificate-hashes}
 
-In the vast majority of cases, a user agent authenticates a TLS connection
-between itself and a remote endpoint by verifying the validity of the TLS
-server certificate provided against the server name in the URL.  This is
-accomplished by chaining server certificates to one of the trust anchors
-maintained by the browser; the trust anchors in question are responisble for
-authenticating the server names in the certificates.  We will refer to this
-system as Web PKI.
+Normally, a user agent authenticates a TLS connection between itself and a
+remote endpoint by verifying the validity of the TLS server certificate
+provided against the server name in the URL.  This is accomplished by chaining
+server certificates to one of the trust anchors maintained by the browser; the
+trust anchors in question are responisble for authenticating the server names
+in the certificates.  We will refer to this system as Web PKI.
 
 This API provides web applications with a capability to connect to a remote
 network endpoint authenticated by a specific server certificate, rather than
-its server name.  This mechanism enables connections to endpoints that are not
-capable of getting long-term certificates, including hosts that are ephemeral
-in nature (e.g. short-lived virtual machines), or that are not publicly
-routable.  Since this mechanism substitutes Web PKI-based authentication for an
-individual connection, we need to compare the security properties of both.
+its server name.  This mechanism enables connections to endpoints for which
+getting long-term certificates can be challenging, including hosts that are
+ephemeral in nature (e.g. short-lived virtual machines), or that are not
+publicly routable.  Since this mechanism substitutes Web PKI-based
+authentication for an individual connection, we need to compare the security
+properties of both.
 
 A remote server will be able to successfully perform a TLS handshake only if it
 posesses the private key corresponding to the public key of the certificate

--- a/index.bs
+++ b/index.bs
@@ -1792,10 +1792,10 @@ willing to accept connections from the Web.
 
 Normally, a user agent authenticates a TLS connection between itself and a
 remote endpoint by verifying the validity of the TLS server certificate
-provided against the server name in the URL.  This is accomplished by chaining
-server certificates to one of the trust anchors maintained by the user agent; the
-trust anchors in question are responsible for authenticating the server names
-in the certificates.  We will refer to this system as Web PKI.
+provided against the server name in the URL [[!RFC6125]].  This is accomplished
+by chaining server certificates to one of the trust anchors maintained by the
+user agent; the trust anchors in question are responsible for authenticating
+the server names in the certificates.  We will refer to this system as Web PKI.
 
 This API provides web applications with a capability to connect to a remote
 network endpoint authenticated by a specific server certificate, rather than
@@ -1834,8 +1834,9 @@ For this reason, WebTransport imposes a similar expiry requirement; as the
 certificates are expected to be ephemeral or short-lived, the expiry period is
 limited to two weeks.  The two weeks limit is a balance between setting the
 expiry limit as low as possible to minimize consequences of a key compromise,
-and maintaining it sufficiently high to lower the operational costs of
-provisioning certificates.
+and maintaining it sufficiently high to accomodate for clock skew across
+devices, and to lower the costs of synchronizing certificates between the
+client and the server side.
 
 The WebTransport API lets the application specify multiple certificate
 hashes at once, allowing the client to accept multiple certificates for a

--- a/index.bs
+++ b/index.bs
@@ -1793,7 +1793,7 @@ willing to accept connections from the Web.
 Normally, a user agent authenticates a TLS connection between itself and a
 remote endpoint by verifying the validity of the TLS server certificate
 provided against the server name in the URL.  This is accomplished by chaining
-server certificates to one of the trust anchors maintained by the browser; the
+server certificates to one of the trust anchors maintained by the user agent; the
 trust anchors in question are responsible for authenticating the server names
 in the certificates.  We will refer to this system as Web PKI.
 

--- a/index.bs
+++ b/index.bs
@@ -1092,15 +1092,19 @@ To <dfn>verify a certificate hash</dfn>, do the following:
 </div>
 
 The <dfn>custom certificate requirements</dfn> are as follows: the certificate
-MUST be an X.509v3 certificate as defined in [[!RFC5280]], the current time
-MUST be within the validity period of the certificate as defined in Section
-4.1.2.5 of [[!RFC5280]] and the total length of the validity period MUST NOT
-exceed two weeks.
+MUST be an X.509v3 certificate as defined in [[!RFC5280]], the key used in the
+Subject Public Key field MUST be one of the [=allowed public key algorithms=],
+the current time MUST be within the validity period of the certificate as
+defined in Section 4.1.2.5 of [[!RFC5280]] and the total length of the validity
+period MUST NOT exceed two weeks.  The user agent MAY impose additional
+[=implementation-defined=] requirements on the certificate.
 
-Issue: Reconsider the time period above.  We want it to be sufficiently large
-that applications using this for ephemeral certificates can do so without
-having to fight the clock skew, but small enough to discourage long-term use
-without key rotation.
+The exact list of <dfn>allowed public key algorithms</dfn> used in the Subject
+Public Key Info field (and, as a consequence, in the TLS CertificateVerify
+message) is [=implementation-defined=]; however, it SHOULD include ECDSA with
+secp256r1 (NIST P-256) named group ([[!RFC3279]], Section 2.3.5; [[!RFC8422]])
+to provide an interoperable default.  It MUST NOT contain RSA keys
+([[!RFC3279]], Section 2.3.1).
 
 ## `WebTransportCloseInfo` Dictionary ##  {#web-transport-close-info}
 
@@ -1783,6 +1787,57 @@ to this problem: the specific connection error is not returned until an
 endpoint is verified to be a WebTransport endpoint; thus, the Web application
 cannot distinguish between a non-existing endpoint and the endpoint that is not
 willing to accept connections from the Web.
+
+## Authentication using Certificate Hashes {#certificate-hashes}
+
+In the vast majority of cases, a user agent authenticates a TLS connection
+between itself and a remote endpoint by verifying the validity of the TLS
+server certificate provided against the server name in the URL; this approach
+will be further referred to as Web PKI.  The full details of how the Web PKI
+functions are implementation-defined, and go far beyond the scope of this
+docuement; in practice, those tend to be fairly complex, and involve
+procedures for maintaining roots of trust, handling revocations of previously
+issued certificates, as well as defending against key compromise, certificate
+mis-issuance, and numerous other security risks.
+
+This API provides web applications with a capability to connect to a remote
+network endpoint authenticated by the hash of its server certificate, rather
+than its server name.  This enables connections to the endpoints that are not
+capable of getting long-term certificates, including hosts that are ephemeral
+in nature (e.g. short-lived virtual machines), or that are not publicly
+routable.  Since this mechanism substitutes Web PKI-based authentication for an
+individual connection, we need to compare the security properties of both.
+
+Validating against a specific hash has certain desirable security properties
+that Web PKI normally does not provide.  For instance, the hashes used for
+verification are scoped to the context of a single connection, which can limit
+the consequences of any individual certificate being compromised.  In addition,
+hash-based verification has a single unambiguous root of trust (the hash
+provided by the Web application), while the Web PKI allows names to be
+authenticated by multiple certificate authorities;  the latter fact arises from
+a variety of operational and ecosystem concerns that are not usually
+relevant for the use cases where hash-based verification is used.
+
+It is, however, important to note that Web PKI provides additional security
+mechanisms in addition to simply establishing a chain of trust for a server
+name.  One of them is handling certificate revocation.  In cases where the
+certificate used is ephemeral, such mechanism is not necessary.  In other
+cases, the Web application has to consider the mechanism by which the
+certificate hashes are provisioned; for instance, if the hash is provided as a
+cached HTTP resource, the cache needs to be invalidated if the corresponding
+certificate has been rotated due to compromise.
+
+Web PKI enforces an expiry period requirement on the certificates.  This
+requirement limits the scope of potential key compromise; it also forces server
+operators to design systems that support and actively perform key rotation.
+For this reason, WebTransport imposes a similar expiry requirement; as the
+certificates are expected to be ephemeral or short-lived, the expiry period is
+limited to two weeks.  This also improves the cryptographic agility of the
+system, as the keys in the Subject Public Key Info field can be upgraded to a
+different algorithm as a part of the key rotation process.  WebTransport API
+lets the application to specify multiple certificate hashes at once, allowing
+the client to accept multiple certificates for a perioid in which a new
+certificate is being rolled out.
 
 # Examples #  {#examples}
 

--- a/index.bs
+++ b/index.bs
@@ -1792,33 +1792,29 @@ willing to accept connections from the Web.
 
 In the vast majority of cases, a user agent authenticates a TLS connection
 between itself and a remote endpoint by verifying the validity of the TLS
-server certificate provided against the server name in the URL; this approach
-will be further referred to as Web PKI.  The full details of how the Web PKI
-functions are implementation-defined, and go far beyond the scope of this
-document; in practice, those tend to be fairly complex, and involve
-procedures for maintaining roots of trust, handling revocations of previously
-issued certificates, as well as defending against key compromise, certificate
-mis-issuance, and numerous other security risks.
+server certificate provided against the server name in the URL.  This is
+accomplished by chaining server certificates to one of the trust anchors
+maintained by the browser; the trust anchors in question are responisble for
+authenticating the server names in the certificates.  We will refer to this
+system as Web PKI.
 
 This API provides web applications with a capability to connect to a remote
-network endpoint authenticated by the hash of its server certificate, rather
-than its server name.  This enables connections to endpoints that are not
+network endpoint authenticated by a specific server certificate, rather than
+its server name.  This mechanism enables connections to endpoints that are not
 capable of getting long-term certificates, including hosts that are ephemeral
 in nature (e.g. short-lived virtual machines), or that are not publicly
 routable.  Since this mechanism substitutes Web PKI-based authentication for an
 individual connection, we need to compare the security properties of both.
 
-Validating against a specific hash has certain desirable security properties
-that Web PKI normally does not provide.  For instance, the hashes used for
-verification are scoped to the context of a single connection, which can limit
-the consequences of any individual certificate being compromised.  In addition,
-hash-based verification has a single unambiguous root of trust (the hash
-provided by the Web application), while the Web PKI allows names to be
-authenticated by multiple certificate authorities;  the latter fact arises from
-a variety of operational and ecosystem concerns that are not usually
-relevant for the use cases where hash-based verification is used.
+A remote server will be able to successfully perform a TLS handshake only if it
+posesses the private key corresponding to the public key of the certificate
+specified.  The API identifies the certificates using their hashes.  That is
+only secure as long as the cryptographic hash function used has second-preimage
+resistance.  The only function defined in this document is SHA-256; the API
+provides a way to introduce new hash functions through allowing multiple
+algorithm-hash pairs to be specified.
 
-It is, however, important to note that Web PKI provides additional security
+It is important to note that Web PKI provides additional security
 mechanisms in addition to simply establishing a chain of trust for a server
 name.  One of them is handling certificate revocation.  In cases where the
 certificate used is ephemeral, such mechanism is not necessary.  In other
@@ -1838,6 +1834,12 @@ different algorithm as a part of the key rotation process.  WebTransport API
 lets the application to specify multiple certificate hashes at once, allowing
 the client to accept multiple certificates for a perioid in which a new
 certificate is being rolled out.
+
+Unlike a similar mechanism in WebRTC, the server certificate hash API in
+WebTransport does not provide any form of authenticating the client; the fact
+that the client knows what the server certificate is or how to contact it is
+not sufficient.  The application has to establish the identity of the client
+in-band if necessary.
 
 # Examples #  {#examples}
 


### PR DESCRIPTION
This adds extra requirements on custom certificates used by
WebTransportHash API, as well as adds a discussion concerning the
security properties of those into Security Considerations section.

Fixes #349.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vasilvv/web-transport/pull/375.html" title="Last updated on Dec 9, 2021, 10:50 PM UTC (e35741a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/375/5b0a9ec...vasilvv:e35741a.html" title="Last updated on Dec 9, 2021, 10:50 PM UTC (e35741a)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vasilvv/web-transport/pull/375.html" title="Last updated on Feb 4, 2022, 6:14 PM UTC (5d6b3d2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/375/5b0a9ec...vasilvv:5d6b3d2.html" title="Last updated on Feb 4, 2022, 6:14 PM UTC (5d6b3d2)">Diff</a>