### PR TITLE
Receiving a DRAIN_WEBTRANSPORT_SESSION capsule

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -261,6 +261,25 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
  </tbody>
 </table>
 
+[=WebTransport session=] has the following signals:
+
+<table class="data" dfn-for="session-signal">
+ <thead>
+  <tr>
+   <th>event
+   <th>definition
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>draining</dfn> a [=WebTransport session=]
+   <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
+   <td>[[!WEB-TRANSPORT-HTTP3]]
+   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
+  </tr>
+ </tbody>
+</table>
+
 # `WebTransportDatagramDuplexStream` Interface #  {#duplex-stream}
 
 A <dfn interface>WebTransportDatagramDuplexStream</dfn> is a generic duplex stream.

--- a/index.bs
+++ b/index.bs
@@ -933,7 +933,7 @@ these steps.
    following steps:
 
    1. Let |transport| be [=this=].
-   1. If |transport|.{{[[State]]}} is `"draining"`, `"closed"` or `"failed"`,
+   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
       return a new [=rejected=] promise with an {{InvalidStateError}}.
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
@@ -961,7 +961,7 @@ these steps.
    When `createUnidirectionalStream()` method is called, the user agent MUST
    run the following steps:
      1. Let |transport| be [=this=].
-     1. If |transport|.{{[[State]]}} is `"draining"`, `"closed"` or `"failed"`,
+     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
         return a new [=rejected=] promise with an {{InvalidStateError}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=], but abort them whenever |transport|'s

