### PR TITLE
Add per-stream getStats().

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1402,9 +1402,9 @@ on stats specific to one {{WebTransportSendStream}}.
 <pre class="idl">
 dictionary WebTransportSendStreamStats {
   DOMHighResTimeStamp timestamp;
-  unsigned long long amountWrittenTo;
-  unsigned long long sentProgress;
-  unsigned long long acknowledgedProgress;
+  unsigned long long bytesWritten;
+  unsigned long long bytesSent;
+  unsigned long long bytesAcknowledged;
 };
 </pre>
 
@@ -1413,21 +1413,26 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportSendStreamStats" dict-member>timestamp</dfn>
 :: The `timestamp` for when the stats are gathered, relative to the
    UNIX epoch (Jan 1, 1970, UTC).
-: <dfn for="WebTransportSendStreamStats" dict-member>amountWrittenTo</dfn>
+: <dfn for="WebTransportSendStreamStats" dict-member>bytesWritten</dfn>
 :: The total number of bytes the application has successfully written to this
    {{WebTransportSendStream}}. This number can only increase.
-: <dfn for="WebTransportSendStreamStats" dict-member>sentProgress</dfn>
+: <dfn for="WebTransportSendStreamStats" dict-member>bytesSent</dfn>
 :: An indicator of progress on how many of the application bytes written to this
    {{WebTransportSendStream}} has been sent at least once. This
-   number can only increase, and is always less than or equal to {{amountWrittenTo}}.
-: <dfn for="WebTransportSendStreamStats" dict-member>acknowledgedProgress</dfn>
-<!-- for HTTP/2 fallback, acknowledgedProgress may be == sentProgress -->
+   number can only increase, and is always less than or equal to
+   {{WebTransportSendStreamStats/bytesWritten}}.
+   
+   Note: this is progress of app data sent on a single stream only, and does not
+   include any network overhead.
+: <dfn for="WebTransportSendStreamStats" dict-member>bytesAcknowledged</dfn>
 :: An indicator of progress on how many of the application bytes written to this
    {{WebTransportSendStream}} have been sent and acknowledged as received by
    the server using QUIC's ACK mechanism. Only sequential bytes up to, but not
    including, the first non-acknowledged byte, are counted. This number can only
-   increase and is always less than or equal to {{sentProgress}}.
+   increase and is always less than or equal to {{WebTransportSendStreamStats/bytesSent}}.
 
+   Note: This value will match {{WebTransportSendStreamStats/bytesSent}} when
+   the connection is over HTTP/2.
 # Interface `WebTransportReceiveStream` #  {#receive-stream}
 
 A {{WebTransportReceiveStream}} is a {{ReadableStream}} providing incoming streaming
@@ -1624,8 +1629,8 @@ information on stats specific to one {{WebTransportReceiveStream}}.
 <pre class="idl">
 dictionary WebTransportReceiveStreamStats {
   DOMHighResTimeStamp timestamp;
-  unsigned long long amountReadFrom;
-  unsigned long long receivedProgress;
+  unsigned long long bytesReceived;
+  unsigned long long bytesRead;
 };
 </pre>
 
@@ -1634,15 +1639,18 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportReceiveStreamStats" dict-member>timestamp</dfn>
 :: The `timestamp` for when the stats are gathered, relative to the
    UNIX epoch (Jan 1, 1970, UTC).
-: <dfn for="WebTransportReceiveStreamStats" dict-member>amountReadFrom</dfn>
-:: The total number of bytes the application has successfully read from this
-   {{WebTransportReceiveStream}}. This number can only increase, and is always
-   less than or equal to {{receivedProgress}}.
-: <dfn for="WebTransportReceiveStreamStats" dict-member>receivedProgress</dfn>
+: <dfn for="WebTransportReceiveStreamStats" dict-member>bytesReceived</dfn>
 :: An indicator of progress on how many of the server application's bytes
    intended for this {{WebTransportReceiveStream}} have been received so far.
    Only sequential bytes up to, but not including, the first missing byte, are
    counted. This number can only increase.
+
+   Note: this is progress of app data received on a single stream only, and does
+   not include any network overhead.
+: <dfn for="WebTransportReceiveStreamStats" dict-member>bytesRead</dfn>
+:: The total number of bytes the application has successfully read from this
+   {{WebTransportReceiveStream}}. This number can only increase, and is always
+   less than or equal to {{bytesReceived}}.
 
 # Interface `WebTransportBidirectionalStream` #  {#bidirectional-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -544,8 +544,8 @@ interface WebTransport {
   /* a ReadableStream of WebTransportBidirectionalStream objects */
   readonly attribute ReadableStream incomingBidirectionalStreams;
 
