### PR TITLE
Add packetsLost to WebTransportStats.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1154,7 +1154,7 @@ The dictionary SHALL have the following attributes:
 :: The number of bytes sent on the QUIC connection, including retransmissions.
    Does not include UDP or any other outer framing.
 : <dfn for="WebTransportStats" dict-member>packetsSent</dfn>
-:: The number of packets sent on the QUIC connection, including loss.
+:: The number of packets sent on the QUIC connection, including those that are determined to have been lost.
 : <dfn for="WebTransportStats" dict-member>packetsLost</dfn>
 :: The number of packets lost on the QUIC connection.
 : <dfn for="WebTransportStats" dict-member>numOutgoingStreamsCreated</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1156,7 +1156,7 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportStats" dict-member>packetsSent</dfn>
 :: The number of packets sent on the QUIC connection, including those that are determined to have been lost.
 : <dfn for="WebTransportStats" dict-member>packetsLost</dfn>
-:: The number of packets lost on the QUIC connection.
+:: The number of packets lost on the QUIC connection (does not monotonically increase).
 : <dfn for="WebTransportStats" dict-member>numOutgoingStreamsCreated</dfn>
 :: The number of outgoing QUIC streams created on the QUIC connection.
 : <dfn for="WebTransportStats" dict-member>numIncomingStreamsCreated</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1156,7 +1156,7 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportStats" dict-member>packetsSent</dfn>
 :: The number of packets sent on the QUIC connection, including those that are determined to have been lost.
 : <dfn for="WebTransportStats" dict-member>packetsLost</dfn>
-:: The number of packets lost on the QUIC connection (does not monotonically increase).
+:: The number of packets lost on the QUIC connection (does not monotonically increase, because packets that are declared lost can subsequently be received).
 : <dfn for="WebTransportStats" dict-member>numOutgoingStreamsCreated</dfn>
 :: The number of outgoing QUIC streams created on the QUIC connection.
 : <dfn for="WebTransportStats" dict-member>numIncomingStreamsCreated</dfn>

--- a/index.bs
+++ b/index.bs
@@ -1135,6 +1135,7 @@ dictionary WebTransportStats {
   DOMHighResTimeStamp timestamp;
   unsigned long long bytesSent;
   unsigned long long packetsSent;
+  unsigned long long packetsLost;
   unsigned long numOutgoingStreamsCreated;
   unsigned long numIncomingStreamsCreated;
   unsigned long long bytesReceived;
@@ -1153,7 +1154,9 @@ The dictionary SHALL have the following attributes:
 :: The number of bytes sent on the QUIC connection, including retransmissions.
    Does not include UDP or any other outer framing.
 : <dfn for="WebTransportStats" dict-member>packetsSent</dfn>
-:: The number of packets sent on the QUIC connection, including retransmissions.
+:: The number of packets sent on the QUIC connection, including loss.
+: <dfn for="WebTransportStats" dict-member>packetsLost</dfn>
+:: The number of packets lost on the QUIC connection.
 : <dfn for="WebTransportStats" dict-member>numOutgoingStreamsCreated</dfn>
 :: The number of outgoing QUIC streams created on the QUIC connection.
 : <dfn for="WebTransportStats" dict-member>numIncomingStreamsCreated</dfn>


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/373.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/387.html" title="Last updated on Feb 15, 2022, 3:19 PM UTC (dfabdc9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/387/fca64e2...jan-ivar:dfabdc9.html" title="Last updated on Feb 15, 2022, 3:19 PM UTC (dfabdc9)">Diff</a>