### PR TITLE
Make WebTransportSendStream & WebTransportReceiveStream transferable.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1269,7 +1269,8 @@ A {{WebTransportSendStream}} is always created by the
 [=WebTransportSendStream/create=] procedure.
 
 The {{WebTransportSendStream}}'s [=transfer steps=] and
-[=transfer-receiving steps=] are those of {{WritableStream}}.
+[=transfer-receiving steps=] are
+[those of](https://streams.spec.whatwg.org/#ws-transfer) {{WritableStream}}.
 
 ## Methods ##  {#send-stream-methods}
 
@@ -1504,7 +1505,8 @@ A {{WebTransportReceiveStream}} is always created by the
 [=WebTransportReceiveStream/create=] procedure.
 
 The {{WebTransportReceiveStream}}'s [=transfer steps=] and
-[=transfer-receiving steps=] are those of {{ReadableStream}}.
+[=transfer-receiving steps=] are
+[those of](https://streams.spec.whatwg.org/#rs-transfer) {{ReadableStream}}.
 
 ## Methods ##  {#receive-stream-methods}
 

--- a/index.bs
+++ b/index.bs
@@ -1259,7 +1259,7 @@ It is a {{WritableStream}} of {{Uint8Array}} that can be written to, to send
 data to the server.
 
 <pre class="idl">
-[Exposed=(Window,Worker), SecureContext]
+[Exposed=(Window,Worker), SecureContext, Transferable]
 interface WebTransportSendStream : WritableStream {
   Promise&lt;WebTransportSendStreamStats&gt; getStats();
 };
@@ -1267,6 +1267,9 @@ interface WebTransportSendStream : WritableStream {
 
 A {{WebTransportSendStream}} is always created by the
 [=WebTransportSendStream/create=] procedure.
+
+The {{WebTransportSendStream}}'s [=transfer steps=] and
+[=transfer-receiving steps=] are those of {{WritableStream}}.
 
 ## Methods ##  {#send-stream-methods}
 
@@ -1490,11 +1493,8 @@ data received from the server. {{WebTransportReceiveStream}} is a [=readable byt
 and hence it allows
 its consumers to use a [=BYOB reader=] as well as a [=default reader=].
 
-A {{WebTransportReceiveStream}} is always created by the
-[=WebTransportReceiveStream/create=] procedure.
-
 <pre class="idl">
-[Exposed=(Window,Worker), SecureContext]
+[Exposed=(Window,Worker), SecureContext, Transferable]
 interface WebTransportReceiveStream : ReadableStream {
   Promise&lt;WebTransportReceiveStreamStats&gt; getStats();
 };
@@ -1502,6 +1502,9 @@ interface WebTransportReceiveStream : ReadableStream {
 
 A {{WebTransportReceiveStream}} is always created by the
 [=WebTransportReceiveStream/create=] procedure.
+
+The {{WebTransportReceiveStream}}'s [=transfer steps=] and
+[=transfer-receiving steps=] are those of {{ReadableStream}}.
 
 ## Methods ##  {#receive-stream-methods}
 


### PR DESCRIPTION
Fixes #424.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/433.html" title="Last updated on Dec 1, 2022, 8:54 PM UTC (14b9ae6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/433/f2fe7de...jan-ivar:14b9ae6.html" title="Last updated on Dec 1, 2022, 8:54 PM UTC (14b9ae6)">Diff</a>