### PR TITLE
 Improve markup for definitions and automatic links

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -15,3 +15,4 @@ jobs:
           GH_PAGES_BRANCH: gh-pages
           TOOLCHAIN: bikeshed
           VALIDATE_MARKUP: false
+          BUILD_FAIL_ON: link-error

--- a/index.bs
+++ b/index.bs
@@ -37,24 +37,10 @@ Boilerplate: omit conformance
     "status": "Internet-Draft",
     "publisher": "IETF"
   },
-    "http3-datagram": {
-    "authors": ["David Schinazi", "Lucas Pardue"],
-    "href": "https://datatracker.ietf.org/doc/html/draft-ietf-masque-h3-datagram",
-    "title": "Using QUIC Datagrams with HTTP/3",
-    "status": "Internet-Draft",
-    "publisher": "IETF"
-  },
   "web-transport-overview": {
     "authors": ["Victor Vasiliev"],
     "href": "https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview",
     "title": "WebTransport Protocol Framework",
-    "status": "Internet-Draft",
-    "publisher": "IETF"
-  },
-  "web-transport-quic": {
-    "authors": ["Victor Vasiliev"],
-    "href": "https://datatracker.ietf.org/doc/html/draft-vvv-webtransport-quic",
-    "title": "WebTransport over QUIC",
     "status": "Internet-Draft",
     "publisher": "IETF"
   },

--- a/index.bs
+++ b/index.bs
@@ -54,6 +54,7 @@ Boilerplate: omit conformance
 }
 </pre>
 <pre class="link-defaults">
+spec:infra; type:dfn; for:set; text:for each
 spec:infra; type:dfn; for:/; text:set
 spec:streams; type:interface; text:ReadableStream
 spec:fetch; type:dfn; for:/; text:fetch

--- a/index.bs
+++ b/index.bs
@@ -796,7 +796,7 @@ these steps.
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
    {{ReceiveStream}}, that have been received from the server.
    The getter steps for `incomingUnidirectionalStreams` are:
-     1. Return [=this=]'s {{[[IncomingUnidirectionalStreams]]}}.
+     1. Return [=this=].{{[[IncomingUnidirectionalStreams]]}}.
 
 ## Methods ##  {#webtransport-methods}
 

--- a/index.bs
+++ b/index.bs
@@ -68,13 +68,14 @@ Boilerplate: omit conformance
 }
 </pre>
 <pre class="link-defaults">
+spec:infra; type:dfn; for:/; text:set
 spec:streams; type:interface; text:ReadableStream
-spec:html; type:dfn; for:/; text:origin
 spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 </pre>
 <pre class="anchors">
+url: https://html.spec.whatwg.org/multipage/origin.html#concept-origin; type: dfn; text: origin; for:/
 url: https://streams.spec.whatwg.org/#high-water-mark; type: dfn; text: high water mark
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
   type: dfn
@@ -172,11 +173,11 @@ There may be multiple [=WebTransport sessions=] on one [=connection=], when pool
  </tbody>
 </table>
 
-To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=origin=] |origin|,
+To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin|,
 follow [[!WEB-TRANSPORT-HTTP3]]
 [section 3.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.3),
 with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
-as the "Origin" header of the request.
+as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
@@ -689,7 +690,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 1. Let |client| be |transport|'s [=relevant settings object=].
 1. Let |origin| be |client|'s [=environment settings object/origin=].
