### PR TITLE
Add wt.reliability attr and {requireUnreliable} constructor option.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -599,7 +599,7 @@ A {{WebTransport}} object has the following internal slots.
    failed.
   </tr>
   <tr>
-   <td><dfn>\`[[Reliability]]`</dfn>
+   <td><dfn>`[[Reliability]]`</dfn>
    <td class="non-normative">A {{WebTransportReliabilityMode}} indicating whether
    unreliable (UDP) transport is supported or whether only reliable (TCP fallback)
    transport is used. Returns `"pending"` until a connection has been established.

--- a/index.bs
+++ b/index.bs
@@ -2006,7 +2006,7 @@ connect.onclick = async () => {
     wt = new WebTransport(url);
     addToEventLog('Initiating connection...');
     await wt.ready;
-    addToEventLog(\`HTTP/${(wt.reliability == "reliable-only")? 2 : 3} connection ready.\`);
+    addToEventLog(\`${(wt.reliability == "reliable-only")? "TCP" : "UDP"} connection ready.\`);
     wt.closed
       .then(() => addToEventLog('Connection closed normally.'))
       .catch(() => addToEventLog('Connection closed abruptly.', 'error'));

--- a/index.bs
+++ b/index.bs
@@ -670,9 +670,8 @@ agent MUST run the following steps:
    {{WebTransportOptions/serverCertificateHashes}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateHashes| is non-null, then [=throw=] a
    {{TypeError}}.
-1. Let |disallowFallback| be {{WebTransport/constructor(url, options)/options}}'s
-   {{WebTransportOptions/disallowFallback}} if it exists, and false otherwise.
-1. Let |fallback| be the negation of |disallowFallback|.
+1. Let |requireUnreliable| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/requireUnreliable}}.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
@@ -715,14 +714,14 @@ agent MUST run the following steps:
 1. [=ReadableStream/Set up=] |transport|'s [=[[IncomingUnidirectionalStreams]]=] with
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
-1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated| and |fallback|.
+1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated|, and |requireUnreliable|.
 1. Return |transport|.
 
 </div>
 
 <div algorithm>
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
-<var>transport</var>, a [=URL record=] |url|, a boolean |dedicated| and a boolean |fallback|, run these steps.
+<var>transport</var>, a [=URL record=] |url|, a boolean |dedicated|, and a boolean |http3Only|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
 1. Let |origin| be |client|'s [=environment settings object/origin=].
@@ -745,8 +744,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    [=[[State]]=] becomes `"closed"` or `"failed"`.
 1. Let |newConnection| be "`no`" if |dedicated| is false; otherwise "`yes-and-dedicated`".
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
-   |networkPartitionKey|, |url|, false, |newConnection|, and with [=obtain a connection/http3Only=]
-   set to the negation of |fallback|.
+   |networkPartitionKey|, |url|, false, |newConnection|, and |http3Only|.
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
@@ -1067,7 +1065,7 @@ dictionary WebTransportHash {
 
 dictionary WebTransportOptions {
   boolean allowPooling;
-  boolean disallowFallback;
+  boolean requireUnreliable = false;
   sequence&lt;WebTransportHash&gt; serverCertificateHashes;
 };
 </pre>
@@ -1079,7 +1077,7 @@ that determine how WebTransport connection is established and used.
 :: When set to true, the WebTransport connection can be pooled, that is, the network connection for
    the WebTransport session can be shared with other HTTP/3 sessions.
 
-: <dfn for="WebTransportOptions" dict-member>disallowFallback</dfn>
+: <dfn for="WebTransportOptions" dict-member>requireUnreliable</dfn>
 :: When set to true, the WebTransport connection cannot be established over HTTP/2 if
    an HTTP/3 connection is not possible.
 

--- a/index.bs
+++ b/index.bs
@@ -670,6 +670,9 @@ agent MUST run the following steps:
    {{WebTransportOptions/serverCertificateHashes}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateHashes| is non-null, then [=throw=] a
    {{TypeError}}.
+1. Let |disallowFallback| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/disallowFallback}} if it exists, and false otherwise.
+1. Let |fallback| be the negation of |disallowFallback|.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
 1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
@@ -712,14 +715,14 @@ agent MUST run the following steps:
 1. [=ReadableStream/Set up=] |transport|'s [=[[IncomingUnidirectionalStreams]]=] with
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
-1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL| and |dedicated|.
+1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated| and |fallback|.
 1. Return |transport|.
 
 </div>
 
 <div algorithm>
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
-<var>transport</var>, a [=URL record=] |url|, and a boolean |dedicated|, run these steps.
+<var>transport</var>, a [=URL record=] |url|, a boolean |dedicated| and a boolean |fallback|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
 1. Let |origin| be |client|'s [=environment settings object/origin=].
@@ -743,7 +746,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. Let |newConnection| be "`no`" if |dedicated| is false; otherwise "`yes-and-dedicated`".
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
    |networkPartitionKey|, |url|, false, |newConnection|, and with [=obtain a connection/http3Only=]
-   set to true.
+   set to the negation of |fallback|.
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
@@ -1064,6 +1067,7 @@ dictionary WebTransportHash {
 
 dictionary WebTransportOptions {
   boolean allowPooling;
+  boolean disallowFallback;
   sequence&lt;WebTransportHash&gt; serverCertificateHashes;
 };
 </pre>
@@ -1074,6 +1078,10 @@ that determine how WebTransport connection is established and used.
 : <dfn for="WebTransportOptions" dict-member>allowPooling</dfn>
 :: When set to true, the WebTransport connection can be pooled, that is, the network connection for
    the WebTransport session can be shared with other HTTP/3 sessions.
+
+: <dfn for="WebTransportOptions" dict-member>disallowFallback</dfn>
+:: When set to true, the WebTransport connection cannot be established over HTTP/2 if
+   an HTTP/3 connection is not possible.
 
 : <dfn for="WebTransportOptions" dict-member>serverCertificateHashes</dfn>
 :: This option is only supported for transports using dedicated connections.

--- a/index.bs
+++ b/index.bs
@@ -302,19 +302,12 @@ A <dfn interface>WebTransportDatagramDuplexStream</dfn> is a generic duplex stre
 interface WebTransportDatagramDuplexStream {
   readonly attribute ReadableStream readable;
   readonly attribute WritableStream writable;
-  readonly attribute WebTransportDatagramMode mode;
 
   readonly attribute unsigned long maxDatagramSize;
   attribute double? incomingMaxAge;
   attribute double? outgoingMaxAge;
   attribute long incomingHighWaterMark;
   attribute long outgoingHighWaterMark;
-};
-
-enum WebTransportDatagramMode {
-  "new",
-  "reliable",
-  "unreliable",
 };
 </pre>
 
@@ -337,12 +330,6 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
   <tr>
    <td><dfn>\[[Writable]]</dfn>
    <td class="non-normative">A {{WritableStream}} for outgoing datagrams.
-  </tr>
-  <tr>
-   <td><dfn>\[[Mode]]</dfn>
-   <td class="non-normative">A {{WebTransportDatagramMode}} indicating whether
-   unreliable (UDP) transport or reliable (TCP fallback) transport is used.
-   Returns `"new"` until a connection has been established.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
@@ -398,8 +385,6 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
     :: |readable|
     : [=[[Writable]]=]
     :: |writable|
-    : [=[[Mode]]=]
-    :: "new"
     : [=[[IncomingDatagramsQueue]]=]
     :: an empty queue
     : [=[[IncomingDatagramsPullPromise]]=]
@@ -439,10 +424,6 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
      1. Let |value| be the given value.
      1. If |value| is null or |value| > 0:
        1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |value|.
-
-: <dfn for="WebTransportDatagramDuplexStream" attribute>mode</dfn>
-:: Whether {{WebTransportDatagramDuplexStream/writable}}.
-   The getter steps are to return [=this=]'s [=[[Datagrams]]=]'s [=[[Mode]]=].
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>maxDatagramSize</dfn>
 :: The maximum size data that may be passed to {{WebTransportDatagramDuplexStream/writable}}.
@@ -587,6 +568,7 @@ interface WebTransport {
 
   Promise&lt;WebTransportStats&gt; getStats();
   readonly attribute Promise&lt;undefined&gt; ready;
+  readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
   undefined close(optional WebTransportCloseInfo closeInfo = {});
 
@@ -601,6 +583,11 @@ interface WebTransport {
   readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
 
+enum WebTransportReliabilityMode {
+  "new",
+  "reliable",
+  "unreliable",
+};
 </pre>
 
 ## Internal slots ## {#webtransport-internal-slots}
@@ -643,6 +630,12 @@ A {{WebTransport}} object has the following internal slots.
    <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
    gets [=session/established=], or rejected if the [=session/establish|establishment process=]
    failed.
+  </tr>
+  <tr>
+   <td><dfn>\[[Reliability]]</dfn>
+   <td class="non-normative">A {{WebTransportReliabilityMode}} indicating whether
+   unreliable (UDP) transport or reliable (TCP fallback) transport is used.
+   Returns `"new"` until a connection has been established.
   </tr>
   <tr>
    <td><dfn>\[[Closed]]</dfn>
@@ -695,6 +688,8 @@ agent MUST run the following steps:
     :: `"connecting"`
     : [=[[Ready]]=]
     :: a new promise
+    : [=[[Reliability]]=]
+    :: "new"
     : [=[[Closed]]=]
     :: a new promise
     : [=[[Datagrams]]=]
@@ -782,7 +777,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
     1. Abort these steps.
   1. Set |transport|'s [=[[State]]=] to `"connected"`.
   1. Set |transport|'s [=[[Session]]=] to |session|.
-  1. Set |transport|'s [=[[Datagrams]]=]'s [=[[Mode]]=] to `"unreliable"`.
+  1. Set |transport|'s [=[[Reliability]]=] to `"unreliable"`.
   1. [=Resolve=] |transport|'s [=[[Ready]]=] with undefined.
 
 </div>
@@ -852,6 +847,12 @@ these steps.
    {{ReceiveStream}}, that have been received from the server.
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Return [=this=]'s [=[[IncomingUnidirectionalStreams]]=].
+
+: <dfn for="WebTransport" attribute>reliability</dfn>
+:: Whether connection is unreliable (over UDP) or reliable (over TCP fallback).
+   Returns `"new"` until a connection has been established.
+   The getter steps are to return [=this=]'s [=[[Reliability]]=].
+
 
 ## Methods ##  {#webtransport-methods}
 
@@ -1958,7 +1959,7 @@ connect.onclick = async () => {
     wt = new WebTransport(url);
     addToEventLog('Initiating connection...');
     await wt.ready;
-    addToEventLog(\`HTTP/${(wt.datagrams.mode == "reliable")? 2 : 3} connection ready.\`);
+    addToEventLog(\`HTTP/${(wt.reliability == "reliable")? 2 : 3} connection ready.\`);
     wt.closed
       .then(() => addToEventLog('Connection closed normally.'))
       .catch(() => addToEventLog('Connection closed abruptly.', 'error'));

--- a/index.bs
+++ b/index.bs
@@ -819,7 +819,7 @@ these steps.
 :: Whether connection supports unreliable (over UDP) transport or only reliable
    (over TCP fallback) transport.
    Returns `"pending"` until a connection has been established.
-   The getter steps are to return [=this=]'s [=[[Reliability]]=].
+   The getter steps are to return [=this=]'s {{[[Reliability]]}}.
 
 
 ## Methods ##  {#webtransport-methods}

--- a/index.bs
+++ b/index.bs
@@ -585,8 +585,8 @@ interface WebTransport {
 
 enum WebTransportReliabilityMode {
   "pending",
-  "reliable",
-  "unreliable",
+  "reliable-only",
+  "supports-unreliable",
 };
 </pre>
 
@@ -634,8 +634,8 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>\[[Reliability]]</dfn>
    <td class="non-normative">A {{WebTransportReliabilityMode}} indicating whether
-   unreliable (UDP) transport or reliable (TCP fallback) transport is used.
-   Returns `"new"` until a connection has been established.
+   unreliable (UDP) transport is supported or whether only reliable (TCP fallback)
+   transport is used. Returns `"pending"` until a connection has been established.
   </tr>
   <tr>
    <td><dfn>\[[Closed]]</dfn>
@@ -778,7 +778,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
     1. Abort these steps.
   1. Set |transport|'s [=[[State]]=] to `"connected"`.
   1. Set |transport|'s [=[[Session]]=] to |session|.
-  1. Set |transport|'s [=[[Reliability]]=] to `"unreliable"`.
+  1. Set |transport|'s [=[[Reliability]]=] to `"supports-unreliable"`.
   1. [=Resolve=] |transport|'s [=[[Ready]]=] with undefined.
 
 </div>
@@ -850,8 +850,9 @@ these steps.
      1. Return [=this=]'s [=[[IncomingUnidirectionalStreams]]=].
 
 : <dfn for="WebTransport" attribute>reliability</dfn>
-:: Whether connection is unreliable (over UDP) or reliable (over TCP fallback).
-   Returns `"new"` until a connection has been established.
+:: Whether connection supports unreliable (over UDP) transport or only reliable
+   (over TCP fallback) transport.
+   Returns `"pending"` until a connection has been established.
    The getter steps are to return [=this=]'s [=[[Reliability]]=].
 
 
@@ -1965,7 +1966,7 @@ connect.onclick = async () => {
     wt = new WebTransport(url);
     addToEventLog('Initiating connection...');
     await wt.ready;
-    addToEventLog(\`HTTP/${(wt.reliability == "reliable")? 2 : 3} connection ready.\`);
+    addToEventLog(\`HTTP/${(wt.reliability == "reliable-only")? 2 : 3} connection ready.\`);
     wt.closed
       .then(() => addToEventLog('Connection closed normally.'))
       .catch(() => addToEventLog('Connection closed abruptly.', 'error'));

--- a/index.bs
+++ b/index.bs
@@ -2006,7 +2006,8 @@ connect.onclick = async () => {
     wt = new WebTransport(url);
     addToEventLog('Initiating connection...');
     await wt.ready;
-    addToEventLog(\`${(wt.reliability == "reliable-only")? "TCP" : "UDP"} connection ready.\`);
+    addToEventLog(\`${(wt.reliability == "reliable-only")? "TCP" : "UDP"} \` +
+                  \`connection ready.\`);
     wt.closed
       .then(() => addToEventLog('Connection closed normally.'))
       .catch(() => addToEventLog('Connection closed abruptly.', 'error'));

--- a/index.bs
+++ b/index.bs
@@ -1065,7 +1065,7 @@ dictionary WebTransportHash {
 };
 
 dictionary WebTransportOptions {
-  boolean allowPooling;
+  boolean allowPooling = false;
   boolean requireUnreliable = false;
   sequence&lt;WebTransportHash&gt; serverCertificateHashes;
 };

--- a/index.bs
+++ b/index.bs
@@ -302,12 +302,19 @@ A <dfn interface>WebTransportDatagramDuplexStream</dfn> is a generic duplex stre
 interface WebTransportDatagramDuplexStream {
   readonly attribute ReadableStream readable;
   readonly attribute WritableStream writable;
+  readonly attribute WebTransportDatagramMode mode;
 
   readonly attribute unsigned long maxDatagramSize;
   attribute double? incomingMaxAge;
   attribute double? outgoingMaxAge;
   attribute long incomingHighWaterMark;
   attribute long outgoingHighWaterMark;
+};
+
+enum WebTransportDatagramMode {
+  "new",
+  "reliable",
+  "unreliable",
 };
 </pre>
 
@@ -330,6 +337,12 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
   <tr>
    <td><dfn>\[[Writable]]</dfn>
    <td class="non-normative">A {{WritableStream}} for outgoing datagrams.
+  </tr>
+  <tr>
+   <td><dfn>\[[Mode]]</dfn>
+   <td class="non-normative">A {{WebTransportDatagramMode}} indicating whether
+   unreliable (UDP) transport or reliable (TCP fallback) transport is used.
+   Returns `"new"` until a connection has been established.
   </tr>
   <tr>
    <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
@@ -385,6 +398,8 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
     :: |readable|
     : [=[[Writable]]=]
     :: |writable|
+    : [=[[Mode]]=]
+    :: "new"
     : [=[[IncomingDatagramsQueue]]=]
     :: an empty queue
     : [=[[IncomingDatagramsPullPromise]]=]
@@ -424,6 +439,10 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
      1. Let |value| be the given value.
      1. If |value| is null or |value| > 0:
        1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |value|.
+
+: <dfn for="WebTransportDatagramDuplexStream" attribute>mode</dfn>
+:: Whether {{WebTransportDatagramDuplexStream/writable}}.
+   The getter steps are to return [=this=]'s [=[[Datagrams]]=]'s [=[[Mode]]=].
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>maxDatagramSize</dfn>
 :: The maximum size data that may be passed to {{WebTransportDatagramDuplexStream/writable}}.
@@ -763,6 +782,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
     1. Abort these steps.
   1. Set |transport|'s [=[[State]]=] to `"connected"`.
   1. Set |transport|'s [=[[Session]]=] to |session|.
+  1. Set |transport|'s [=[[Datagrams]]=]'s [=[[Mode]]=] to `"unreliable"`.
   1. [=Resolve=] |transport|'s [=[[Ready]]=] with undefined.
 
 </div>
@@ -1938,8 +1958,7 @@ connect.onclick = async () => {
     wt = new WebTransport(url);
     addToEventLog('Initiating connection...');
     await wt.ready;
-    addToEventLog('Connection ready.');
-
+    addToEventLog(\`HTTP/${(wt.datagrams.mode == "reliable")? 2 : 3} connection ready.\`);
     wt.closed
       .then(() => addToEventLog('Connection closed normally.'))
       .catch(() => addToEventLog('Connection closed abruptly.', 'error'));

--- a/index.bs
+++ b/index.bs
@@ -584,7 +584,7 @@ interface WebTransport {
 };
 
 enum WebTransportReliabilityMode {
-  "new",
+  "pending",
   "reliable",
   "unreliable",
 };


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/107.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/385.html" title="Last updated on Mar 31, 2022, 3:48 PM UTC (73518d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/385/e3f77e5...jan-ivar:73518d8.html" title="Last updated on Mar 31, 2022, 3:48 PM UTC (73518d8)">Diff</a>