### PR TITLE
Make code and reason WebTransportCloseInfo non-optional

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -847,16 +847,12 @@ these steps.
        1. [=Cleanup=] |transport| with |error|, |error| and true.
        1. Abort these steps.
      1. Let |session| be |transport|'s [=[[Session]]=].
+     1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
      1. Let |reason| be an empty [=byte sequence=].
-     1. If |closeInfo|.{{WebTransportCloseInfo/reason}} exists, set |reason| be
-        |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
+     1. Set |reason| to |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
      1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
         [=byte sequence/prefix=] of |reason| whose length is 1024.
-     1. If |closeInfo|.{{WebTransportCloseInfo/closeCode}} exists:
-       1. [=In parallel=], [=session/terminate=] |session| with
-          |closeInfo|.{{WebTransportCloseInfo/closeCode}} and |reason|.
-     1. Otherwise:
-       1. [=In parallel=], [=session/terminate=] |session|.
+     1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.
 
        Note: This also [=resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in
        |transport|'s [=[[SendStreams]]=] and [=[[ReceiveStreams]]=].
@@ -1111,8 +1107,8 @@ frame.
 
 <pre class="idl">
 dictionary WebTransportCloseInfo {
-  unsigned long closeCode;
-  DOMString reason;
+  unsigned long closeCode = 0;
+  DOMString reason = "";
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -848,7 +848,7 @@ these steps.
        1. Abort these steps.
      1. Let |session| be |transport|'s [=[[Session]]=].
      1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
-     1. Set |reason| to |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
+     1. Let |reason| be |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
      1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
         [=byte sequence/prefix=] of |reason| whose length is 1024.
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.

--- a/index.bs
+++ b/index.bs
@@ -848,7 +848,6 @@ these steps.
        1. Abort these steps.
      1. Let |session| be |transport|'s [=[[Session]]=].
      1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
-     1. Let |reason| be an empty [=byte sequence=].
      1. Set |reason| to |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
      1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
         [=byte sequence/prefix=] of |reason| whose length is 1024.


### PR DESCRIPTION
Fixes #366.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/379.html" title="Last updated on Dec 8, 2021, 12:15 AM UTC (4dd63c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/379/3ddc1a8...4dd63c7.html" title="Last updated on Dec 8, 2021, 12:15 AM UTC (4dd63c7)">Diff</a>