-  Promise&lt;WritableStream&gt; createUnidirectionalStream();
-  /* a ReadableStream of ReceiveStreams */
+  Promise&lt;WebTransportSendStream&gt; createUnidirectionalStream();
+  /* a ReadableStream of WebTransportReceiveStream objects */
   readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
 

--- a/index.bs
+++ b/index.bs
@@ -565,11 +565,11 @@ A {{WebTransport}} object has the following internal slots.
  <tbody>
   <tr>
    <td><dfn>`[[SendStreams]]`</dfn>
-   <td class="non-normative">An [=ordered set=] of {{SendStream}}s owned by this {{WebTransport}}.
+   <td class="non-normative">An [=ordered set=] of {{WebTransportSendStream}}s owned by this {{WebTransport}}.
   </tr>
   <tr>
    <td><dfn>`[[ReceiveStreams]]`</dfn>
-   <td class="non-normative">An [=ordered set=] of {{ReceiveStream}}s owned by this
+   <td class="non-normative">An [=ordered set=] of {{WebTransportReceiveStream}}s owned by this
    {{WebTransport}}.
   </tr>
   <tr>
@@ -579,7 +579,7 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[IncomingUnidirectionalStreams]]`</dfn>
-   <td class="non-normative">A {{ReadableStream}} consisting of {{ReceiveStream}}s.
+   <td class="non-normative">A {{ReadableStream}} consisting of {{WebTransportReceiveStream}}s.
   </tr>
   <tr>
    <td><dfn>`[[State]]`</dfn>
@@ -768,7 +768,7 @@ these steps.
    [=session/receive an incoming unidirectional stream|available incoming unidirectional stream=].
 1. Let |internalStream| be the result of [=session/receiving an incoming unidirectional stream=].
 1. [=Queue a network task=] with |transport| to run these steps:
-  1. Let |stream| be the result of [=ReceiveStream/creating=] a {{ReceiveStream}} with
+  1. Let |stream| be the result of [=WebTransportReceiveStream/creating=] a {{WebTransportReceiveStream}} with
      |internalStream| and |transport|.
   1. [=ReadableStream/Enqueue=] |stream| to |transport|.{{[[IncomingUnidirectionalStreams]]}}.
   1. [=Resolve=] |p| with undefined.
@@ -795,7 +795,7 @@ these steps.
      1. Return [=this=]'s {{[[IncomingBidirectionalStreams]]}}.
 : <dfn for="WebTransport" attribute>incomingUnidirectionalStreams</dfn>
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
-   {{ReceiveStream}}, that have been received from the server.
+   {{WebTransportReceiveStream}}, that have been received from the server.
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Return [=this=].{{[[IncomingUnidirectionalStreams]]}}.
 
@@ -873,7 +873,7 @@ these steps.
 
 : <dfn for="WebTransport" method>createUnidirectionalStream()</dfn>
 
-:: Creates a {{SendStream}} for an outgoing unidirectional stream.  Note
+:: Creates a {{WebTransportSendStream}} for an outgoing unidirectional stream.  Note
    that the mere creation of a stream is not immediately visible to the server until it is used
    to send data.
 
@@ -894,7 +894,7 @@ these steps.
         1. [=Queue a network task=] with |transport| to run the following steps:
           1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
-          1. Let |stream| be the result of [=SendStream/creating=] a {{SendStream}} with
+          1. Let |stream| be the result of [=WebTransportSendStream/creating=] a {{WebTransportSendStream}} with
              |internalStream| and |transport|.
           1. [=Resolve=] |p| with |stream|.
      1. return |p|.
@@ -1151,19 +1151,46 @@ The dictionary SHALL have the following attributes:
 :: The number of datagrams that were dropped, due to too many datagrams buffered
    between calls to {{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}.
 
-# `SendStream` #  {#send-stream}
+# Interface `WebTransportSendStream` #  {#send-stream}
 
-In this spec, we call a {{WritableStream}} providing outgoing streaming features with an [=outgoing
-unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn interface>SendStream</dfn>.
+A {{WebTransportSendStream}} is a {{WritableStream}} providing outgoing streaming
+features with an [=outgoing unidirectional=] or [=bidirectional=]
+[=WebTransport stream=].
 
-Note: {{SendStream}} is not a Web IDL type. A {{SendStream}} is always created by the
-[=SendStream/create=] procedure.
+It is a {{WritableStream}} of {{Uint8Array}} that can be written to, to send
+data to the server.
+
+<pre class="idl">
+[Exposed=(Window,Worker), SecureContext]
+interface WebTransportSendStream : WritableStream {
+  Promise&lt;WebTransportSendStreamStats&gt; getStats();
+};
+</pre>
+
+A {{WebTransportSendStream}} is always created by the
+[=WebTransportSendStream/create=] procedure.
+
+## Methods ##  {#send-stream-methods}
+
+: <dfn for="WebTransportSendStream" method>getStats()</dfn>
+:: Gathers stats specific to this {{WebTransportSendStream}}'s performance,
+   and reports the result asynchronously.</p>
+
+   When getStats is called, the user agent MUST run the following steps:
+     1. Let |p| be a new promise.
+     1. Return |p| and continue the following steps [=in parallel=].
+         1. Gather the stats specific to this {{WebTransportSendStream}}.
+         1. Wait for the stats to be ready.
+         1. [=Queue a network task=] with |transport| to run the following steps:
+           1. Let |stats| be a [=new=] {{WebTransportSendStreamStats}} object
+              representing the gathered stats.
+           1. [=Resolve=] |p| with |stats|.
 
 ## Internal Slots ## {#send-stream-internal-slots}
 
-A {{SendStream}} has the following internal slots.
+A {{WebTransportSendStream}} has the following internal slots.
 
-<table class="data" dfn-for="SendStream" dfn-type="attribute">
+<table class="data" dfn-for="WebTransportSendStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1182,25 +1209,20 @@ A {{SendStream}} has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[Transport]]`</dfn>
-   <td class="non-normative">A {{WebTransport}} which owns this {{SendStream}}.
+   <td class="non-normative">A {{WebTransport}} which owns this {{WebTransportSendStream}}.
   </tr>
  <tbody>
 </table>