-1. Let |request| be a new [=request=] whose [=request/URL=] is |url|, [=request/client=] is
+1. Let |request| be a new [=/request=] whose [=request/URL=] is |url|, [=request/client=] is
    |client|, [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
    and [=request/origin=] is |origin|.
@@ -834,7 +835,7 @@ these steps.
         [=byte sequence/prefix=] of |reason| whose length is 1024.
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.
 
-       Note: This also [=resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in
+       Note: This also [=stream/resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in
        |transport|.{{[[SendStreams]]}} and {{[[ReceiveStreams]]}}.
      1. [=Cleanup=] |transport| with |closeInfo|, an {{AbortError}} and false.
 
@@ -927,8 +928,8 @@ To <dfn for="WebTransport">cleanup</dfn> a {{WebTransport}} |transport| with |re
 1. Set |transport|.{{[[ReceiveStreams]]}} to an empty [=set=].
 1. If |abruptly| is true, then set |transport|.{{[[State]]}} to `"failed"`.
 1. Otherwise, set |transport|.{{[[State]]}} to `"closed"`.
-1. [=For each=] |sendStream| in |sendStreams|, [=WritableStream/error=] |sendStream| with |error|.
-1. [=For each=] |receiveStream| in |receiveStreams|, [=ReadableStream/error=] |receiveStream|
+1. [=set/For each=] |sendStream| in |sendStreams|, [=WritableStream/error=] |sendStream| with |error|.
+1. [=set/For each=] |receiveStream| in |receiveStreams|, [=ReadableStream/error=] |receiveStream|
    with |error|.
 
   Note: Script authors can inject code which runs in Promise resolution synchronously. Hence
@@ -1432,7 +1433,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 
 1. [=Queue a network task=] with |transport| to run these steps:
 
-   Note: If the buffer described above is available in the [=event loop=] where this procedure is
+   Note: If the buffer described above is available in the [=agent/event loop=] where this procedure is
    running, the following steps may run immediately.
 
   1. If |read| > 0:
@@ -1467,7 +1468,7 @@ steps.
 1. [=Send STOP_SENDING=] with |internalStream| and |code|.
 1. [=Queue a network task=] with |transport| to run these steps:
 
-  Note: If the buffer described above is available in the [=event loop=] where this procedure is
+  Note: If the buffer described above is available in the [=agent/event loop=] where this procedure is
   running, the following steps may run immediately.
 
   1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.

--- a/index.bs
+++ b/index.bs
@@ -123,26 +123,6 @@ specification MUST implement them in a manner consistent with the ECMAScript
 Bindings defined in the Web IDL specification [[!WEBIDL]], as this
 specification uses that specification and terminology.
 
-# Terminology #  {#terminology}
-
-The {{EventHandler}} interface, representing a callback used for event
-handlers, and the {{ErrorEvent}} interface are defined in [[!HTML]].
-
-The concepts [=queue a task=] and [=networking task source=] are defined in
-[[!HTML]].
-
-The terms [=event=], [=event handlers=] and [=event handler event types=] are
-defined in [[!HTML]].
-
-When referring to exceptions, the terms [=throw=] and [=create=] are defined in
-[[!WEBIDL]].
-
-The terms [=fulfilled=], [=rejected=], [=resolved=], [=pending=] and
-[=settled=] used in the context of Promises are defined in [[!ECMASCRIPT-6.0]].
-
-The terms {{ReadableStream}} and {{WritableStream}} are defined in
-[[!WHATWG-STREAMS]].
-
 # Protocol concepts # {#protocol-concepts}
 
 A <dfn for="protocol">WebTransport session</dfn> is a session of WebTransport over HTTP/3.

--- a/index.bs
+++ b/index.bs
@@ -62,7 +62,6 @@ spec:url; type:dfn; text:fragment
 </pre>
 <pre class="anchors">
 url: https://html.spec.whatwg.org/multipage/origin.html#concept-origin; type: dfn; text: origin; for:/
-url: https://streams.spec.whatwg.org/#high-water-mark; type: dfn; text: high water mark
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
   type: dfn
     text: fulfilled; url: sec-promise-objects

--- a/index.bs
+++ b/index.bs
@@ -315,7 +315,7 @@ interface WebTransportDatagramDuplexStream {
 
 A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
 
-<table class="data" dfn-for="DatagramDuplexStream">
+<table class="data" dfn-for="WebTransportDatagramDuplexStream">
  <thead>
   <tr>
    <th>Internal Slot
@@ -374,10 +374,10 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
 The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport}} object whose
 [=[[State]]=] is either `"connecting"` or `"connected"`.
 
- To <dfn export for="DatagramDuplexStream" lt="create|creating">create</dfn> a
+ To <dfn export for="WebTransportDatagramDuplexStream" lt="create|creating">create</dfn> a
  {{WebTransportDatagramDuplexStream}} given a
- <dfn export for="DatagramDuplexStream/create"><var>readable</var></dfn>, and
- a <dfn export for="DatagramDuplexStream/create"><var>writable</var></dfn>,
+ <dfn export for="WebTransportDatagramDuplexStream/create"><var>readable</var></dfn>, and
+ a <dfn export for="WebTransportDatagramDuplexStream/create"><var>writable</var></dfn>,
  perform the following steps.
 
  1. Let |stream| be a [=new=] {{WebTransportDatagramDuplexStream}}, with:
@@ -465,7 +465,7 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
 1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
 1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
-   [=DatagramDuplexStream/[[Readable]]=].
+   [=WebTransportDatagramDuplexStream/[[Readable]]=].
 1. Return [=a promise resolved with=] undefined.
 
 To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
@@ -492,7 +492,7 @@ To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run
   1. Set |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] to null.
   1. [=Queue a network task=] with |transport| to run the following steps:
     1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-    1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|'s [=DatagramDuplexStream/[[Readable]]=].
+    1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|'s [=WebTransportDatagramDuplexStream/[[Readable]]=].
     1. [=Resolve=] |promise| with undefined.
 
 The user agent SHOULD run [=receiveDatagrams=] for any {{WebTransport}} object whose
@@ -660,9 +660,9 @@ agent MUST run the following steps:
    {{TypeError}}.
 1. Let |incomingDatagrams| be a [=new=] {{ReadableStream}}.
 1. Let |outgoingDatagrams| be a [=new=] {{WritableStream}}.
-1. Let |datagrams| be the result of [=DatagramDuplexStream/creating=] a
-   {{WebTransportDatagramDuplexStream}}, its [=DatagramDuplexStream/create/readable=] set to
-   |incomingDatagrams| and its [=DatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
+1. Let |datagrams| be the result of [=WebTransportDatagramDuplexStream/creating=] a
+   {{WebTransportDatagramDuplexStream}}, its [=WebTransportDatagramDuplexStream/create/readable=] set to
+   |incomingDatagrams| and its [=WebTransportDatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
 1. Let |transport| be a newly constructed {{WebTransport}} object, with:
     : [=[[SendStreams]]=]
     :: an empty [=ordered set=]
@@ -1184,7 +1184,7 @@ The dictionary SHALL have the following attributes:
 :: The minimum round-trip time observed on the entire connection.
 : <dfn for="WebTransportStats" dict-member>numReceivedDatagramsDropped</dfn>
 :: The number of datagrams that were dropped, due to too many datagrams buffered
-   between calls to {{DatagramTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}.
+   between calls to {{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}.
 
 # `SendStream` #  {#send-stream}
 
@@ -1865,8 +1865,8 @@ in-band if necessary.
 *This section is non-normative.*
 
 Sending a buffer of datagrams can be achieved by using the
-{{DatagramTransport/datagrams}}' {{WebTransportDatagramDuplexStream/writable}} attribute. In the
-following example datagrams are only sent if the {{DatagramTransport}} is ready to send.
+{{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/writable}} attribute. In the
+following example datagrams are only sent if the transport is ready to send.
 
 <pre class="example" highlight="js">
 async function sendDatagrams(url, datagrams) {
@@ -1884,7 +1884,7 @@ async function sendDatagrams(url, datagrams) {
 *This section is non-normative.*
 
 Sending datagrams at a fixed rate regardless if the transport is ready to send
-can be achieved by simply using {{DatagramTransport/datagrams}}'
+can be achieved by simply using {{WebTransport/datagrams}}'
 {{WebTransportDatagramDuplexStream/writable}} and not using the `ready` attribute. More complex
 scenarios can utilize the `ready` attribute.
 
@@ -1904,7 +1904,7 @@ async function sendFixedRate(url, createDatagram, ms = 100) {
 *This section is non-normative.*
 
 Datagrams can be received by reading from the
-transport.{{DatagramTransport/datagrams}}.{{DatagramTransport/datagrams}}.{{WebTransportDatagramDuplexStream/readable}}
+transport.{{WebTransport/datagrams}}.{{WebTransportDatagramDuplexStream/readable}}
 attribute. Null values may indicate that packets are not being processed quickly
 enough.
 

--- a/index.bs
+++ b/index.bs
@@ -75,6 +75,7 @@ spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 </pre>
 <pre class="anchors">
+url: https://streams.spec.whatwg.org/#high-water-mark; type: dfn; text: high water mark
 urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMASCRIPT-6.0
   type: dfn
     text: fulfilled; url: sec-promise-objects
@@ -295,7 +296,7 @@ interface WebTransportDatagramDuplexStream {
 
 A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
 
-<table class="data" dfn-for="WebTransportDatagramDuplexStream">
+<table class="data" dfn-for="WebTransportDatagramDuplexStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -304,55 +305,55 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[Readable]]</dfn>
+   <td><dfn>`[[Readable]]`</dfn>
    <td class="non-normative">A {{ReadableStream}} for incoming datagrams.
   </tr>
   <tr>
-   <td><dfn>\[[Writable]]</dfn>
+   <td><dfn>`[[Writable]]`</dfn>
    <td class="non-normative">A {{WritableStream}} for outgoing datagrams.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingDatagramsQueue]]</dfn>
-   <td class="non-normative">A queue of [=pairs=] of an incoming datagram and a timestamp.
+   <td><dfn>`[[IncomingDatagramsQueue]]`</dfn>
+   <td class="non-normative">A queue of pairs of an incoming datagram and a timestamp.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingDatagramsPullPromise]]</dfn>
+   <td><dfn>`[[IncomingDatagramsPullPromise]]`</dfn>
    <td class="non-normative">A promise set by [=pullDatagrams=], to wait for an incoming datagram.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingDatagramsHighWaterMark]]</dfn>
+   <td><dfn>`[[IncomingDatagramsHighWaterMark]]`</dfn>
    <td class="non-normative">An integer representing the [=high water mark=] of the incoming
    datagrams.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingDatagramsExpirationDuration]]</dfn>
+   <td><dfn>`[[IncomingDatagramsExpirationDuration]]`</dfn>
    <td class="non-normative">A {{double}} value representing the expiration duration for incoming
    datagrams (in milliseconds), or null.
   </tr>
   <tr>
-   <td><dfn>\[[OutgoingDatagramsQueue]]</dfn>
+   <td><dfn>`[[OutgoingDatagramsQueue]]`</dfn>
    <td class="non-normative">A queue of tuples of an outgoing datagram, a timestamp and a promise
    which is resolved when the datagram is sent or discarded.
   </tr>
   <tr>
-   <td><dfn>\[[OutgoingDatagramsHighWaterMark]]</dfn>
+   <td><dfn>`[[OutgoingDatagramsHighWaterMark]]`</dfn>
    <td class="non-normative">An integer representing the [=high water mark=] of the outgoing
    datagrams.
   </tr>
   <tr>
-   <td><dfn>\[[OutgoingDatagramsExpirationDuration]]</dfn>
+   <td><dfn>`[[OutgoingDatagramsExpirationDuration]]`</dfn>
    <td class="non-normative">A {{double}} value representing the expiration duration for outgoing
    datagrams (in milliseconds), or null.
   </tr>
   <tr>
-   <td><dfn>\[[OutgoingMaxDatagramSize]]</dfn>
+   <td><dfn>`[[OutgoingMaxDatagramSize]]`</dfn>
    <td class="non-normative">An integer representing the maximum size for an outgoing datagram.
   </tr>
  </tbody>
 </table>
 
-The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport}} object whose
-[=[[State]]=] is either `"connecting"` or `"connected"`.
+The user agent MAY update {{[[OutgoingMaxDatagramSize]]}} for any {{WebTransport}} object whose
+{{[[State]]}} is either `"connecting"` or `"connected"`.
 
  To <dfn export for="WebTransportDatagramDuplexStream" lt="create|creating">create</dfn> a
  {{WebTransportDatagramDuplexStream}} given a
@@ -361,29 +362,29 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
  perform the following steps.
 
  1. Let |stream| be a [=new=] {{WebTransportDatagramDuplexStream}}, with:
-    : [=[[Readable]]=]
+    : {{WebTransportDatagramDuplexStream/[[Readable]]}}
     :: |readable|
-    : [=[[Writable]]=]
+    : {{WebTransportDatagramDuplexStream/[[Writable]]}}
     :: |writable|
-    : [=[[IncomingDatagramsQueue]]=]
+    : {{[[IncomingDatagramsQueue]]}}
     :: an empty queue
-    : [=[[IncomingDatagramsPullPromise]]=]
+    : {{[[IncomingDatagramsPullPromise]]}}
     :: null
-    : [=[[IncomingDatagramsHighWaterMark]]=]
+    : {{[[IncomingDatagramsHighWaterMark]]}}
     :: an [=implementation-defined=] integer
-    : [=[[IncomingDatagramsExpirationDuration]]=]
+    : {{[[IncomingDatagramsExpirationDuration]]}}
     :: null
-    : [=[[OutgoingDatagramsQueue]]=]
+    : {{[[OutgoingDatagramsQueue]]}}
     :: an empty queue
