### PR TITLE
Use AbortSignal's abort reason to abort SendStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1237,7 +1237,7 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
    [=WritableStream/set up/abortAlgorithm=] set to |abortAlgorithm|.
 1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
   1. If |stream|'s [=[[PendingOperation]]=] is null, then abort these steps.
-  1. Let |reason| be |stream|'s \[[controller]]'s \[[signal]]'s \[[reason]].
+  1. Let |reason| be |stream|'s \[[controller]]'s \[[signal]]'s [=AbortSignal/abort reason=].
   1. Let |abortPromise| be the result of [=aborting=] stream with |reason|.
   1. [=Upon fulfillment=] of |abortPromise|, [=reject=] |promise| with |reason|.
   1. Let |pendingOperation| be |stream|'s [=[[PendingOperation]]=].

--- a/index.bs
+++ b/index.bs
@@ -1237,7 +1237,7 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
    [=WritableStream/set up/abortAlgorithm=] set to |abortAlgorithm|.
 1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
   1. If |stream|'s [=[[PendingOperation]]=] is null, then abort these steps.
-  1. Let |reason| be |stream|'s \[[controller]]'s \[[abortReason]].
+  1. Let |reason| be |stream|'s \[[controller]]'s \[[signal]]'s \[[reason]].
   1. Let |abortPromise| be the result of [=aborting=] stream with |reason|.
   1. [=Upon fulfillment=] of |abortPromise|, [=reject=] |promise| with |reason|.
   1. Let |pendingOperation| be |stream|'s [=[[PendingOperation]]=].


### PR DESCRIPTION
Update spec as `WritableStreamDefaultController.abortReason` was removed in https://github.com/whatwg/streams/pull/1177, and AbortSignal now has an "abort reason" property (i.e. `signal.reason` based on https://github.com/whatwg/dom/pull/1027) that can be used instead for aborting a SendStream.

@yutakahirano Is it okay if you could take a look?


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/377.html" title="Last updated on Dec 2, 2021, 6:05 AM UTC (1378bfe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/377/b68a616...nidhijaju:1378bfe.html" title="Last updated on Dec 2, 2021, 6:05 AM UTC (1378bfe)">Diff</a>