### PR TITLE
Add smoothedRtt & rttVariation to WebTransportStats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1167,7 +1167,7 @@ The dictionary SHALL have the following attributes:
 :: The number of total packets received on the QUIC connection, including
    packets that were not processable.
 : <dfn for="WebTransportStats" dict-member>smoothedRtt</dfn>
-:: The smoothed round-trip time currently observed on the connection, as defined
+:: The smoothed round-trip time (RTT) currently observed on the connection, as defined
    in [[!RFC9002]] [section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
 : <dfn for="WebTransportStats" dict-member>rttVariation</dfn>
 :: The mean variation in round-trip time samples currently observed on the

--- a/index.bs
+++ b/index.bs
@@ -1172,7 +1172,7 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportStats" dict-member>rttVariation</dfn>
 :: The mean variation in round-trip time samples currently observed on the
    connection, as defined in [[!RFC9002]]
-   [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3)..
+   [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
 : <dfn for="WebTransportStats" dict-member>minRtt</dfn>
 :: The minimum round-trip time observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1172,7 +1172,7 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportStats" dict-member>rttVariation</dfn>
 :: The mean variation in round-trip time samples currently observed on the
    connection, as defined in [[!RFC9002]]
-   [section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3)..
+   [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3)..
 : <dfn for="WebTransportStats" dict-member>minRtt</dfn>
 :: The minimum round-trip time observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1139,6 +1139,8 @@ dictionary WebTransportStats {
   unsigned long numIncomingStreamsCreated;
   unsigned long long bytesReceived;
   unsigned long long packetsReceived;
+  DOMHighResTimeStamp smoothedRtt;
+  DOMHighResTimeStamp rttVariation;
   DOMHighResTimeStamp minRtt;
   unsigned long numReceivedDatagramsDropped;
 };
@@ -1164,8 +1166,15 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportStats" dict-member>packetsReceived</dfn>
 :: The number of total packets received on the QUIC connection, including
    packets that were not processable.
+: <dfn for="WebTransportStats" dict-member>smoothedRtt</dfn>
+:: The smoothed round-trip time currently observed on the connection, as defined
+   in [[!RFC9002]] [section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
+: <dfn for="WebTransportStats" dict-member>rttVariation</dfn>
+:: The mean variation in round-trip time samples currently observed on the
+   connection, as defined in [[!RFC9002]]
+   [section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3)..
 : <dfn for="WebTransportStats" dict-member>minRtt</dfn>
-:: The minimum RTT observed on the entire connection.
+:: The minimum round-trip time observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
    between calls to {{DatagramTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}.

--- a/index.bs
+++ b/index.bs
@@ -1168,7 +1168,7 @@ The dictionary SHALL have the following attributes:
    packets that were not processable.
 : <dfn for="WebTransportStats" dict-member>smoothedRtt</dfn>
 :: The smoothed round-trip time (RTT) currently observed on the connection, as defined
-   in [[!RFC9002]] [section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
+   in [[!RFC9002]] [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
 : <dfn for="WebTransportStats" dict-member>rttVariation</dfn>
 :: The mean variation in round-trip time samples currently observed on the
    connection, as defined in [[!RFC9002]]


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/374.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/386.html" title="Last updated on Feb 2, 2022, 12:34 AM UTC (5577154)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/386/fca64e2...jan-ivar:5577154.html" title="Last updated on Feb 2, 2022, 12:34 AM UTC (5577154)">Diff</a>