### PR TITLE
Define default send order.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1361,10 +1361,18 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the
    operation to complete.
-   This sending MAY be interleaved with sending of previously queued streams and datagrams,
-   as well as streams and datagrams yet to be queued to be sent over this transport.
+   By default, if no order is specified, the prioritization of this sending of
+   bytes is [=implementation-defined=], but SHOULD, to the extent allowed by
+   flow control, be interleaved with sending of any previously queued bytes on
+   other streams and datagrams, as well as bytes yet to be queued on other
+   streams and datagrams to be sent over this transport, regardless of whether
+   the other streams and datagrams are strictly ordered or not.
 
-   Note: Solving prioritization is an outstanding issue.
+   If an order is specified, bytes queued on streams with the same order number
+   SHOULD be sent at equal rates, to the extent allowed by flow control, but
+   MUST be sent ahead of bytes queued on streams with a lower order number,
+   unless blocked by flow control.
+
 1. If the previous step failed, abort the remaining steps.
 
   Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps

--- a/index.bs
+++ b/index.bs
@@ -258,6 +258,14 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
    <td>No
    <td>Yes
   </tr>
+  <tr>
+   <td><dfn>flow control</dfn>
+   <td>[[!QUIC]]
+   [section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-quic-transport#section-4.1)
+   <td>No
+   <td>Yes
+   <td>Yes
+  </tr>
  </tbody>
 </table>
 
@@ -1361,17 +1369,17 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Return |promise| and run the remaining steps [=in parallel=].
 1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the
    operation to complete.
-   By default, if no order is specified, the prioritization of this sending of
-   bytes is [=implementation-defined=], but SHOULD, to the extent allowed by
-   flow control, be interleaved with sending of any previously queued bytes on
-   other streams and datagrams, as well as bytes yet to be queued on other
-   streams and datagrams to be sent over this transport, regardless of whether
-   the other streams and datagrams are strictly ordered or not.
+   This sending MAY be interleaved with sending of previously queued streams and datagrams,
+   as well as streams and datagrams yet to be queued to be sent over this transport.
 
-   If an order is specified, bytes queued on streams with the same order number
-   SHOULD be sent at equal rates, to the extent allowed by flow control, but
-   MUST be sent ahead of bytes queued on streams with a lower order number,
-   unless blocked by flow control.
+   If |stream|.{{[[SendOrder]]}} is `null` then this sending MUST NOT starve
+   except for [=flow control=] reasons or [=WritableStream/Error | error=].
+
+   If |stream|.{{[[SendOrder]]}} is not `null` then this sending MUST starve
+   until all bytes queued for sending on {{WebTransportSendStream}}s with a
+   non-null and higher {{[[SendOrder]]}}, that are neither
+   [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
+   sent.
 
 1. If the previous step failed, abort the remaining steps.
 


### PR DESCRIPTION
Fixes #428. Contains tentative language based on assumptions in https://github.com/w3c/webtransport/pull/438.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/441.html" title="Last updated on Dec 7, 2022, 11:05 PM UTC (d40fceb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/441/5841bfe...jan-ivar:d40fceb.html" title="Last updated on Dec 7, 2022, 11:05 PM UTC (d40fceb)">Diff</a>