-    : [=[[OutgoingDatagramsHighWaterMark]]=]
+    : {{[[OutgoingDatagramsHighWaterMark]]}}
     :: an [=implementation-defined=] integer
        <div class="note">
         <p>This implementation-defined value should be tuned to ensure decent throughput, without
            jeopardizing the timeliness of transmitted data.</p>
        </div>
-    : [=[[OutgoingDatagramsExpirationDuration]]=]
+    : {{[[OutgoingDatagramsExpirationDuration]]}}
     :: null
-    : [=[[OutgoingMaxDatagramSize]]=]
+    : {{[[OutgoingMaxDatagramSize]]}}
     :: an [=implementation-defined=] integer.
  1. Return |stream|.
 
@@ -391,109 +392,108 @@ The user agent MAY update [=[[OutgoingMaxDatagramSize]]=] for any {{WebTransport
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>readable</dfn>
 :: The getter steps are:
-     1. Return [=this=].`[[Readable]]`.
+     1. Return [=this=].{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>writable</dfn>
 :: The getter steps are:
-     1. Return [=this=].`[[Writable]]`.
+     1. Return [=this=].{{WebTransportDatagramDuplexStream/[[Writable]]}}.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>incomingMaxAge</dfn>
 :: The getter steps are:
-     1. Return [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=].
+     1. Return [=this=].{{[[IncomingDatagramsExpirationDuration]]}}.
 :: The setter steps are:
      1. Let |value| be the given value.
      1. If |value| is null or |value| > 0:
-       1. Set [=this=]'s [=[[IncomingDatagramsExpirationDuration]]=] to |value|.
+       1. Set [=this=].{{[[IncomingDatagramsExpirationDuration]]}} to |value|.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>maxDatagramSize</dfn>
 :: The maximum size data that may be passed to {{WebTransportDatagramDuplexStream/writable}}.
-   The getter steps are to return [=this=]'s [=[[Datagrams]]=]'s [=[[OutgoingMaxDatagramSize]]=].
+   The getter steps are to return [=this=].{{[[OutgoingMaxDatagramSize]]}}.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>outgoingMaxAge</dfn>
 :: The getter steps are:
-     1. Return [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=].
+     1. Return [=this=]'s {{[[OutgoingDatagramsExpirationDuration]]}}.
 :: The setter steps are:
      1. Let |value| be the given value.
      1. If |value| is null or |value| > 0:
-       1. Set [=this=]'s [=[[OutgoingDatagramsExpirationDuration]]=] to |value|.
+       1. Set [=this=]'s {{[[OutgoingDatagramsExpirationDuration]]}} to |value|.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>incomingHighWaterMark</dfn>
 :: The getter steps are:
-     1. Return [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=].
+     1. Return [=this=].{{[[IncomingDatagramsHighWaterMark]]}}.
 :: The setter steps are:
      1. Let |value| be the given value.
      1. If |value| ≥ 0:
-       1. Set [=this=]'s [=[[IncomingDatagramsHighWaterMark]]=] to |value|.
+       1. Set [=this=].{{[[IncomingDatagramsHighWaterMark]]}} to |value|.
 
 : <dfn for="WebTransportDatagramDuplexStream" attribute>outgoingHighWaterMark</dfn>
 :: The getter steps are:
-     1. Return [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=].
+     1. Return [=this=].{{[[OutgoingDatagramsHighWaterMark]]}}.
 :: The setter steps are:
      1. Let |value| be the given value.
      1. If |value| ≥ 0:
-       1. Set [=this=]'s [=[[OutgoingDatagramsHighWaterMark]]=] to |value|.
+       1. Set [=this=].{{[[OutgoingDatagramsHighWaterMark]]}} to |value|.
 
 ## Procedures ## {#datagram-duplex-stream-procedures}
 
 To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
-1. Let |datagrams| be |transport|'s [=[[Datagrams]]=].
-1. Assert: |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] is null.
-1. Let |queue| be |datagrams|'s [=[[IncomingDatagramsQueue]]=].
+1. Let |datagrams| be |transport|.{{[[Datagrams]]}}.
+1. Assert: |datagrams|.{{[[IncomingDatagramsPullPromise]]}} is null.
+1. Let |queue| be |datagrams|.{{[[IncomingDatagramsQueue]]}}.
 1. If |queue| is empty, then:
-  1. Set |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] to a new promise.
-  1. Return |datagrams|'s [=[[IncomingDatagramsPullPromise]]=].
+  1. Set |datagrams|.{{[[IncomingDatagramsPullPromise]]}} to a new promise.
+  1. Return |datagrams|.{{[[IncomingDatagramsPullPromise]]}}.
 1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-1. [=ReadableStream/Enqueue=] |chunk| to |transport|'s [=[[Datagrams]]=]' s
-   [=WebTransportDatagramDuplexStream/[[Readable]]=].
+1. [=ReadableStream/Enqueue=] |chunk| to |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Return [=a promise resolved with=] undefined.
 
 To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
 1. Let |timestamp| be a timestamp representing now.
-1. Let |queue| be |datagrams|'s [=[[IncomingDatagramsQueue]]=].
-1. Let |duration| be |datagrams|'s [=[[IncomingDatagramsExpirationDuration]]=].
+1. Let |queue| be |datagrams|.{{[[IncomingDatagramsQueue]]}}.
+1. Let |duration| be |datagrams|.{{[[IncomingDatagramsExpirationDuration]]}}.
 1. If |duration| is null, then set |duration| to an [=implementation-defined=] value.
-1. Let |session| be |transport|'s [=[[Session]]=].
+1. Let |session| be |transport|.{{[[Session]]}}.
 1. While there are [=session/receive a datagram|available incoming datagrams=] on |session|:
   1. Let |datagram| be the result of [=session/receiving a datagram=] with |session|.
   1. Let |timestamp| be a timestamp representing now.
-  1. Let |chunk| be a [=pair=] of |datagram| and |timestamp|.
-  1. [=Enqueue=] |chunk| to |queue|.
-1. Let |toBeRemoved| be the length of |queue| minus |datagrams|'s
-   [=[[IncomingDatagramsHighWaterMark]]=].
-1. If |toBeRemoved| is positive, repeat [=dequeuing=] |queue| |toBeRemoved| times.
+  1. Let |chunk| be a pair of |datagram| and |timestamp|.
+  1. [=queue/Enqueue=] |chunk| to |queue|.
+1. Let |toBeRemoved| be the length of |queue| minus |datagrams|.{{[[IncomingDatagramsHighWaterMark]]}}.
+1. If |toBeRemoved| is positive, repeat [=queue/dequeuing=] |queue| |toBeRemoved| times.
 1. While |queue| is not empty:
   1. Let |bytes| and |timestamp| be |queue|'s first element.
-  1. If more than |duration| milliseconds have passed since |timestamp|, then [=dequeue=] |queue|.
-  1. Otherwise, [=break=] this loop.
-1. If |queue| is not empty and |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] is non-null, then:
-  1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
-  1. Let |promise| be |datagrams|'s [=[[IncomingDatagramsPullPromise]]=].
-  1. Set |datagrams|'s [=[[IncomingDatagramsPullPromise]]=] to null.
-  1. [=Queue a network task=] with |transport| to run the following steps:
+  1. If more than |duration| milliseconds have passed since |timestamp|, then [=queue/dequeue=] |queue|.
+  1. Otherwise, [=iteration/break=] this loop.
+1. If |queue| is not empty and |datagrams|.{{[[IncomingDatagramsPullPromise]]}} is non-null, then:
+  1. Let |bytes| and |timestamp| be the result of [=queue/dequeuing=] |queue|.
+  1. Let |promise| be |datagrams|.{{[[IncomingDatagramsPullPromise]]}}.
+  1. Set |datagrams|.{{[[IncomingDatagramsPullPromise]]}} to null.
+  1. [=WebTransport/Queue a network task=] with |transport| to run the following steps:
     1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-    1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|'s [=WebTransportDatagramDuplexStream/[[Readable]]=].
+    1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
     1. [=Resolve=] |promise| with undefined.
 
 The user agent SHOULD run [=receiveDatagrams=] for any {{WebTransport}} object whose
-[=[[State]]=] is `"connected"` as soon as reasonably possible whenever the algorithm can make
+{{[[State]]}} is `"connected"` as soon as reasonably possible whenever the algorithm can make
 progress.
 
 <div algorithm>
 
 The <dfn>writeDatagrams</dfn> algorithm is given a |transport| as parameter and
 |data| as input. It is defined by running the following steps:
+
 1. Let |timestamp| be a timestamp representing now.
 1. If |data| is not a {{BufferSource}} object, then return [=a promise rejected with=] a {{TypeError}}.
