### PR TITLE
Update link to websockets spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2015,7 +2015,7 @@ Protocol security considerations related are described in the
 Networking APIs can be commonly used to scan the local network for available
 hosts, and thus be used for fingerprinting and other forms of attacks.
 WebTransport follows the [WebSocket
-approach](https://html.spec.whatwg.org/multipage/web-sockets.html#feedback-from-the-protocol)
+approach](https://websockets.spec.whatwg.org/#feedback-from-the-protocol)
 to this problem: the specific connection error is not returned until an
 endpoint is verified to be a WebTransport endpoint; thus, the Web application
 cannot distinguish between a non-existing endpoint and the endpoint that is not


### PR DESCRIPTION
To standalone spec instead of HTML


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dontcallmedom/webtransport/pull/418.html" title="Last updated on Sep 8, 2022, 11:55 AM UTC (c42342a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/418/bc732e3...dontcallmedom:c42342a.html" title="Last updated on Sep 8, 2022, 11:55 AM UTC (c42342a)">Diff</a>