### PR TITLE
Allow opening streams in parallel to the CONNECT request

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -905,7 +905,6 @@ these steps.
    1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
       [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}.
-      1. Wait for |transport|.{{[[State]]}} to be `"connected"`.
       1. Let |internalStream| be the result of [=creating a bidirectional stream=] with
          |transport|.{{[[Session]]}}.
 
@@ -933,7 +932,6 @@ these steps.
      1. Run the following steps [=in parallel=], but abort them whenever |transport|'s
         {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
         [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}.
-        1. Wait for |transport|.{{[[State]]}} to be `"connected"`.
         1. Let |internalStream| be the result of [=creating an outgoing unidirectional stream=] with
            |transport|.{{[[Session]]}}.
 


### PR DESCRIPTION
Fixes: https://github.com/w3c/webtransport/issues/435

Note: Writing datagrams while the transport's state  is `"connecting"` is already allowed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/440.html" title="Last updated on Dec 4, 2022, 11:55 PM UTC (84e4710)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/440/5841bfe...84e4710.html" title="Last updated on Dec 4, 2022, 11:55 PM UTC (84e4710)">Diff</a>