-1. Let |datagrams| be |transport|'s [=[[Datagrams]]=].
-1. If |datagrams|'s [=[[OutgoingMaxDatagramSize]]=] is less than |data|'s \[[ByteLength]], return
+1. Let |datagrams| be |transport|.{{[[Datagrams]]}}.
+1. If |datagrams|.{{[[OutgoingMaxDatagramSize]]}} is less than |data|'s \[[ByteLength]], return
    [=a promise resolved with=] undefined.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of bytes which |data| represents.
 1. Let |chunk| be a tuple of |bytes|, |timestamp| and |promise|.
-1. Enqueue |chunk| to |datagrams|'s [=[[OutgoingDatagramsQueue]]=].
-1. If the length of |datagrams|'s [=[[OutgoingDatagramsQueue]]=] is less than
-   |datagrams|'s [=[[OutgoingDatagramsHighWaterMark]]=], then [=resolve=] |promise| with undefined.
+1. Enqueue |chunk| to |datagrams|.{{[[OutgoingDatagramsQueue]]}}.
+1. If the length of |datagrams|.{{[[OutgoingDatagramsQueue]]}} is less than
+   |datagrams|.{{[[OutgoingDatagramsHighWaterMark]]}}, then [=resolve=] |promise| with undefined.
 1. Return |promise|.
 
 Note: The associated {{WritableStream}} calls [=writeDatagrams=] only when all the promises that
@@ -506,8 +506,8 @@ duration work well only when the web developer pays attention to
 <div algorithm>
 
 To <dfn>sendDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
-1. Let |queue| be |datagrams|'s [=[[OutgoingDatagramsQueue]]=].
-1. Let |duration| be |datagrams|'s [=[[OutgoingDatagramsExpirationDuration]]=].
+1. Let |queue| be |datagrams|.{{[[OutgoingDatagramsQueue]]}}.
+1. Let |duration| be |datagrams|.{{[[OutgoingDatagramsExpirationDuration]]}}.
 1. If |duration| is null, then set |duration| to an [=implementation-defined=] value.
 1. While |queue| is not empty:
   1. Let |bytes|, |timestamp| and |promise| be |queue|'s first element.
@@ -515,25 +515,25 @@ To <dfn>sendDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
      1. Remove the first element from |queue|.
      1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with |undefined|.
   1. Otherwise, break this loop.
-1. If |transport|'s [=[[State]]=] is not `"connected"`, then return.
-1. Let |maxSize| be |datagrams|'s [=[[OutgoingMaxDatagramSize]]=].
+1. If |transport|.{{[[State]]}} is not `"connected"`, then return.
+1. Let |maxSize| be |datagrams|.{{[[OutgoingMaxDatagramSize]]}}.
 1. While |queue| is not empty:
   1. Let |bytes|, |timestamp| and |promise| be |queue|'s first element.
   1. If |bytes|'s length ≤ |maxSize|:
     1. If it is not possible to send |bytes| to the network immediately, then break this loop.
-    1. [=session/Send a datagram=], with |transport|'s [=[[Session]]=] and |bytes|.
+    1. [=session/Send a datagram=], with |transport|.{{[[Session]]}} and |bytes|.
   1. Remove the first element from |queue|.
   1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 
 </div>
 
 The user agent SHOULD run [=sendDatagrams=] for any {{WebTransport}} object whose
-[=[[State]]=] is `"connecting"` or `"connected"` as soon as reasonably possible whenever the
+{{[[State]]}} is `"connecting"` or `"connected"` as soon as reasonably possible whenever the
 algorithm can make progress.
 
-Note: Writing datagrams while the transport's [=[[State]]=] is `"connecting"` is allowed. The
-datagrams are stored in [=[[OutgoingDatagramsExpirationDuration]]=], and they can be discarded
-in the same manner as the `"connected"` case. Once the transport's [=[[State]]=] becomes
+Note: Writing datagrams while the transport's {{[[State]]}} is `"connecting"` is allowed. The
+datagrams are stored in {{[[OutgoingDatagramsExpirationDuration]]}}, and they can be discarded
+in the same manner as the `"connected"` case. Once the transport's {{[[State]]}} becomes
 `"connected"`, it will start sending stored datagrams.
 
 # `WebTransport` Interface #  {#web-transport}
@@ -568,7 +568,7 @@ interface WebTransport {
 
 A {{WebTransport}} object has the following internal slots.
 
-<table class="data" dfn-for="WebTransport">
+<table class="data" dfn-for="WebTransport" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -577,46 +577,46 @@ A {{WebTransport}} object has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[SendStreams]]</dfn>
+   <td><dfn>`[[SendStreams]]`</dfn>
    <td class="non-normative">An [=ordered set=] of {{SendStream}}s owned by this {{WebTransport}}.
   </tr>
   <tr>
-   <td><dfn>\[[ReceiveStreams]]</dfn>
+   <td><dfn>`[[ReceiveStreams]]`</dfn>
    <td class="non-normative">An [=ordered set=] of {{ReceiveStream}}s owned by this
    {{WebTransport}}.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingBidirectionalStreams]]</dfn>
+   <td><dfn>`[[IncomingBidirectionalStreams]]`</dfn>
    <td class="non-normative">A {{ReadableStream}} consisting of {{WebTransportBidirectionalStream}}
    objects.
   </tr>
   <tr>
-   <td><dfn>\[[IncomingUnidirectionalStreams]]</dfn>
+   <td><dfn>`[[IncomingUnidirectionalStreams]]`</dfn>
    <td class="non-normative">A {{ReadableStream}} consisting of {{ReceiveStream}}s.
   </tr>
   <tr>
-   <td><dfn>\[[State]]</dfn>
+   <td><dfn>`[[State]]`</dfn>
    <td class="non-normative">An enum indicating the state of the transport. One of `"connecting"`,
    `"connected"`, `"closed"`, and `"failed"`.
   </tr>
   <tr>