-
-Note: These internal slots need to be attached to {{SendStream}} (which is a kind of
-{{WritableStream}}) conceptually, not physically. For example, an implementation could place them on
-an object which is referenced from |writeAlgorithm|, |closeAlgorithm| and |abortAlgorithm| in the
-[=SendStream/create=] procedure.
 
 ## Procedures ##  {#send-stream-procedures}
 
 <div algorithm="create a SendStream">
 
-To <dfn export for="SendStream" lt="create|creating">create</dfn> a
-{{SendStream}}, with an [=outgoing unidirectional=] or [=bidirectional=] [=WebTransport stream=]
+To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
+{{WebTransportSendStream}}, with an [=outgoing unidirectional=] or [=bidirectional=] [=WebTransport stream=]
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
-1. Let |stream| be a [=new=] {{WritableStream}}, with:
+1. Let |stream| be a [=new=] {{WebTransportSendStream}}, with:
     : {{SendStream/[[InternalStream]]}}
     :: |internalStream|
     : {{[[PendingOperation]]}}
@@ -1227,7 +1249,7 @@ To <dfn export for="SendStream" lt="create|creating">create</dfn> a
 </div>
 
 <div algorithm>
-To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run these steps:
+To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSendStream}} |stream|, run these steps:
 
 1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. If |chunk| is not a {{BufferSource}}, return [=a promise rejected with=] a {{TypeError}}.
@@ -1251,7 +1273,7 @@ To <dfn for="SendStream">write</dfn> |chunk| to a {{SendStream}} |stream|, run t
 
 Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
 SHOULD have a fixed upper limit, to carry the backpressure information to the user of
