### PR TITLE
Block ports on fetch's bad ports list & use WebTransportError for it and CSP.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -715,7 +715,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    and [=request/origin=] is |origin|.
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns
-   <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
+   <b>"Blocked"</b>, or |request| [=block bad port|should be blocked due to a bad port=]
+   returns <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
    to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
   1. Let |error| be a {{SecurityError}}.

--- a/index.bs
+++ b/index.bs
@@ -715,7 +715,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    and [=request/origin=] is |origin|.
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns
-   <b>"Blocked"</b>, or |request| [=block bad port|should be blocked due to a bad port=]
+   <b>"Blocked"</b>, or if |request| [=block bad port|should be blocked due to a bad port=]
    returns <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
    to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -719,7 +719,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    returns <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
    to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be a {{SecurityError}}.
+  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
+     `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
    |transport|'s [=relevant settings object=].


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/229.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/378.html" title="Last updated on Dec 7, 2021, 4:44 PM UTC (1bdb11e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/378/3ddc1a8...jan-ivar:1bdb11e.html" title="Last updated on Dec 7, 2021, 4:44 PM UTC (1bdb11e)">Diff</a>