--- a/index.bs
+++ b/index.bs
@@ -538,6 +538,7 @@ interface WebTransport {
   readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute WebTransportCongestionControl congestionControl;
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
+  readonly attribute Promise&lt;WebTransportCloseInfo&gt; draining;
   undefined close(optional WebTransportCloseInfo closeInfo = {});
 
   readonly attribute WebTransportDatagramDuplexStream datagrams;
@@ -591,7 +592,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[State]]`</dfn>
    <td class="non-normative">An enum indicating the state of the transport. One of `"connecting"`,
-   `"connected"`, `"closed"`, and `"failed"`.
+   `"connected"`, `"draining"`, `"closed"`, and `"failed"`.
   </tr>
   <tr>
    <td><dfn>`[[Ready]]`</dfn>
@@ -616,6 +617,11 @@ A {{WebTransport}} object has the following internal slots.
    <td><dfn>`[[Closed]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
    closed gracefully, or rejected when it is closed abruptly or failed on initialization.
+  </tr>
+  <tr>
+   <td><dfn>`[[Draining]]`</dfn>
+   <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object
+   receives DRAIN_WEBTRANSPORT_SESSION.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>
@@ -1959,6 +1965,23 @@ not be immediate due to buffering.
         <td>Network error<br>
         <td>(await wt.{{WebTransport/closed}}) rejects, and
           [=ReadableStream/error|errors=] open streams</td>
+      </tr>
+    </tbody>
+  </table>
+  
+    <table class="data">
+    <colgroup class="header"><col></colgroup>
+    <colgroup><col></colgroup>
+    <thead>
+      <tr>
+        <th>WebTransport Protocol Action</th>
+        <th>API Effect</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Received [=session/draining] with closeInfo<br>
+        <td>(await wt.{{WebTransport/draining}}).closeInfo
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -538,7 +538,7 @@ interface WebTransport {
   readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute WebTransportCongestionControl congestionControl;
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
-  readonly attribute Promise&lt;WebTransportCloseInfo&gt; draining;
+  readonly attribute Promise&lt;undefined&gt; draining;
   undefined close(optional WebTransportCloseInfo closeInfo = {});
 
   readonly attribute WebTransportDatagramDuplexStream datagrams;
@@ -621,7 +621,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[Draining]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object
-   receives DRAIN_WEBTRANSPORT_SESSION.
+   receives a DRAIN_WEBTRANSPORT_SESSION capsule.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>
@@ -829,9 +829,7 @@ these steps.
    `closeCode` fields of {{WebTransportCloseInfo}}.
 : <dfn for="WebTransport" attribute>draining</dfn>
 :: On getting, it MUST return [=this=]'s {{[[Draining]]}}.
-:: This promise MUST be [=resolved=] when the transport receives DRAIN_WEBTRANSPORT_SESSION;
-   an implementation SHOULD include error information in the `reason` and
-   `closeCode` fields of {{WebTransportCloseInfo}}.
+:: This promise MUST be [=resolved=] when the transport receives a DRAIN_WEBTRANSPORT_SESSION capsule.
 : <dfn for="WebTransport" attribute>datagrams</dfn>
 :: A single duplex stream for sending and receiving datagrams over this session.
    The getter steps for the `datagrams` attribute SHALL be:
@@ -912,7 +910,7 @@ these steps.
    following steps:
 
    1. Let |transport| be [=this=].
-   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
+   1. If |transport|.{{[[State]]}} is `"draining"`, `"closed"` or `"failed"`,
       return a new [=rejected=] promise with an {{InvalidStateError}}.
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
@@ -940,7 +938,7 @@ these steps.
    When `createUnidirectionalStream()` method is called, the user agent MUST
    run the following steps:
      1. Let |transport| be [=this=].
-     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
+     1. If |transport|.{{[[State]]}} is `"draining"`, `"closed"` or `"failed"`,
         return a new [=rejected=] promise with an {{InvalidStateError}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
@@ -1987,8 +1985,8 @@ not be immediate due to buffering.
     </thead>
     <tbody>
       <tr>
-        <td>Received [=session/draining] with closeInfo<br>
-        <td>(await wt.{{WebTransport/draining}}).closeInfo
+        <td>Received [=session/draining]<br>
+        <td>(await wt.{{WebTransport/draining}})
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -1974,7 +1974,7 @@ not be immediate due to buffering.
     </tbody>
   </table>
   
-    <table class="data">
+  <table class="data">
     <colgroup class="header"><col></colgroup>
     <colgroup><col></colgroup>
     <thead>
@@ -1985,8 +1985,8 @@ not be immediate due to buffering.
     </thead>
     <tbody>
       <tr>
-        <td>Received [=session/draining]<br>
-        <td>(await wt.{{WebTransport/draining}})
+        <td>Received [=session/draining|draining=] session<td>
+        <td>await wt.{{WebTransport/draining}}</td>
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -682,6 +682,8 @@ agent MUST run the following steps:
     :: |congestionControl|
     : {{[[Closed]]}}
     :: a new promise
+    : {{[[Draining]]}}
+    :: a new promise
     : {{[[Datagrams]]}}
     :: |datagrams|
     : {{[[Session]]}}
@@ -824,6 +826,11 @@ these steps.
 :: On getting, it MUST return [=this=]'s {{[[Closed]]}}.
 :: This promise MUST be [=resolved=] when the transport is closed; an
    implementation SHOULD include error information in the `reason` and
+   `closeCode` fields of {{WebTransportCloseInfo}}.
+: <dfn for="WebTransport" attribute>draining</dfn>
+:: On getting, it MUST return [=this=]'s {{[[Draining]]}}.
+:: This promise MUST be [=resolved=] when the transport receives DRAIN_WEBTRANSPORT_SESSION;
+   an implementation SHOULD include error information in the `reason` and
    `closeCode` fields of {{WebTransportCloseInfo}}.
 : <dfn for="WebTransport" attribute>datagrams</dfn>
 :: A single duplex stream for sending and receiving datagrams over this session.

--- a/index.bs
+++ b/index.bs
@@ -2008,7 +2008,7 @@ not be immediate due to buffering.
     </thead>
     <tbody>
       <tr>
-        <td>Received [=session/draining|draining=] session<td>
+        <td>received [=session-signal/DRAIN_WEBTRANSPORT_SESSION=]<td>
         <td>await wt.{{WebTransport/draining}}</td>
       </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -261,7 +261,7 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
  </tbody>
 </table>
 
-[=WebTransport session=] has the following signals:
+A [=WebTransport session=] has the following signals:
 
 <table class="data" dfn-for="session-signal">
  <thead>
@@ -639,8 +639,8 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[Draining]]`</dfn>
-   <td class="non-normative">A promise fulfilled when the associated [=WebTransport sessions=]
-   receives a DRAIN_WEBTRANSPORT_SESSION capsule.
+   <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
+   receives a {{DRAIN_WEBTRANSPORT_SESSION}} capsule.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>

--- a/index.bs
+++ b/index.bs
@@ -166,6 +166,11 @@ with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomo
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 
+A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
+HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
+{{DRAIN_WEBTRANSPORT_SESSION}} capsule, as described at [[!WEB-TRANSPORT-HTTP3]]
+[section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
+
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
 |code| and an optional [=byte sequence=] |reason|, follow [[!WEB-TRANSPORT-HTTP3]]
 [section 5](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-5).
@@ -175,6 +180,24 @@ an integer |code| and a [=byte sequence=] |reason|, when the HTTP/3 stream assoc
 CONNECT request that initiated |session| is closed by the server, as described at
 [[!WEB-TRANSPORT-HTTP3]]
 [section 5](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-5).
+
+A [=WebTransport session=] has the following signals:
+
+<table class="data" dfn-for="session-signal">
+ <thead>
+  <tr>
+   <th>event
+   <th>definition
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
+   <td>[[!WEB-TRANSPORT-HTTP3]]
+   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
+  </tr>
+ </tbody>
+</table>
 
 <dfn>WebTransport stream</dfn> is a concept for HTTP/3 stream on a [=WebTransport session=].
 
@@ -257,24 +280,6 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
    <td>Yes
    <td>No
    <td>Yes
-  </tr>
- </tbody>
-</table>
-
-A [=WebTransport session=] has the following signals:
-
-<table class="data" dfn-for="session-signal">
- <thead>
-  <tr>
-   <th>event
-   <th>definition
-  </tr>
- </thead>
- <tbody>
-  <tr>
-   <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
-   <td>[[!WEB-TRANSPORT-HTTP3]]
-   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
   </tr>
  </tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -620,7 +620,7 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[Draining]]`</dfn>
-   <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object
+   <td class="non-normative">A promise fulfilled when the associated [=WebTransport sessions=]
    receives a DRAIN_WEBTRANSPORT_SESSION capsule.
   </tr>
   <tr>

--- a/index.bs
+++ b/index.bs
@@ -168,7 +168,7 @@ When establishing a session, the client MUST NOT provide any [=credentials=].
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
-{{DRAIN_WEBTRANSPORT_SESSION}} capsule, as described at [[!WEB-TRANSPORT-HTTP3]]
+[=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, as described at [[!WEB-TRANSPORT-HTTP3]]
 [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
@@ -644,7 +644,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[Draining]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
-   receives a {{DRAIN_WEBTRANSPORT_SESSION}} capsule.
+   receives a [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>
@@ -2008,7 +2008,7 @@ not be immediate due to buffering.
     </thead>
     <tbody>
       <tr>
-        <td>received [=session-signal/DRAIN_WEBTRANSPORT_SESSION=]<td>
+        <td>received [=session-signal/DRAIN_WEBTRANSPORT_SESSION=]</td>
         <td>await wt.{{WebTransport/draining}}</td>
       </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -272,7 +272,6 @@ A [=WebTransport session=] has the following signals:
  </thead>
  <tbody>
   <tr>
-   <td><dfn>draining</dfn> a [=WebTransport session=]
    <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
    <td>[[!WEB-TRANSPORT-HTTP3]]
    [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/432


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/437.html" title="Last updated on Dec 20, 2022, 2:24 PM UTC (23dbaa1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/437/87df5e2...23dbaa1.html" title="Last updated on Dec 20, 2022, 2:24 PM UTC (23dbaa1)">Diff</a>