-{{SendStream}}. This also means the [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
+{{WebTransportSendStream}}. This also means the [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
 {{WritableStreamDefaultWriter/write|WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
 the chunk arrives at the server, use an application-level protocol.
@@ -1259,7 +1281,7 @@ the chunk arrives at the server, use an application-level protocol.
 </div>
 
 <div algorithm>
-To <dfn for="SendStream">close</dfn> a {{SendStream}} |stream|, run these steps:
+To <dfn for="WebTransportSendStream">close</dfn> a {{WebTransportSendStream}} |stream|, run these steps:
 
 1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
@@ -1276,7 +1298,7 @@ To <dfn for="SendStream">close</dfn> a {{SendStream}} |stream|, run these steps:
 </div>
 
 <div algorithm>
-To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, run these steps:
+To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |stream| with |reason|, run these steps:
 
 1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
@@ -1299,7 +1321,7 @@ To <dfn for="SendStream">abort</dfn> a {{SendStream}} |stream| with |reason|, ru
 ## STOP_SENDING signal coming from the server ##  {#send-stream-STOP_SENDING}
 
 <div algorithm="STOP_SENDING signal">
-Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| gets a
+Whenever a [=WebTransport stream=] associated with a {{WebTransportSendStream}} |stream| gets a
 [=stream-signal/STOP_SENDING=] signal from the server, run these steps:
 
 1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
@@ -1318,23 +1340,84 @@ Whenever a [=WebTransport stream=] associated with a {{SendStream}} |stream| get
 
 </div>
 
-# `ReceiveStream` #  {#receive-stream}
+## `WebTransportSendStreamStats` Dictionary ##  {#send-stream-stats}
 
-In this spec, we call a {{ReadableStream}} providing incoming streaming features with an [=incoming
-unidirectional=] or [=bidirectional=] [=WebTransport stream=] a <dfn interface>ReceiveStream</dfn>.
+The <dfn dictionary>WebTransportSendStreamStats</dfn> dictionary includes information
+on stats specific to one {{WebTransportSendStream}}.
 
-A {{ReceiveStream}} is a {{ReadableStream}} of {{Uint8Array}} that can be read from, to consume
-data received from the server. {{ReceiveStream}} is a [=readable byte stream=], and hence it allows
+<pre class="idl">
+dictionary WebTransportSendStreamStats {
+  DOMHighResTimeStamp timestamp;
+  unsigned long long amountWrittenTo;
+  unsigned long long sentProgress;
+  unsigned long long acknowledgedProgress;
+};
+</pre>
+
+The dictionary SHALL have the following attributes:
+
+: <dfn for="WebTransportSendStreamStats" dict-member>timestamp</dfn>
+:: The `timestamp` for when the stats are gathered, relative to the
+   UNIX epoch (Jan 1, 1970, UTC).
+: <dfn for="WebTransportSendStreamStats" dict-member>amountWrittenTo</dfn>
+:: The total number of bytes the application has successfully written to this
+   {{WebTransportSendStream}}. This number can only increase.
+: <dfn for="WebTransportSendStreamStats" dict-member>sentProgress</dfn>
+:: An indicator of progress on how many of the application bytes written to this
+   {{WebTransportSendStream}} have reached the stage of being sent. This
+   number can only increase, and is always less than or equal to {{amountWrittenTo}}.
+: <dfn for="WebTransportSendStreamStats" dict-member>acknowledgedProgress</dfn>
+:: An indicator of progress on how many of the application bytes written to this
+   {{WebTransportSendStream}} have been sent and acknowledged as received by
+   the server using QUIC's ACK mechanism. Only sequential bytes up to, but not
+   including, the first non-acknowledged byte, are counted. This number can only
+   increase, and is always less than or equal to {{sentProgress}}.
+
+# Interface `WebTransportReceiveStream` #  {#receive-stream}
+
+A {{WebTransportReceiveStream}} is a {{ReadableStream}} providing incoming streaming
+features with an [=incoming unidirectional=] or [=bidirectional=]
+[=WebTransport stream=].
+
+It is a {{ReadableStream}} of {{Uint8Array}} that can be read from, to consume
+data received from the server. {{WebTransportReceiveStream}} is a [=readable byte stream=],
+and hence it allows
 its consumers to use a [=BYOB reader=] as well as a [=default reader=].
 
-Note: {{ReceiveStream}} is not a Web IDL type. A {{ReceiveStream}} is always created by the
-[=ReceiveStream/create=] procedure.
+A {{WebTransportReceiveStream}} is always created by the
+[=WebTransportReceiveStream/create=] procedure.
+
+<pre class="idl">
+[Exposed=(Window,Worker), SecureContext]
+interface WebTransportReceiveStream : ReadableStream {
+  Promise&lt;WebTransportReceiveStreamStats&gt; getStats();
+};
+</pre>
+
+A {{WebTransportReceiveStream}} is always created by the
+[=WebTransportReceiveStream/create=] procedure.
+
+## Methods ##  {#receive-stream-methods}
+
+: <dfn for="WebTransportReceiveStream" method>getStats()</dfn>
+:: Gathers stats specific to this {{WebTransportReceiveStream}}'s performance,
+   and reports the result asynchronously.</p>
+
+   When getStats is called, the user agent MUST run the following steps:
+     1. Let |p| be a new promise.
+     1. Return |p| and continue the following steps [=in parallel=].
+         1. Gather the stats specific to this {{WebTransportReceiveStream}}.
+         1. Wait for the stats to be ready.
+         1. [=Queue a network task=] with |transport| to run the following steps:
+           1. Let |stats| be a [=new=] {{WebTransportReceiveStreamStats}} object
+              representing the gathered stats.
+           1. [=Resolve=] |p| with |stats|.
 
 ## Internal Slots ## {#receive-stream-internal-slots}
 
-A {{ReceiveStream}} has the following internal slots.
+A {{WebTransportReceiveStream}} has the following internal slots.
 
-<table class="data" dfn-for="ReceiveStream" dfn-type="attribute">
+<table class="data" dfn-for="WebTransportReceiveStream" dfn-type="attribute">
  <thead>
   <tr>
    <th>Internal Slot
@@ -1349,30 +1432,25 @@ A {{ReceiveStream}} has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[Transport]]`</dfn>
-   <td class="non-normative">The {{WebTransport}} object owning this {{ReceiveStream}}.
+   <td class="non-normative">The {{WebTransport}} object owning this {{WebTransportReceiveStream}}.
   </tr>
 </table>
-
-Note: These internal slots need to be attached to {{ReceiveStream}} (which is a kind of
-{{ReadableStream}}) conceptually, not physically. For example, an implementation could place them on
-an object which is referenced from |pullAlgorithm| and |cancelAlgorithm| in the
-[=ReceiveStream/create=] procedure.
 
 ## Procedures ##  {#receive-stream-procedures}
 
 <div algorithm>
 
-To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
-{{ReceiveStream}}, with an [=incoming unidirectional=] or [=bidirectional=] [=WebTransport stream=]
+To <dfn export for="WebTransportReceiveStream" lt="create|creating">create</dfn> a
+{{WebTransportReceiveStream}}, with an [=incoming unidirectional=] or [=bidirectional=] [=WebTransport stream=]
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
-1. Let |stream| be a [=new=] {{ReadableStream}}, with:
+1. Let |stream| be a [=new=] {{WebTransportReceiveStream}}, with:
     : {{ReceiveStream/[[InternalStream]]}}
     :: |internalStream|
     : {{ReceiveStream/[[Transport]]}}
     :: |transport|
 1. Let |pullAlgorithm| be an action that [=pulls bytes=] from |stream|.
-1. Let |cancelAlgorithm| be an action that [=ReceiveStream/cancels=] |stream| with |reason|, given
+1. Let |cancelAlgorithm| be an action that [=WebTransportReceiveStream/cancels=] |stream| with |reason|, given
    |reason|.
 1. [=ReadableStream/Set up with byte reading support=] |stream| with
    [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to |pullAlgorithm| and
@@ -1384,7 +1462,7 @@ To <dfn export for="ReceiveStream" lt="create|creating">create</dfn> a
 
 <div algorithm>
 
-To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, run these steps.
+To <dfn for="WebTransportReceiveStream">pull bytes</dfn> from a {{WebTransportReceiveStream}} |stream|, run these steps.
 
 1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
 1. Let |internalStream| be |stream|.{{ReceiveStream/[[InternalStream]]}}.
@@ -1433,7 +1511,7 @@ To <dfn for="ReceiveStream">pull bytes</dfn> from a {{ReceiveStream}} |stream|, 
 
 <div algorithm>
 
-To <dfn for="ReceiveStream">cancel</dfn> a {{ReceiveStream}} |stream| with |reason|, run these
+To <dfn for="WebTransportReceiveStream">cancel</dfn> a {{WebTransportReceiveStream}} |stream| with |reason|, run these
 steps.
 
 1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
@@ -1464,7 +1542,7 @@ steps.
 ## Reset signal coming from the server ##  {#receive-stream-RESET_STREAM}
 
 <div algorithm="reset signal">
-Whenever a [=WebTransport stream=] associated with a {{ReceiveStream}} |stream| gets a
+Whenever a [=WebTransport stream=] associated with a {{WebTransportReceiveStream}} |stream| gets a
 [=stream-signal/reset=] signal from the server, run these steps:
 
 1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
@@ -1482,6 +1560,33 @@ Whenever a [=WebTransport stream=] associated with a {{ReceiveStream}} |stream| 
   1. [=ReadableStream/Error=] |stream| with |error|.
 
 </div>
+
+## `WebTransportReceiveStreamStats` Dictionary ##  {#receive-stream-stats}
+
+The <dfn dictionary>WebTransportReceiveStreamStats</dfn> dictionary includes
+information on stats specific to one {{WebTransportReceiveStream}}.
+
+<pre class="idl">
+dictionary WebTransportReceiveStreamStats {
+  DOMHighResTimeStamp timestamp;
+  unsigned long long amountReadFrom;
+  unsigned long long receivedProgress;
+};
+</pre>
+
+The dictionary SHALL have the following attributes:
+
+: <dfn for="WebTransportReceiveStreamStats" dict-member>timestamp</dfn>
+:: The `timestamp` for when the stats are gathered, relative to the
+   UNIX epoch (Jan 1, 1970, UTC).
+: <dfn for="WebTransportReceiveStreamStats" dict-member>amountReadFrom</dfn>
+:: The total number of bytes the application has successfully read from this
+   {{WebTransportReceiveStream}}. This number can only increase, and is always
+   less than or equal to {{receivedProgress}}.
+: <dfn for="WebTransportReceiveStreamStats" dict-member>receivedProgress</dfn>
+:: An indicator of progress on how many of the server application's bytes
+   intended for this {{WebTransportReceiveStream}} have been received so far.
+   This number can only increase.
 
 # Interface `WebTransportBidirectionalStream` #  {#bidirectional-stream}
 
@@ -1507,11 +1612,11 @@ A {{WebTransportBidirectionalStream}} has the following internal slots.
  <tbody>
   <tr>
    <td><dfn>`[[Readable]]`</dfn>
-   <td class="non-normative">A {{ReceiveStream}}.
+   <td class="non-normative">A {{WebTransportReceiveStream}}.
   </tr>
   <tr>
    <td><dfn>`[[Writable]]`</dfn>
-   <td class="non-normative">A {{SendStream}}.
+   <td class="non-normative">A {{WebTransportSendStream}}.
   </tr>
   <tr>
    <td><dfn>`[[Transport]]`</dfn>
@@ -1535,9 +1640,9 @@ To <dfn for=BidirectionalStream>create</dfn> a {{WebTransportBidirectionalStream
 [=bidirectional=] [=WebTransport stream=] |internalStream| and a {{WebTransport}}
 object |transport|, run these steps.
 
-1. Let |readable| be the result of [=ReceiveStream/creating=] a {{ReceiveStream}} with
+1. Let |readable| be the result of [=WebTransportReceiveStream/creating=] a {{WebTransportReceiveStream}} with
    |internalStream| and |transport|.
-1. Let |writable| be the result of [=SendStream/creating=] a {{SendStream}} with
+1. Let |writable| be the result of [=WebTransportSendStream/creating=] a {{WebTransportSendStream}} with
    |internalStream| and |transport|.
 1. Let |stream| be a [=new=] {{WebTransportBidirectionalStream}}, with:
     : {{WebTransportBidirectionalStream/[[Readable]]}}
@@ -1917,7 +2022,7 @@ async function sendText(url, readableStreamOfTextData) {
 
 Reading incoming streams can be achieved by iterating over the
 {{WebTransport/incomingUnidirectionalStreams}} attribute,
-and then consuming each {{ReceiveStream}} by iterating over its chunks.
+and then consuming each {{WebTransportReceiveStream}} by iterating over its chunks.
 
 <pre class="example" highlight="js">
 async function receiveData(url, processTheData) {

--- a/index.bs
+++ b/index.bs
@@ -1364,7 +1364,7 @@ The dictionary SHALL have the following attributes:
    {{WebTransportSendStream}}. This number can only increase.
 : <dfn for="WebTransportSendStreamStats" dict-member>sentProgress</dfn>
 :: An indicator of progress on how many of the application bytes written to this
-   {{WebTransportSendStream}} have reached the stage of being sent. This
+   {{WebTransportSendStream}} has been sent at least once. This
    number can only increase, and is always less than or equal to {{amountWrittenTo}}.
 : <dfn for="WebTransportSendStreamStats" dict-member>acknowledgedProgress</dfn>
 <!-- for HTTP/2 fallback, acknowledgedProgress may be == sentProgress --!>

--- a/index.bs
+++ b/index.bs
@@ -1433,6 +1433,7 @@ The dictionary SHALL have the following attributes:
 
    Note: This value will match {{WebTransportSendStreamStats/bytesSent}} when
    the connection is over HTTP/2.
+
 # Interface `WebTransportReceiveStream` #  {#receive-stream}
 
 A {{WebTransportReceiveStream}} is a {{ReadableStream}} providing incoming streaming
@@ -1650,7 +1651,7 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportReceiveStreamStats" dict-member>bytesRead</dfn>
 :: The total number of bytes the application has successfully read from this
    {{WebTransportReceiveStream}}. This number can only increase, and is always
-   less than or equal to {{bytesReceived}}.
+   less than or equal to {{WebTransportReceiveStreamStats/bytesReceived}}.
 
 # Interface `WebTransportBidirectionalStream` #  {#bidirectional-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -1223,11 +1223,11 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
 1. Let |stream| be a [=new=] {{WebTransportSendStream}}, with:
-    : {{SendStream/[[InternalStream]]}}
+    : {{WebTransportSendStream/[[InternalStream]]}}
     :: |internalStream|
     : {{[[PendingOperation]]}}
     :: null
-    : {{SendStream/[[Transport]]}}
+    : {{WebTransportSendStream/[[Transport]]}}
     :: |transport|
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
 1. Let |closeAlgorithm| be an action that [=closes=] |stream|.
@@ -1251,7 +1251,7 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
 <div algorithm>
 To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSendStream}} |stream|, run these steps:
 
-1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
+1. Let |transport| be |stream|.{{WebTransportSendStream/[[Transport]]}}.
 1. If |chunk| is not a {{BufferSource}}, return [=a promise rejected with=] a {{TypeError}}.
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
@@ -1260,7 +1260,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Wait for |transport|.{{[[Datagrams]]}}'s {{[[OutgoingDatagramsQueue]]}} to be empty.
 
    Note: This means outgoing datagrams are prioritized over stream data.
-1. [=stream/Send=] |bytes| on |stream|.{{SendStream/[[InternalStream]]}} and wait for the operation to
+1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the operation to
    complete.
 1. If the previous step failed, abort the remaining steps.
 
@@ -1283,14 +1283,14 @@ the chunk arrives at the server, use an application-level protocol.
 <div algorithm>
 To <dfn for="WebTransportSendStream">close</dfn> a {{WebTransportSendStream}} |stream|, run these steps:
 
-1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
+1. Let |transport| be |stream|.{{WebTransportSendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
 1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
 1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/Send=] FIN on |stream|.{{SendStream/[[InternalStream]]}} and wait for the operation to
+1. [=stream/Send=] FIN on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the operation to
    complete.
-1. Wait for |stream|.{{SendStream/[[InternalStream]]}} to enter the "Data Recvd" state. [[!QUIC]]
+1. Wait for |stream|.{{WebTransportSendStream/[[InternalStream]]}} to enter the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
   1. Set |stream|.{{[[PendingOperation]]}} to null.
   1. [=Resolve=] |promise| with undefined.
@@ -1300,7 +1300,7 @@ To <dfn for="WebTransportSendStream">close</dfn> a {{WebTransportSendStream}} |s
 <div algorithm>
 To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |stream| with |reason|, run these steps:
 
-1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
+1. Let |transport| be |stream|.{{WebTransportSendStream/[[Transport]]}}.
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
 1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
@@ -1313,7 +1313,7 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
          [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[WEB-TRANSPORT-HTTP3]].
 
 1. Return |promise| and run the remaining steps [=in parallel=].
-1. [=stream/Reset=] |stream|.{{SendStream/[[InternalStream]]}} with |code|.
+1. [=stream/Reset=] |stream|.{{WebTransportSendStream/[[InternalStream]]}} with |code|.
 1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 
 </div>
@@ -1324,7 +1324,7 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 Whenever a [=WebTransport stream=] associated with a {{WebTransportSendStream}} |stream| gets a
 [=stream-signal/STOP_SENDING=] signal from the server, run these steps:
 
-1. Let |transport| be |stream|.{{SendStream/[[Transport]]}}.
+1. Let |transport| be |stream|.{{WebTransportSendStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the STOP_SENDING frame. [[!QUIC]]
 
    Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in
@@ -1367,7 +1367,7 @@ The dictionary SHALL have the following attributes:
    {{WebTransportSendStream}} has been sent at least once. This
    number can only increase, and is always less than or equal to {{amountWrittenTo}}.
 : <dfn for="WebTransportSendStreamStats" dict-member>acknowledgedProgress</dfn>
-<!-- for HTTP/2 fallback, acknowledgedProgress may be == sentProgress --!>
+<!-- for HTTP/2 fallback, acknowledgedProgress may be == sentProgress -->
 :: An indicator of progress on how many of the application bytes written to this
    {{WebTransportSendStream}} have been sent and acknowledged as received by
    the server using QUIC's ACK mechanism. Only sequential bytes up to, but not
@@ -1446,9 +1446,9 @@ To <dfn export for="WebTransportReceiveStream" lt="create|creating">create</dfn>
 |internalStream| and a {{WebTransport}} |transport|, run these steps:
 
 1. Let |stream| be a [=new=] {{WebTransportReceiveStream}}, with:
-    : {{ReceiveStream/[[InternalStream]]}}
+    : {{WebTransportReceiveStream/[[InternalStream]]}}
     :: |internalStream|
-    : {{ReceiveStream/[[Transport]]}}
+    : {{WebTransportReceiveStream/[[Transport]]}}
     :: |transport|
 1. Let |pullAlgorithm| be an action that [=pulls bytes=] from |stream|.
 1. Let |cancelAlgorithm| be an action that [=WebTransportReceiveStream/cancels=] |stream| with |reason|, given
@@ -1465,8 +1465,8 @@ To <dfn export for="WebTransportReceiveStream" lt="create|creating">create</dfn>
 
 To <dfn for="WebTransportReceiveStream">pull bytes</dfn> from a {{WebTransportReceiveStream}} |stream|, run these steps.
 
-1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
-1. Let |internalStream| be |stream|.{{ReceiveStream/[[InternalStream]]}}.
+1. Let |transport| be |stream|.{{WebTransportReceiveStream/[[Transport]]}}.
+1. Let |internalStream| be |stream|.{{WebTransportReceiveStream/[[InternalStream]]}}.
 1. Let |promise| be a new promise.
 1. Let |buffer|, |offset|, and |maxBytes| be null.
 1. If |stream|'s [=ReadableStream/current BYOB request view=] for |stream| is not null:
@@ -1515,8 +1515,8 @@ To <dfn for="WebTransportReceiveStream">pull bytes</dfn> from a {{WebTransportRe
 To <dfn for="WebTransportReceiveStream">cancel</dfn> a {{WebTransportReceiveStream}} |stream| with |reason|, run these
 steps.
 
-1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
-1. Let |internalStream| be |stream|.{{ReceiveStream/[[InternalStream]]}}.
+1. Let |transport| be |stream|.{{WebTransportReceiveStream/[[Transport]]}}.
+1. Let |internalStream| be |stream|.{{WebTransportReceiveStream/[[InternalStream]]}}.
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
 1. If |reason| is a {{WebTransportError}} and |reasons|.{{WebTransportError/[[StreamErrorCode]]}} is not
@@ -1546,7 +1546,7 @@ steps.
 Whenever a [=WebTransport stream=] associated with a {{WebTransportReceiveStream}} |stream| gets a
 [=stream-signal/reset=] signal from the server, run these steps:
 
-1. Let |transport| be |stream|.{{ReceiveStream/[[Transport]]}}.
+1. Let |transport| be |stream|.{{WebTransportReceiveStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the RESET_STREAM frame. [[!QUIC]]
 
    Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in

--- a/index.bs
+++ b/index.bs
@@ -1371,7 +1371,7 @@ The dictionary SHALL have the following attributes:
    {{WebTransportSendStream}} have been sent and acknowledged as received by
    the server using QUIC's ACK mechanism. Only sequential bytes up to, but not
    including, the first non-acknowledged byte, are counted. This number can only
-   increase, and is always less than or equal to {{sentProgress}}.
+   increase and is always less than or equal to {{sentProgress}}.
 
 # Interface `WebTransportReceiveStream` #  {#receive-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -1367,6 +1367,7 @@ The dictionary SHALL have the following attributes:
    {{WebTransportSendStream}} have reached the stage of being sent. This
    number can only increase, and is always less than or equal to {{amountWrittenTo}}.
 : <dfn for="WebTransportSendStreamStats" dict-member>acknowledgedProgress</dfn>
+<!-- for HTTP/2 fallback, acknowledgedProgress may be == sentProgress --!>
 :: An indicator of progress on how many of the application bytes written to this
    {{WebTransportSendStream}} have been sent and acknowledged as received by
    the server using QUIC's ACK mechanism. Only sequential bytes up to, but not

--- a/index.bs
+++ b/index.bs
@@ -1586,7 +1586,8 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportReceiveStreamStats" dict-member>receivedProgress</dfn>
 :: An indicator of progress on how many of the server application's bytes
    intended for this {{WebTransportReceiveStream}} have been received so far.
-   This number can only increase.
+   Only sequential bytes up to, but not including, the first missing byte, are
+   counted. This number can only increase.
 
 # Interface `WebTransportBidirectionalStream` #  {#bidirectional-stream}
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/372.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/395.html" title="Last updated on Apr 27, 2022, 5:11 PM UTC (030e1ca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/395/23a4ef4...jan-ivar:030e1ca.html" title="Last updated on Apr 27, 2022, 5:11 PM UTC (030e1ca)">Diff</a>