### PR TITLE
html validity

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -614,7 +614,6 @@ A {{WebTransport}} object has the following internal slots.
    <td class="non-normative">A {{WebTransportDatagramDuplexStream}}.
   </tr>
   <tr>
-  <tr>
    <td><dfn>`[[Session]]`</dfn>
    <td class="non-normative">A [=WebTransport session=] for this {{WebTransport}} object, or null.
   </tr>


### PR DESCRIPTION
removed extra (and unclosed) empty \<tr>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/403.html" title="Last updated on Jun 24, 2022, 8:40 AM UTC (007475c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/403/3da2076...007475c.html" title="Last updated on Jun 24, 2022, 8:40 AM UTC (007475c)">Diff</a>