### PR TITLE
BidirectionalStream's readable and writable lost their types.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1703,8 +1703,8 @@ The dictionary SHALL have the following attributes:
 <pre class="idl">
 [Exposed=(Window,Worker), SecureContext]
 interface WebTransportBidirectionalStream {
-  readonly attribute ReadableStream readable;
-  readonly attribute WritableStream writable;
+  readonly attribute WebTransportReceiveStream readable;
+  readonly attribute WebTransportSendStream writable;
 };
 </pre>
 


### PR DESCRIPTION
They [used to be](https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/275.html#bidirectional-stream) `ReceiveStream` and `SendStream` but lost their types during the conversion to simple `ReadableStream` and `WritableStream` and back.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/423.html" title="Last updated on Oct 6, 2022, 12:29 AM UTC (172c906)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/423/a8fec03...jan-ivar:172c906.html" title="Last updated on Oct 6, 2022, 12:29 AM UTC (172c906)">Diff</a>