-   <td><dfn>\[[Ready]]</dfn>
+   <td><dfn>`[[Ready]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
    gets [=session/established=], or rejected if the [=session/establish|establishment process=]
    failed.
   </tr>
   <tr>
-   <td><dfn>\[[Closed]]</dfn>
+   <td><dfn>`[[Closed]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
    closed gracefully, or rejected when it is closed abruptly or failed on initialization.
   </tr>
   <tr>
-   <td><dfn>\[[Datagrams]]</dfn>
+   <td><dfn>`[[Datagrams]]`</dfn>
    <td class="non-normative">A {{WebTransportDatagramDuplexStream}}.
   </tr>
   <tr>
   <tr>
-   <td><dfn>\[[Session]]</dfn>
+   <td><dfn>`[[Session]]`</dfn>
    <td class="non-normative">A [=WebTransport session=] for this {{WebTransport}} object, or null.
   </tr>
 </table>
@@ -644,23 +644,23 @@ agent MUST run the following steps:
    {{WebTransportDatagramDuplexStream}}, its [=WebTransportDatagramDuplexStream/create/readable=] set to
    |incomingDatagrams| and its [=WebTransportDatagramDuplexStream/create/writable=] set to |outgoingDatagrams|.
 1. Let |transport| be a newly constructed {{WebTransport}} object, with:
-    : [=[[SendStreams]]=]
+    : {{[[SendStreams]]}}
     :: an empty [=ordered set=]
-    : [=[[ReceiveStreams]]=]
+    : {{[[ReceiveStreams]]}}
     :: an empty [=ordered set=]
-    : [=[[IncomingBidirectionalStreams]]=]
+    : {{[[IncomingBidirectionalStreams]]}}
     :: a new {{ReadableStream}}
-    : [=[[IncomingUnidirectionalStreams]]=]
+    : {{[[IncomingUnidirectionalStreams]]}}
     :: a new {{ReadableStream}}
-    : [=[[State]]=]
+    : {{[[State]]}}
     :: `"connecting"`
-    : [=[[Ready]]=]
+    : {{[[Ready]]}}
     :: a new promise
-    : [=[[Closed]]=]
+    : {{[[Closed]]}}
     :: a new promise
-    : [=[[Datagrams]]=]
+    : {{[[Datagrams]]}}
     :: |datagrams|
-    : [=[[Session]]=]
+    : {{[[Session]]}}
     :: null
 1. Let |pullDatagramsAlgorithm| be an action that runs [=pullDatagrams=] with |transport|.
 1. Let |writeDatagramsAlgorithm| be an action that runs [=writeDatagrams=] with |transport|.
@@ -670,12 +670,12 @@ agent MUST run the following steps:
    set to |writeDatagramsAlgorithm|.
 1. Let |pullBidirectionalStreamAlgorithm| be an action that runs [=pullBidirectionalStream=]
    with |transport|.
-1. [=ReadableStream/Set up=] |transport|'s [=[[IncomingBidirectionalStreams]]=] with
+1. [=ReadableStream/Set up=] |transport|.{{[[IncomingBidirectionalStreams]]}} with
    [=ReadableStream/set up/pullAlgorithm=] set to |pullBidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. Let |pullUnidirectionalStreamAlgorithm| be an action that runs [=pullUnidirectionalStream=]
    with |transport|.
-1. [=ReadableStream/Set up=] |transport|'s [=[[IncomingUnidirectionalStreams]]=] with
+1. [=ReadableStream/Set up=] |transport|.{{[[IncomingUnidirectionalStreams]]}} with
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL| and |dedicated|.
@@ -698,21 +698,20 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    <b>"Blocked"</b>, or if |request| [=block bad port|should be blocked due to a bad port=]
    returns <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
    to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
    |transport|'s [=relevant settings object=].
-1. Run the remaining steps [=in parallel=], but abort them whenever |transport|'s
-   [=[[State]]=] becomes `"closed"` or `"failed"`.
+1. Run the remaining steps [=in parallel=], but abort them whenever |transport|.{{[[State]]}} becomes `"closed"` or `"failed"`.
 1. Let |newConnection| be "`no`" if |dedicated| is false; otherwise "`yes-and-dedicated`".
 1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
    |networkPartitionKey|, |url|, false, |newConnection|, and with [=obtain a connection/http3Only=]
    set to true.
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
@@ -721,7 +720,7 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't
    contain H3_DATAGRAM with a value of 1, then abort the remaining steps and [=queue a network
    task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
@@ -731,19 +730,19 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 
 1. If the previous step fails, abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
 1. Let |session| be the established [=WebTransport session=].
 1. Assert: |maxDatagramSize| is an integer.
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is not `"connecting"`:
+  1. If |transport|.{{[[State]]}} is not `"connecting"`:
     1. [=In parallel=], [=session/terminate=] |session|.
     1. Abort these steps.
-  1. Set |transport|'s [=[[State]]=] to `"connected"`.
-  1. Set |transport|'s [=[[Session]]=] to |session|.
-  1. [=Resolve=] |transport|'s [=[[Ready]]=] with undefined.
+  1. Set |transport|.{{[[State]]}} to `"connected"`.
+  1. Set |transport|.{{[[Session]]}} to |session|.
+  1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.
 
 </div>
 
@@ -751,10 +750,10 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 To <dfn>pullBidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
-1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of performing the
-   following steps [=upon fulfillment=] of |transport|'s [=[[Ready]]=]:
+1. If |transport|.{{[[State]]}} is `"connecting"`, then return the result of performing the
+   following steps [=upon fulfillment=] of |transport|.{{[[Ready]]}}:
   1. Return the result of [=pullBidirectionalStream=] with |transport|.
-1. Let |session| be |transport|'s [=[[Session]]=].
+1. Let |session| be |transport|.{{[[Session]]}}.
 1. Let |p| be a new promise.
 1. Return |p| and run the remaining steps [=in parallel=].
 1. Wait until there is an [=session/receive a bidirectional stream|available incoming bidirectional
@@ -763,7 +762,7 @@ these steps.
 1. [=Queue a network task=] with |transport| to run these steps:
   1. Let |stream| be the result of [=BidirectionalStream/creating=] a
      {{WebTransportBidirectionalStream}} with |internalStream| and |transport|.
-  1. [=ReadableStream/Enqueue=] |stream| to |transport|'s [=[[IncomingBidirectionalStreams]]=].
+  1. [=ReadableStream/Enqueue=] |stream| to |transport|.{{[[IncomingBidirectionalStreams]]}}.
   1. [=Resolve=] |p| with undefined.
 
 </div>
@@ -772,10 +771,10 @@ these steps.
 To <dfn>pullUnidirectionalStream</dfn>, given a {{WebTransport}} object <var>transport</var>, run
 these steps.
 
-1. If |transport|'s [=[[State]]=] is `"connecting"`, then return the result of performing the
-   following steps [=upon fulfillment=] of |transport|'s [=[[Ready]]=]:
+1. If |transport|.{{[[State]]}} is `"connecting"`, then return the result of performing the
+   following steps [=upon fulfillment=] of |transport|.{{[[Ready]]}}:
   1. Return the result of [=pullUnidirectionalStream=] with |transport|.
-1. Let |session| be |transport|'s [=[[Session]]=].
+1. Let |session| be |transport|.{{[[Session]]}}.
 1. Let |p| be a new promise.
 1. Return |p| and run the remaining steps [=in parallel=].
 1. Wait until there is an
@@ -784,7 +783,7 @@ these steps.
 1. [=Queue a network task=] with |transport| to run these steps:
   1. Let |stream| be the result of [=ReceiveStream/creating=] a {{ReceiveStream}} with
      |internalStream| and |transport|.
-  1. [=ReadableStream/Enqueue=] |stream| to |transport|'s [=[[IncomingUnidirectionalStreams]]=].
+  1. [=ReadableStream/Enqueue=] |stream| to |transport|.{{[[IncomingUnidirectionalStreams]]}}.
   1. [=Resolve=] |p| with undefined.
 
 </div>
@@ -792,26 +791,26 @@ these steps.
 ## Attributes ##  {#webtransport-attributes}
 
 : <dfn for="WebTransport" attribute>ready</dfn>
-:: On getting, it MUST return [=this=]'s [=[[Ready]]=].
+:: On getting, it MUST return [=this=]'s {{[[Ready]]}}.
 : <dfn for="WebTransport" attribute>closed</dfn>
-:: On getting, it MUST return [=this=]'s [=[[Closed]]=].
+:: On getting, it MUST return [=this=]'s {{[[Closed]]}}.
 :: This promise MUST be [=resolved=] when the transport is closed; an
    implementation SHOULD include error information in the `reason` and
    `closeCode` fields of {{WebTransportCloseInfo}}.
 : <dfn for="WebTransport" attribute>datagrams</dfn>
 :: A single duplex stream for sending and receiving datagrams over this session.
    The getter steps for the `datagrams` attribute SHALL be:
-     1. Return [=this=]'s [=[[Datagrams]]=].
+     1. Return [=this=]'s {{[[Datagrams]]}}.
 : <dfn for="WebTransport" attribute>incomingBidirectionalStreams</dfn>
 :: Returns a {{ReadableStream}} of {{WebTransportBidirectionalStream}}s that have been
    received from the server.
    The getter steps for the `incomingBidirectionalStreams` attribute SHALL be:
-     1. Return [=this=]'s [=[[IncomingBidirectionalStreams]]=].
+     1. Return [=this=]'s {{[[IncomingBidirectionalStreams]]}}.
 : <dfn for="WebTransport" attribute>incomingUnidirectionalStreams</dfn>
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
    {{ReceiveStream}}, that have been received from the server.
    The getter steps for `incomingUnidirectionalStreams` are:
-     1. Return [=this=]'s [=[[IncomingUnidirectionalStreams]]=].
+     1. Return [=this=]'s {{[[IncomingUnidirectionalStreams]]}}.
 
 ## Methods ##  {#webtransport-methods}
 
@@ -822,13 +821,13 @@ these steps.
 
    When close is called, the user agent MUST run the following steps:
      1. Let |transport| be [=this=].
-     1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, then abort these steps.
-     1. If |transport|'s [=[[State]]=] is `"connecting"`:
+     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
+     1. If |transport|.{{[[State]]}} is `"connecting"`:
        1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
           `"session"`.
        1. [=Cleanup=] |transport| with |error|, |error| and true.
        1. Abort these steps.
-     1. Let |session| be |transport|'s [=[[Session]]=].
+     1. Let |session| be |transport|.{{[[Session]]}}.
      1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
      1. Let |reason| be |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
      1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
@@ -836,7 +835,7 @@ these steps.
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.
 
        Note: This also [=resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in
-       |transport|'s [=[[SendStreams]]=] and [=[[ReceiveStreams]]=].
+       |transport|.{{[[SendStreams]]}} and {{[[ReceiveStreams]]}}.
      1. [=Cleanup=] |transport| with |closeInfo|, an {{AbortError}} and false.
 
 </div>
@@ -866,19 +865,19 @@ these steps.
    following steps:
 
    1. Let |transport| be [=this=].
-   1. If |transport|'s [=WebTransport/[[State]]=] is `"closed"` or `"failed"`,
+   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
       return a new [=rejected=] promise with an {{InvalidStateError}}.
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
-      [=WebTransport/[[State]]=] becomes `"closed"` or `"failed"`, and instead
+      {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
       [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}.
-      1. Wait for |transport|'s [=WebTransport/[[State]]=] to be `"connected"`.
+      1. Wait for |transport|.{{[[State]]}} to be `"connected"`.
       1. Let |internalStream| be the result of [=creating a bidirectional stream=] with
-         |transport|'s [=[[Session]]=].
+         |transport|.{{[[Session]]}}.
 
         Note: This operation may take time, for example when the stream ID is exhausted. [[!QUIC]]
       1. [=Queue a network task=] with |transport| to run the following steps:
-        1. If |transport|'s [=WebTransport/[[State]]=] is `"closed"` or `"failed"`,
+        1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
            [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
         1. Let |stream| be the result of [=BidirectionalStream/creating=] a
            {{WebTransportBidirectionalStream}} with |internalStream| and |transport|.
@@ -894,19 +893,19 @@ these steps.
    When `createUnidirectionalStream()` method is called, the user agent MUST
    run the following steps:
      1. Let |transport| be [=this=].
-     1. If |transport|'s [=WebTransport/[[State]]=] is `"closed"` or `"failed"`,
+     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
         return a new [=rejected=] promise with an {{InvalidStateError}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
-        [=WebTransport/[[State]]=] becomes `"closed"` or `"failed"`, and instead
+        {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
         [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}.
-        1. Wait for |transport|'s [=WebTransport/[[State]]=] to be `"connected"`.
+        1. Wait for |transport|.{{[[State]]}} to be `"connected"`.
         1. Let |internalStream| be the result of [=creating an outgoing unidirectional stream=] with
-           |transport|'s [=[[Session]]=].
+           |transport|.{{[[Session]]}}.
 
           Note: This operation may take time, for example when the stream ID is exhausted. [[!QUIC]]
         1. [=Queue a network task=] with |transport| to run the following steps:
-          1. If |transport|'s [=WebTransport/[[State]]=] is `"closed"` or `"failed"`,
+          1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
           1. Let |stream| be the result of [=SendStream/creating=] a {{SendStream}} with
              |internalStream| and |transport|.
@@ -918,16 +917,16 @@ these steps.
 <div algorithm="cleanup a WebTransport">
 To <dfn for="WebTransport">cleanup</dfn> a {{WebTransport}} |transport| with |reason|,
 |error| and a boolean |abruptly|, run these steps:
-1. Let |sendStreams| be a copy of |transport|'s [=[[SendStreams]]=].
-1. Let |receiveStreams| be a copy of |transport|'s [=[[ReceiveStreams]]=].
-1. Let |ready| be |transport|'s [=[[Ready]]=].
-1. Let |closed| be |transport|'s [=[[Closed]]=].
-1. Let |incomingBidirectionalStreams| be |transport|'s [=[[IncomingBidirectionalStreams]]=].
-1. Let |incomingUnidirectionalStreams| be |transport|'s [=[[IncomingUnidirectionalStreams]]=].
-1. Set |transport|'s [=[[SendStreams]]=] to an empty [=set=].
-1. Set |transport|'s [=[[ReceiveStreams]]=] to an empty [=set=].
-1. If |abruptly| is true, then set |transport|'s [=[[State]]=] to `"failed"`.
-1. Otherwise, set |transport|'s [=[[State]]=] to `"closed"`.
+1. Let |sendStreams| be a copy of |transport|.{{[[SendStreams]]}}.
+1. Let |receiveStreams| be a copy of |transport|.{{[[ReceiveStreams]]}}.
+1. Let |ready| be |transport|.{{[[Ready]]}}.
+1. Let |closed| be |transport|.{{[[Closed]]}}.
+1. Let |incomingBidirectionalStreams| be |transport|.{{[[IncomingBidirectionalStreams]]}}.
+1. Let |incomingUnidirectionalStreams| be |transport|.{{[[IncomingUnidirectionalStreams]]}}.
+1. Set |transport|.{{[[SendStreams]]}} to an empty [=set=].
+1. Set |transport|.{{[[ReceiveStreams]]}} to an empty [=set=].
+1. If |abruptly| is true, then set |transport|.{{[[State]]}} to `"failed"`.
+1. Otherwise, set |transport|.{{[[State]]}} to `"closed"`.
 1. [=For each=] |sendStream| in |sendStreams|, [=WritableStream/error=] |sendStream| with |error|.
 1. [=For each=] |receiveStream| in |receiveStreams|, [=ReadableStream/error=] |receiveStream|
    with |error|.
@@ -965,16 +964,16 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
 [=session/terminated=] with optionally |code| and |reasonBytes|, run these steps:
 
 1. Let |cleanly| be a boolean representing whether the HTTP/3 stream associated with the CONNECT
-   request that initiated |transport|'s [=[[Session]]=] is in the "Data Recvd" state. [[!QUIC]]
+   request that initiated |transport|.{{[[Session]]}} is in the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. Let |reason| be |error|.
   1. If |cleanly| is true:
      1. Set |reason| to a [=new=] {{WebTransportCloseInfo}}.
-     1. If |code| is given, set |reason|'s {{WebTransportCloseInfo/closeCode}} to |code|.
-     1. If |reasonBytes| is given, set |reason|'s {{WebTransportCloseInfo/reason}} to |reasonBytes|,
+     1. If |code| is given, set |reason|.{{WebTransportCloseInfo/closeCode}} to |code|.
+     1. If |reasonBytes| is given, set |reason|.{{WebTransportCloseInfo/reason}} to |reasonBytes|,
         [=UTF-8 decoded=].
   1. [=Cleanup=] |transport| with |reason|, |error| and the negation of |cleanly|.
 
@@ -985,7 +984,7 @@ Whenever a [=connection=] associated with a {{WebTransport}} |transport| gets a 
 run these steps:
 
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"session"`.
   1. [=Cleanup=] |transport| with |error|, |error| and true.
@@ -997,11 +996,11 @@ run these steps:
 This specification defines [=unloading document cleanup steps=] as the following steps, given a
 {{Document}} document:
 
-1. Let |window| be |document|'s [=relevent global object=].
-1. For each {{WebTransport}} |transport| whose [=relevent global object=] is |window|:
-  1. If |transport|'s [=[[State]]=] is `"connected"`, set |transport|'s [=[[State]]=] to `"failed"`
-     and [=session/terminate=] |transport|'s [=[[Session]]=] [=in parallel=].
-  1. If |transport|'s [=[[State]]=] is `"connecting"`, set |transport|'s [=[[State]]=] to
+1. Let |window| be |document|'s [=relevant global object=].
+1. For each {{WebTransport}} |transport| whose [=relevant global object=] is |window|:
+  1. If |transport|.{{[[State]]}} is `"connected"`, set |transport|.{{[[State]]}} to `"failed"`
+     and [=session/terminate=] |transport|.{{[[Session]]}} [=in parallel=].
+  1. If |transport|.{{[[State]]}} is `"connecting"`, set |transport|.{{[[State]]}} to
      `"failed"`.
 
   Issue: This needs to be done in workers too. See
@@ -1010,7 +1009,7 @@ This specification defines [=unloading document cleanup steps=] as the following
 
 ## Garbage Collection ## {#web-transport-gc}
 
-The user agent MUST NOT garbage collect a {{WebTransport}} object whose [=[[State]]=] is either
+The user agent MUST NOT garbage collect a {{WebTransport}} object whose {{[[State]]}} is either
 `"connecting"` or `"connected"`.
 
 ## Configuration ##  {#web-transport-configuration}
@@ -1060,8 +1059,8 @@ To <dfn>verify a certificate hash</dfn>, do the following:
 1. Let |hashes| be the input array of hashes.
 1. Let |referenceHash| be the [=compute a certificate hash|computed hash=] of the input certificate.
 1. For every hash |hash| in |hashes|:
-   1. If |hash|'s {{WebTransportHash/value}} is not null:
-     1. Let |hashValue| be the byte sequence which |hash|'s {{WebTransportHash/value}} represents.
+   1. If |hash|.{{WebTransportHash/value}} is not null:
+     1. Let |hashValue| be the byte sequence which |hash|.{{WebTransportHash/value}} represents.
      1. If {{WebTransportHash/algorithm}} of |hash| is equal to "sha-256", and |hashValue| is equal
         to |referenceHash|, the certificate is valid. Return true.
 1. Return false.
@@ -1178,7 +1177,7 @@ Note: {{SendStream}} is not a Web IDL type. A {{SendStream}} is always created b
 
 A {{SendStream}} has the following internal slots.
 
-<table class="data" dfn-for="SendStream">
+<table class="data" dfn-for="SendStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1187,16 +1186,16 @@ A {{SendStream}} has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[InternalStream]]</dfn>
+   <td><dfn>`[[InternalStream]]`</dfn>
    <td class="non-normative">An [=outgoing unidirectional=] or [=bidirectional=]
    [=WebTransport stream=].
   </tr>
   <tr>
-   <td><dfn>\[[PendingOperation]]</dfn>
+   <td><dfn>`[[PendingOperation]]`</dfn>
    <td class="non-normative">A promise representing a pending write or close operation, or null.
   </tr>
   <tr>
-   <td><dfn>\[[Transport]]</dfn>
+   <td><dfn>`[[Transport]]`</dfn>
    <td class="non-normative">A {{WebTransport}} which owns this {{SendStream}}.
   </tr>
  <tbody>
@@ -1216,11 +1215,11 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
 1. Let |stream| be a [=new=] {{WritableStream}}, with:
-    : [=[[InternalStream]]=]
+    : {{SendStream/[[InternalStream]]}}
     :: |internalStream|
-    : [=[[PendingOperation]]=]
+    : {{[[PendingOperation]]}}
     :: null
-    : [=[[Transport]]=]
+    : {{SendStream/[[Transport]]}}
     :: |transport|
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
 1. Let |closeAlgorithm| be an action that [=closes=] |stream|.
@@ -1229,14 +1228,14 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
    |writeAlgorithm|, [=WritableStream/set up/closeAlgorithm=] set to |closeAlgorithm|,
    [=WritableStream/set up/abortAlgorithm=] set to |abortAlgorithm|.
 1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
-  1. If |stream|'s [=[[PendingOperation]]=] is null, then abort these steps.
+  1. If |stream|.{{[[PendingOperation]]}} is null, then abort these steps.
   1. Let |reason| be |stream|'s \[[controller]]'s \[[signal]]'s [=AbortSignal/abort reason=].
   1. Let |abortPromise| be the result of [=aborting=] stream with |reason|.
   1. [=Upon fulfillment=] of |abortPromise|, [=reject=] |promise| with |reason|.
-  1. Let |pendingOperation| be |stream|'s [=[[PendingOperation]]=].
-  1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. Let |pendingOperation| be |stream|.{{[[PendingOperation]]}}.
+  1. Set |stream|.{{[[PendingOperation]]}} to null.
   1. [=Resolve=] |pendingOperation| with |promise|.
-1. [=set/Append=] |stream| to |transport|'s [=[[SendStreams]]=].
+1. [=set/Append=] |stream| to |transport|.{{[[SendStreams]]}}.
 1. Return |stream|.
 
 </div>
@@ -1244,16 +1243,16 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 <div algorithm>
 To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run these steps:
 
-1. Let |transport| be |stream|'s [=[[Transport]]=].
+1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. If |chunk| is not a {{BufferSource}}, return [=a promise rejected with=] a {{TypeError}}.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
-1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.
+1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. Wait for |transport|'s [=[[Datagrams]]=]'s [=[[OutgoingDatagramsQueue]]=] to be empty.
+1. Wait for |transport|.{{[[Datagrams]]}}'s {{[[OutgoingDatagramsQueue]]}} to be empty.
 
    Note: This means outgoing datagrams are prioritized over stream data.
-1. [=stream/Send=] |bytes| on |stream|'s [=[[InternalStream]]=] and wait for the operation to
+1. [=stream/Send=] |bytes| on |stream|.{{SendStream/[[InternalStream]]}} and wait for the operation to
    complete.
 1. If the previous step failed, abort the remaining steps.
 
@@ -1261,13 +1260,13 @@ To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run t
   error |stream| and reject the result of this write operation.
 
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. Set |stream|.{{[[PendingOperation]]}} to null.
   1. [=Resolve=] |promise| with undefined.
 
 Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
 SHOULD have a fixed upper limit, to carry the backpressure information to the user of
-{{SendStream}}. This also means the [=fulfillment=] of the promise returned from this algorithm (or,
-{{WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
+{{SendStream}}. This also means the [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
+{{WritableStreamDefaultWriter/write|WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
 the chunk arrives at the server, use an application-level protocol.
 
@@ -1276,16 +1275,16 @@ the chunk arrives at the server, use an application-level protocol.
 <div algorithm>
 To <dfn for="SendStream">close</dfn> a {{SendStream}} |stream|, run these steps:
 
-1. Let |transport| be |stream|'s [=[[Transport]]=].
+1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
-1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
-1. Set |stream|'s [=[[PendingOperation]]=] to |promise|.
+1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
+1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/Send=] FIN on |stream|'s [=[[InternalStream]]=] and wait for the operation to
+1. [=stream/Send=] FIN on |stream|.{{SendStream/[[InternalStream]]}} and wait for the operation to
    complete.
-1. Wait for |stream|'s [=[[InternalStream]]=] to enter the "Data Recvd" state. [[!QUIC]]
+1. Wait for |stream|.{{SendStream/[[InternalStream]]}} to enter the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. Set |stream|'s [=[[PendingOperation]]=] to null.
+  1. Set |stream|.{{[[PendingOperation]]}} to null.
   1. [=Resolve=] |promise| with undefined.
 
 </div>
@@ -1293,12 +1292,12 @@ To <dfn for="SendStream">close</dfn> a {{SendStream}} |stream|, run these steps:
 <div algorithm>
 To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, run these steps:
 
-1. Let |transport| be |stream|'s [=[[Transport]]=].
+1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
-1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
-1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[StreamErrorCode]]=] is not
-   null, then set |code| to |reason|'s [=[[StreamErrorCode]]=].
+1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
+1. If |reason| is a {{WebTransportError}} and |reasons|.{{WebTransportError/[[StreamErrorCode]]}} is not
+   null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
 
@@ -1306,7 +1305,7 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
          [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[WEB-TRANSPORT-HTTP3]].
 
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/Reset=] |stream|'s [=[[InternalStream]]=] with |code|.
+1. [=stream/Reset=] |stream|.{{SendStream/[[InternalStream]]}} with |code|.
 1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 
 </div>
@@ -1317,18 +1316,18 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
 Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| gets a
 [=stream-signal/STOP_SENDING=] signal from the server, run these steps:
 
-1. Let |transport| be |stream|'s [=[[Transport]]=].
+1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the STOP_SENDING frame. [[!QUIC]]
 
    Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in
          [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[WEB-TRANSPORT-HTTP3]].
 
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
-  1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
+  1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"stream"`.
-  1. Set |error|'s [=[[StreamErrorCode]]=] to |code|.
+  1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |code|.
   1. [=WritableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1349,7 +1348,7 @@ Note: {{ReceiveStream}} is not a Web IDL type. A {{ReceiveStream}} is always cre
 
 A {{ReceiveStream}} has the following internal slots.
 
-<table class="data" dfn-for="ReceiveStream">
+<table class="data" dfn-for="ReceiveStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1358,12 +1357,12 @@ A {{ReceiveStream}} has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[InternalStream]]</dfn>
+   <td><dfn>`[[InternalStream]]`</dfn>
    <td class="non-normative">An [=incoming unidirectional=] or [=bidirectional=]
    [=WebTransport stream=].
   </tr>
   <tr>
-   <td><dfn>\[[Transport]]</dfn>
+   <td><dfn>`[[Transport]]`</dfn>
    <td class="non-normative">The {{WebTransport}} object owning this {{ReceiveStream}}.
   </tr>
 </table>
@@ -1382,9 +1381,9 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
 1. Let |stream| be a [=new=] {{ReadableStream}}, with:
-    : [=ReceiveStream/[[InternalStream]]=]
+    : {{ReceiveStream/[[InternalStream]]}}
     :: |internalStream|
-    : [=ReceiveStream/[[Transport]]=]
+    : {{ReceiveStream/[[Transport]]}}
     :: |transport|
 1. Let |pullAlgorithm| be an action that [=pulls bytes=] from |stream|.
 1. Let |cancelAlgorithm| be an action that [=ReceiveStream/cancels=] |stream| with |reason|, given
@@ -1392,7 +1391,7 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 1. [=ReadableStream/Set up with byte reading support=] |stream| with
    [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to |pullAlgorithm| and
    [=ReadableStream/set up with byte reading support/cancelAlgorithm=] set to |cancelAlgorithm|.
-1. [=set/Add=] |stream| to |transport|'s [=[[ReceiveStreams]]=].
+1. [=set/Append=] |stream| to |transport|.{{[[ReceiveStreams]]}}.
 1. Return |stream|.
 
 </div>
@@ -1401,8 +1400,8 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 
 To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, run these steps.
 
-1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
-1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
+1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
+1. Let |internalStream| be |stream|.{{ReceiveStream/[[InternalStream]]}}.
 1. Let |promise| be a new promise.
 1. Let |buffer|, |offset|, and |maxBytes| be null.
 1. If |stream|'s [=ReadableStream/current BYOB request view=] for |stream| is not null:
@@ -1415,7 +1414,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
   1. Set |offset| to 0.
   1. Set |maxBytes| to an [=implementation-defined=] size.
   1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
-     {{ArrayBuffer}} fails, return a promise [=rejected with=] a {{RangeError}}.
+     {{ArrayBuffer}} fails, return [=a promise rejected with=] a {{RangeError}}.
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=ArrayBuffer/Write=] the bytes that area [=stream/receive|read=] from |internalStream| into
    |buffer| with offset |offset|, up to |maxBytes| bytes. Wait until either at least one byte is
@@ -1440,7 +1439,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
     1. Set |view| to a new {{Uint8Array}} with |buffer|, |offset| and |read|.
     1. [=ReadableStream/Enqueue=] |view| into |stream|.
   1. If |hasReceivedFIN| is true:
-    1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+    1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.
     1. [=ReadableStream/Close=] |stream|.
   1. [=Resolve=] |promise| with undefined.
 
@@ -1451,19 +1450,19 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 To <dfn for="ReceiveStream">cancel</dfn> a {{ReceiveStream}} |stream| with |reason|, run these
 steps.
 
-1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
-1. Let |internalStream| be |stream|'s [=ReceiveStream/[[InternalStream]]=].
+1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
+1. Let |internalStream| be |stream|.{{ReceiveStream/[[InternalStream]]}}.
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
-1. If |reason| is a {{WebTransportError}} and |reasons|'s [=[[StreamErrorCode]]=] is not
-   null, then set |code| to |reason|'s [=[[StreamErrorCode]]=].
+1. If |reason| is a {{WebTransportError}} and |reasons|.{{WebTransportError/[[StreamErrorCode]]}} is not
+   null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
 
    Note: Valid values of |code| are from 0 to 255 inclusive. The code will be encoded to a number in
          [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[WEB-TRANSPORT-HTTP3]].
 
-1. [=set/Remove=] |stream| from |transport|'s [=[[SendStreams]]=].
+1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=Send STOP_SENDING=] with |internalStream| and |code|.
 1. [=Queue a network task=] with |transport| to run these steps:
@@ -1471,7 +1470,7 @@ steps.
   Note: If the buffer described above is available in the [=event loop=] where this procedure is
   running, the following steps may run immediately.
 
-  1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+  1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.
   1. [=Resolve=] |promise| with undefined.
 
 </div>
@@ -1482,18 +1481,18 @@ steps.
 Whenever a [=WebTransport stream=] associated with a {{ReceiveStream}} |stream| gets a
 [=stream-signal/reset=] signal from the server, run these steps:
 
-1. Let |transport| be |stream|'s [=ReceiveStream/[[Transport]]=].
+1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the RESET_STREAM frame. [[!QUIC]]
 
    Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in
          [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[WEB-TRANSPORT-HTTP3]].
 
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. If |transport|'s [=[[State]]=] is `"closed"` or `"failed"`, abort these steps.
-  1. [=set/Remove=] |stream| from |transport|'s [=[[ReceiveStreams]]=].
+  1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
+  1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
      `"stream"`.
-  1. Set |error|'s [=[[StreamErrorCode]]=] to |code|.
+  1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |code|.
   1. [=ReadableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1512,7 +1511,7 @@ interface WebTransportBidirectionalStream {
 
 A {{WebTransportBidirectionalStream}} has the following internal slots.
 
-<table class="data" dfn-for="BidirectionalStream">
+<table class="data" dfn-for="WebTransportBidirectionalStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1521,15 +1520,15 @@ A {{WebTransportBidirectionalStream}} has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[Readable]]</dfn>
+   <td><dfn>`[[Readable]]`</dfn>
    <td class="non-normative">A {{ReceiveStream}}.
   </tr>
   <tr>
-   <td><dfn>\[[Writable]]</dfn>
+   <td><dfn>`[[Writable]]`</dfn>
    <td class="non-normative">A {{SendStream}}.
   </tr>
   <tr>
-   <td><dfn>\[[Transport]]</dfn>
+   <td><dfn>`[[Transport]]`</dfn>
    <td class="non-normative">The {{WebTransport}} object owning this
    {{WebTransportBidirectionalStream}}.
   </tr>
@@ -1538,10 +1537,10 @@ A {{WebTransportBidirectionalStream}} has the following internal slots.
 ## Attributes ##  {#bidirectional-stream-attributes}
 
 : <dfn for="WebTransportBidirectionalStream" attribute>readable</dfn>
-:: The getter steps are to return [=this=]'s [=BidirectionalStream/[[Readable]]=].
+:: The getter steps are to return [=this=]'s {{WebTransportBidirectionalStream/[[Readable]]}}.
 
 : <dfn for="WebTransportBidirectionalStream" attribute>writable</dfn>
-:: The getter steps are to return [=this=]'s [=BidirectionalStream/[[Writable]]=].
+:: The getter steps are to return [=this=]'s {{WebTransportBidirectionalStream/[[Writable]]}}.
 
 ## Procedures ## {#bidirectional-stream-procedures}
 
@@ -1555,11 +1554,11 @@ object |transport|, run these steps.
 1. Let |writable| be the result of [=SendStream/creating=] a {{SendStream}} with
    |internalStream| and |transport|.
 1. Let |stream| be a [=new=] {{WebTransportBidirectionalStream}}, with:
-    : [=[[Readable]]=]
+    : {{WebTransportBidirectionalStream/[[Readable]]}}
     :: |readable|
-    : [=[[Writable]]=]
+    : {{WebTransportBidirectionalStream/[[Writable]]}}
     :: |writable|
-    : [=[[Transport]]=]
+    : {{WebTransportBidirectionalStream/[[Transport]]}}
     :: |transport|
 1. Return |stream|.
 
@@ -1596,7 +1595,7 @@ enum WebTransportErrorSource {
 
 A {{WebTransportError}} has the following internal slots.
 
-<table class="data" dfn-for="WebTransportError">
+<table class="data" dfn-for="WebTransportError" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1605,11 +1604,11 @@ A {{WebTransportError}} has the following internal slots.
  </thead>
  <tbody>
   <tr>
-   <td><dfn>\[[Source]]</dfn>
+   <td><dfn>`[[Source]]`</dfn>
    <td class="non-normative">A {{WebTransportErrorSource}} indicating the source of this error.
   </tr>
   <tr>
-   <td><dfn>\[[StreamErrorCode]]</dfn>
+   <td><dfn>`[[StreamErrorCode]]`</dfn>
    <td class="non-normative">The application protocol error code for this error, or null.
   </tr>
  </tbody>
@@ -1623,19 +1622,18 @@ The <dfn constructor for="WebTransportError"
 lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps are:
 
 1. Let |error| be [=this=].
-1. Let |message| be |init|'s {{WebTransportErrorInit/message}} if it exists, and `""` otherwise.
+1. Let |message| be |init|.{{WebTransportErrorInit/message}} if it exists, and `""` otherwise.
 1. [=WebTransportError/Set up=] |error| with |message| and `"stream"`.
-1. Set |error|'s [=[[StreamErrorCode]]=] to |init|'s
-   {{WebTransportErrorInit/streamErrorCode}} if it exists.
+1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |init|.{{WebTransportErrorInit/streamErrorCode}} if it exists.
 
 </div>
 
 ## Attributes ## {#web-transport-error-attributes}
 
 : <dfn for="WebTransportError" attribute>source</dfn>
-:: The getter steps are to return [=this=]'s [=WebTransportError/[[Source]]=].
+:: The getter steps are to return [=this=]'s {{WebTransportError/[[Source]]}}.
 : <dfn for="WebTransportError" attribute>streamErrorCode</dfn>
-:: The getter steps are to return [=this=]'s [=[[StreamErrorCode]]=].
+:: The getter steps are to return [=this=]'s {{WebTransportError/[[StreamErrorCode]]}}.
 
 ## Procedures ## {#web-transport-error-procedures}
 
@@ -1656,9 +1654,9 @@ To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| wit
 |message| and a {{WebTransportErrorSource}} |source|, run these steps:
 
 1. Set |error|'s internal slots as:
-    : [=[[StreamErrorCode]]=]
+    : {{WebTransportError/[[StreamErrorCode]]}}
     :: null
-    : [=WebTransportError/[[Source]]=]
+    : {{WebTransportError/[[Source]]}}
     :: |source|
 1. Run [=DOMException/new DOMException(message, name)=] constructor steps with |error|, |message|
    and `"WebTransportError"`.


### PR DESCRIPTION
Using infrastructure provided by bikeshed

(deleted #390 by mistake)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 23, 2022, 6:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fdontcallmedom%2Fwebtransport%2F2b47c11fdce46c9edee6a323a2e7fba01ff9336f%2Findex.bs&md-warning=not%20ready)

```
<html><body><p><strong>WARNING: </strong>mysqli_connect(): (HY000/2002): Can't connect to local MySQL server through socket '/var/run/mysqld/mysqld.sock' (111)</p></body></html>
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webtransport%23391.)._
</details>
