### PR TITLE
Add order option to createUnidirectionalStream().

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -542,12 +542,13 @@ interface WebTransport {
 
   readonly attribute WebTransportDatagramDuplexStream datagrams;
 
-  Promise&lt;WebTransportBidirectionalStream&gt; createBidirectionalStream();
+  Promise&lt;WebTransportBidirectionalStream&gt; createBidirectionalStream(
+      optional WebTransportSendStreamOptions options = {});
   /* a ReadableStream of WebTransportBidirectionalStream objects */
   readonly attribute ReadableStream incomingBidirectionalStreams;
 
   Promise&lt;WebTransportSendStream&gt; createUnidirectionalStream(
-      optional WebTransportUnidirectionalStreamOptions options = {});
+      optional WebTransportSendStreamOptions options = {});
   /* a ReadableStream of WebTransportReceiveStream objects */
   readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
@@ -1161,32 +1162,32 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportCloseInfo" dict-member>reason</dfn>
 :: The reason for closing the {{WebTransport}}.
 
-## `WebTransportUnidirectionalStreamOptions` Dictionary ##  {#uni-stream-options}
+## `WebTransportSendStreamOptions` Dictionary ##  {#uni-stream-options}
 
-The <dfn dictionary>WebTransportUnidirectionalStreamOptions</dfn> is a
+The <dfn dictionary>WebTransportSendStreamOptions</dfn> is a
 dictionary of parameters that affect how {{WebTransportSendStream}}s created by
-{{WebTransport/createUnidirectionalStream}} behave.
+{{WebTransport/createUnidirectionalStream}} and
+{{WebTransport/createBidirectionalStream}} behave.
 
 <pre class="idl">
