### PR TITLE
Ensure the reason string is valid even when clipped

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -843,7 +843,6 @@ these steps.
         |closeInfo|.{{WebTransportCloseInfo/reason}} where the [=byte sequcne/length=] of the
         [=UTF-8 encoded=] prefix doesn't exceed 1024.
      1. Let |reason| be |reasonString|, [=UTF-8 encoded=].
-        [=byte sequence/prefix=] of |reason| whose length is 1024.
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.
 
        Note: This also [=stream/resets=] or [=sends STOP_SENDING=] [=WebTransport streams=] contained in

--- a/index.bs
+++ b/index.bs
@@ -839,8 +839,10 @@ these steps.
        1. Abort these steps.
      1. Let |session| be |transport|.{{[[Session]]}}.
      1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
-     1. Let |reason| be |closeInfo|.{{WebTransportCloseInfo/reason}}, [=UTF-8 encoded=].
-     1. If |reason|'s [=byte sequence/length=] exceeds 1024, then set |reason| to a
+     1. Let |reasonString| be the maximal [=code unit prefix=] of
+        |closeInfo|.{{WebTransportCloseInfo/reason}} where the [=byte sequcne/length=] of the
+        [=UTF-8 encoded=] prefix doesn't exceed 1024.
+     1. Let |reason| be |reasonString|, [=UTF-8 encoded=].
         [=byte sequence/prefix=] of |reason| whose length is 1024.
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.
 

--- a/index.bs
+++ b/index.bs
@@ -840,7 +840,7 @@ these steps.
      1. Let |session| be |transport|.{{[[Session]]}}.
      1. Let |code| be |closeInfo|.{{WebTransportCloseInfo/closeCode}}.
      1. Let |reasonString| be the maximal [=code unit prefix=] of
-        |closeInfo|.{{WebTransportCloseInfo/reason}} where the [=byte sequcne/length=] of the
+        |closeInfo|.{{WebTransportCloseInfo/reason}} where the [=byte sequence/length=] of the
         [=UTF-8 encoded=] prefix doesn't exceed 1024.
      1. Let |reason| be |reasonString|, [=UTF-8 encoded=].
      1. [=In parallel=], [=session/terminate=] |session| with |code| and |reason|.


### PR DESCRIPTION
Fixes #382.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/397.html" title="Last updated on Apr 22, 2022, 3:13 AM UTC (19d25ba)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/397/23a4ef4...19d25ba.html" title="Last updated on Apr 22, 2022, 3:13 AM UTC (19d25ba)">Diff</a>