-dictionary WebTransportUnidirectionalStreamOptions {
-  unsigned long long order;
+dictionary WebTransportSendStreamOptions {
+  long long sendOrder;
 };
 </pre>
 
 The dictionary SHALL have the following attributes:
 
-: <dfn for="WebTransportUnidirectionalStreamOptions" dict-member>order</dfn>
-:: An order number that, if provided, opts the created
+: <dfn for="WebTransportSendStreamOptions" dict-member>sendOrder</dfn>
+:: An send order number that, if provided, opts the created
    {{WebTransportSendStream}} in to participating in <dfn>strict ordering</dfn>.
    Bytes currently queued on [=strict ordering|strictly ordered=]
    {{WebTransportSendStream}}s MUST be sent ahead of bytes currently queued on
    other [=strict ordering|strictly ordered=] {{WebTransportSendStream}}s
-   created with lower order numbers.
+   created with lower send order numbers.
 
-   If no order number is provided, the created {{WebTransportSendStream}}
-   MUST NOT participate in [=strict ordering=], meaning the order in which the
+   If no send order number is provided, then the order in which the
    user agent sends bytes from it relative to other {{WebTransportSendStream}}s
-   remains [=implementation-defined=].
+   is [=implementation-defined=].
 
    Note: This is sender-side data prioritization which does not guarantee
    reception order.

--- a/index.bs
+++ b/index.bs
@@ -546,7 +546,8 @@ interface WebTransport {
   /* a ReadableStream of WebTransportBidirectionalStream objects */
   readonly attribute ReadableStream incomingBidirectionalStreams;
 
-  Promise&lt;WebTransportSendStream&gt; createUnidirectionalStream();
+  Promise&lt;WebTransportSendStream&gt; createUnidirectionalStream(
+      optional WebTransportUnidirectionalStreamOptions options = {});
   /* a ReadableStream of WebTransportReceiveStream objects */
   readonly attribute ReadableStream incomingUnidirectionalStreams;
 };
@@ -1159,6 +1160,36 @@ The dictionary SHALL have the following attributes:
 :: The error code communicated to the peer.
 : <dfn for="WebTransportCloseInfo" dict-member>reason</dfn>
 :: The reason for closing the {{WebTransport}}.
+
+## `WebTransportUnidirectionalStreamOptions` Dictionary ##  {#uni-stream-options}
+
+The <dfn dictionary>WebTransportUnidirectionalStreamOptions</dfn> is a
+dictionary of parameters that affect how {{WebTransportSendStream}}s created by
+{{WebTransport/createUnidirectionalStream}} behave.
+
+<pre class="idl">
+dictionary WebTransportUnidirectionalStreamOptions {
+  unsigned long long order;
+};
+</pre>
+
+The dictionary SHALL have the following attributes:
+
+: <dfn for="WebTransportUnidirectionalStreamOptions" dict-member>order</dfn>
+:: An order number that, if provided, opts the created
+   {{WebTransportSendStream}} in to participating in <dfn>strict ordering</dfn>.
+   Bytes currently queued on [=strict ordering|strictly ordered=]
+   {{WebTransportSendStream}}s MUST be sent ahead of bytes currently queued on
+   other [=strict ordering|strictly ordered=] {{WebTransportSendStream}}s
+   created with lower order numbers.
+
+   If no order number is provided, the created {{WebTransportSendStream}}
+   MUST NOT participate in [=strict ordering=], meaning the order in which the
+   user agent sends bytes from it relative to other {{WebTransportSendStream}}s
+   remains [=implementation-defined=].
+
+   Note: This is sender-side data prioritization which does not guarantee
+   reception order.
 
 ## `WebTransportStats` Dictionary ##  {#web-transport-stats}
 

--- a/index.bs
+++ b/index.bs
@@ -903,6 +903,8 @@ these steps.
    1. Let |transport| be [=this=].
    1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
       return a new [=rejected=] promise with an {{InvalidStateError}}.
+   1. Let |sendOrder| be {{WebTransport/createBidirectionalStream(options)/options}}'s
+      {{WebTransportSendStreamOptions/sendOrder}}.
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
@@ -916,7 +918,7 @@ these steps.
         1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
            [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
         1. Let |stream| be the result of [=BidirectionalStream/creating=] a
-           {{WebTransportBidirectionalStream}} with |internalStream| and |transport|.
+           {{WebTransportBidirectionalStream}} with |internalStream|, |transport|, and |sendOrder|.
         1. [=Resolve=] |p| with |stream|.
    1. return |p|.
 
@@ -931,6 +933,8 @@ these steps.
      1. Let |transport| be [=this=].
      1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
         return a new [=rejected=] promise with an {{InvalidStateError}}.
+     1. Let |sendOrder| be {{WebTransport/createUnidirectionalStream(options)/options}}'s
+        {{WebTransportSendStreamOptions/sendOrder}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
         {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
@@ -944,7 +948,7 @@ these steps.
           1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
           1. Let |stream| be the result of [=WebTransportSendStream/creating=] a {{WebTransportSendStream}} with
-             |internalStream| and |transport|.
+             |internalStream|, |transport|, and |sendOrder|.
           1. [=Resolve=] |p| with |stream|.
      1. return |p|.
 
@@ -1171,7 +1175,7 @@ dictionary of parameters that affect how {{WebTransportSendStream}}s created by
 
 <pre class="idl">
 dictionary WebTransportSendStreamOptions {
-  long long sendOrder;
+  long long? sendOrder = null;
 };
 </pre>
 
@@ -1341,6 +1345,10 @@ A {{WebTransportSendStream}} has the following internal slots.
    <td><dfn>`[[Transport]]`</dfn>
    <td class="non-normative">A {{WebTransport}} which owns this {{WebTransportSendStream}}.
   </tr>
+  <tr>
+   <td><dfn>`[[SendOrder]]`</dfn>
+   <td class="non-normative">An optional send order number, or null.
+  </tr>
  <tbody>
 </table>
 
@@ -1350,7 +1358,7 @@ A {{WebTransportSendStream}} has the following internal slots.
 
 To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
 {{WebTransportSendStream}}, with an [=outgoing unidirectional=] or [=bidirectional=] [=WebTransport stream=]
-|internalStream| and a {{WebTransport}} |transport|, run these steps:
+|internalStream|, a {{WebTransport}} |transport|, and a |sendOrder|, run these steps:
 
 1. Let |stream| be a [=new=] {{WebTransportSendStream}}, with:
     : {{WebTransportSendStream/[[InternalStream]]}}
@@ -1359,6 +1367,8 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
     :: null
     : {{WebTransportSendStream/[[Transport]]}}
     :: |transport|
+    : {{WebTransportSendStream/[[SendOrder]]}}
+    :: |sendOrder|
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
 1. Let |closeAlgorithm| be an action that [=closes=] |stream|.
 1. Let |abortAlgorithm| be an action that [=aborts=] |stream| with |reason|, given |reason|.
@@ -1779,13 +1789,13 @@ A {{WebTransportBidirectionalStream}} has the following internal slots.
 
 <div algorithm="create a BidirectionalStream">
 To <dfn for=BidirectionalStream>create</dfn> a {{WebTransportBidirectionalStream}} with a
-[=bidirectional=] [=WebTransport stream=] |internalStream| and a {{WebTransport}}
-object |transport|, run these steps.
+[=bidirectional=] [=WebTransport stream=] |internalStream|, a {{WebTransport}}
+object |transport|, and a |sendOrder|, run these steps.
 
 1. Let |readable| be the result of [=WebTransportReceiveStream/creating=] a {{WebTransportReceiveStream}} with
    |internalStream| and |transport|.
 1. Let |writable| be the result of [=WebTransportSendStream/creating=] a {{WebTransportSendStream}} with
-   |internalStream| and |transport|.
+   |internalStream|, |transport|, and |sendOrder|.
 1. Let |stream| be a [=new=] {{WebTransportBidirectionalStream}}, with:
     : {{WebTransportBidirectionalStream/[[Readable]]}}
     :: |readable|


### PR DESCRIPTION
Fixed #431.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/438.html" title="Last updated on Dec 20, 2022, 6:12 AM UTC (44b090b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/438/87df5e2...jan-ivar:44b090b.html" title="Last updated on Dec 20, 2022, 6:12 AM UTC (44b090b)">Diff</a>