### PR TITLE
Align WebTransportError with guidance.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1720,8 +1720,7 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportReceiveStream
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.
   1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"stream"`.
-  1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |code|.
+     `"stream"` and |code|.
   1. [=ReadableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1832,17 +1831,17 @@ object |transport|, and a |sendOrder|, run these steps.
  - A reason for a client-initiated abort operation.
 
 <pre class="idl">
-[Exposed=(Window,Worker), SecureContext]
+[Exposed=(Window,Worker), Serializable, SecureContext]
 interface WebTransportError : DOMException {
-  constructor(optional WebTransportErrorInit init = {});
+  constructor(optional DOMString message = "", WebTransportErrorOptions options = {});
 
   readonly attribute WebTransportErrorSource source;
   readonly attribute octet? streamErrorCode;
 };
 
-dictionary WebTransportErrorInit {
-  [Clamp] octet streamErrorCode;
-  DOMString message;
+dictionary WebTransportErrorOptions {
+  WebTransportErrorSource source = "stream";
+  [Clamp] octet? streamErrorCode = null;
 };
 
 enum WebTransportErrorSource {
@@ -1877,14 +1876,30 @@ A {{WebTransportError}} has the following internal slots.
 ## Constructor ##  {#web-transport-error-constructor1}
 
 <div algorithm>
+To <dfn for="WebTransportError">create</dfn> a {{WebTransportError}} error with a
+{{WebTransportErrorSource}} |source| and optionally a |streamErrorCode| defaulting
+to `null`, run these steps:
+1. Let |message| be an [=implementation-defined=] string.
+1. Let |options| be `{source, streamErrorCode}`.
+1. Return a new {{WebTransportError/constructor()}} with |message| and |options|.
+</div>
+
+<div algorithm>
 
 The <dfn constructor for="WebTransportError"
-lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps are:
+lt="WebTransportError(message, options)">new WebTransportError(message, options)</dfn>
+constructor steps are:
 
-1. Let |error| be [=this=].
-1. Let |message| be |init|.{{WebTransportErrorInit/message}} if it exists, and `""` otherwise.
-1. [=WebTransportError/Set up=] |error| with |message| and `"stream"`.
-1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |init|.{{WebTransportErrorInit/streamErrorCode}} if it exists.
+1. Set |this|'s internal slots as follows:
+    : {{WebTransportError/[[Source]]}}
+    :: |options|.{{WebTransportErrorOptions/source}}
+    : {{WebTransportError/[[StreamErrorCode]]}}
+    :: |options|.{{WebTransportErrorOptions/streamErrorCode}}
+1. Run the [=DOMException/new DOMException(message, name)=] constructor steps on
+   [=this=] with |message| and `"WebTransportError"`.
+
+   Note: This name does not have a mapping to a legacy code, so [=this=]'s {{DOMException/code}}
+   is 0.
 
 </div>
 
@@ -1895,34 +1910,22 @@ lt="WebTransportError(init)">new WebTransportError(init)</dfn> constructor steps
 : <dfn for="WebTransportError" attribute>streamErrorCode</dfn>
 :: The getter steps are to return [=this=]'s {{WebTransportError/[[StreamErrorCode]]}}.
 
-## Procedures ## {#web-transport-error-procedures}
+## Serialization ## {#web-transport-error-serialization}
 
 <div algorithm>
 
-To <dfn for="WebTransportError">create</dfn> a {{WebTransportError}} |error| with a
-{{WebTransportErrorSource}} |source|, run these steps:
+{{WebTransportError}} objects are [=serializable objects=].
+Their [=serialization steps=], given |value| and |serialized|, are:
 
-1. Let |message| be an [=implementation-defined=] string.
-1. Let |error| be a [=new=] {{WebTransportError}}.
-1. [=Set up=] |error| with |message| and |source|.
+1. Run the {{DOMException}} [=serialization steps=] given |value| and |serialized|.
+1. Set |serialized|.`[[Source]]` to |value|.{{WebTransportError/[[Source]]}}.
+1. Set |serialized|.`[[StreamErrorCode]]` to |value|.{{WebTransportError/[[StreamErrorCode]]}}.
 
-</div>
+Their [=deserialization steps=], given |serialized| and |value|, are:
 
-<div algorithm>
-
-To <dfn for="WebTransportError">set up</dfn> a {{WebTransportError}} |error| with a {{DOMString}}
-|message| and a {{WebTransportErrorSource}} |source|, run these steps:
-
-1. Set |error|'s internal slots as:
-    : {{WebTransportError/[[StreamErrorCode]]}}
-    :: null
-    : {{WebTransportError/[[Source]]}}
-    :: |source|
-1. Run [=DOMException/new DOMException(message, name)=] constructor steps with |error|, |message|
-   and `"WebTransportError"`.
-
-   Note: This name does not have a mapping to a legacy code, so [=this=]'s {{DOMException/code}}
-   is 0.
+1. Run the {{DOMException}} [=deserialization steps=] given |serialized| and |value|.
+1. Set |value|.{{WebTransportError/[[Source]]}} to |serialized|.`[[Source]]`.
+1. Set |value|.{{WebTransportError/[[StreamErrorCode]]}} |serialized|.`[[StreamErrorCode]]`.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -73,7 +73,9 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: settled; url: sec-promise-objects
 urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
   type: dfn
-    text: new DOMException(message, name); for:DOMException; url: dom-domexception-domexception
+    text: created; for:DOMException; url: dfn-create-exception
+    text: name; for:DOMException; url: domexception-name
+    text: message; for:DOMException; url: domexception-message
 </pre>
 
 # Introduction #    {#introduction}
@@ -730,8 +732,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    returns <b>blocked</b>, then abort the remaining steps and [=queue a network task=] with |transport|
    to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. [=Cleanup=] |transport| with |error|.
 1. Let |networkPartitionKey| be the result of [=determining the network partition key=] with
    |transport|'s [=relevant settings object=].
@@ -744,8 +746,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. [=Cleanup=] |transport| with |error|.
 1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
    represents the SETTINGS frame.
@@ -753,8 +755,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
    contain H3_DATAGRAM with a value of 1, then abort the remaining steps and [=queue a network
    task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. [=Cleanup=] |transport| with |error|.
 1. [=session/Establish=] a [=WebTransport session=] with |origin| on |connection|.
 
@@ -763,8 +765,8 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 1. If the previous step fails, abort the remaining steps and [=queue a network task=] with
    |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. [=Cleanup=] |transport| with |error|.
 1. Let |session| be the established [=WebTransport session=].
 1. Assert: |maxDatagramSize| is an integer.
@@ -866,8 +868,8 @@ these steps.
      1. Let |transport| be [=this=].
      1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
      1. If |transport|.{{[[State]]}} is `"connecting"`:
-       1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-          `"session"`.
+       1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+          {{WebTransportErrorOptions/source}} is `"session"`.
        1. [=Cleanup=] |transport| with |error|.
        1. Abort these steps.
      1. Let |session| be |transport|.{{[[Session]]}}.
@@ -1011,8 +1013,8 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
    request that initiated |transport|.{{[[Session]]}} is in the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. If |cleanly| is false, then [=cleanup=] |transport| with |error|, and abort these steps.
   1. Let |closeInfo| be a [=new=] {{WebTransportCloseInfo}}.
   1. If |code| is given, set |closeInfo|'s {{WebTransportCloseInfo/closeCode}} to |code|.
@@ -1028,8 +1030,8 @@ run these steps:
 
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"session"`.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"session"`.
   1. [=Cleanup=] |transport| with |error|.
 
 </div>
@@ -1461,7 +1463,7 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
 1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
-1. If |reason| is a {{WebTransportError}} and |reasons|.{{WebTransportError/[[StreamErrorCode]]}} is not
+1. If |reason| is a {{WebTransportError}} and |reason|.{{WebTransportError/[[StreamErrorCode]]}} is not
    null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
@@ -1490,9 +1492,9 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportSendStream}} 
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"stream"`.
-  1. Set |error|.{{WebTransportError/[[StreamErrorCode]]}} to |code|.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"stream"` and
+     {{WebTransportErrorOptions/streamErrorCode}} is |code|.
   1. [=WritableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1683,7 +1685,7 @@ steps.
 1. Let |internalStream| be |stream|.{{WebTransportReceiveStream/[[InternalStream]]}}.
 1. Let |promise| be a new promise.
 1. Let |code| be 0.
-1. If |reason| is a {{WebTransportError}} and |reasons|.{{WebTransportError/[[StreamErrorCode]]}} is not
+1. If |reason| is a {{WebTransportError}} and |reason|.{{WebTransportError/[[StreamErrorCode]]}} is not
    null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
 1. If |code| > 255, then set |code| to 255.
@@ -1719,8 +1721,9 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportReceiveStream
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. [=set/Remove=] |stream| from |transport|.{{[[ReceiveStreams]]}}.
-  1. Let |error| be the result of [=WebTransportError/creating=] a {{WebTransportError}} with
-     `"stream"` and |code|.
+  1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+     {{WebTransportErrorOptions/source}} is `"stream"` and
+     {{WebTransportErrorOptions/streamErrorCode}} is |code|.
   1. [=ReadableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1877,29 +1880,17 @@ A {{WebTransportError}} has the following internal slots.
 
 <div algorithm>
 
-To <dfn for="WebTransportError">create</dfn> a {{WebTransportError}} error with a
-{{WebTransportErrorSource}} |source| and optionally a |streamErrorCode| defaulting
-to `null`, run these steps:
-
-1. Let |message| be an [=implementation-defined=] string.
-1. Let |options| be `{source, streamErrorCode}`.
-1. Return a new {{WebTransportError/constructor()}} with |message| and |options|.
-
-</div>
-
-<div algorithm>
-
 The <dfn constructor for="WebTransportError"
 lt="WebTransportError(message, options)">new WebTransportError(message, options)</dfn>
 constructor steps are:
 
+1. Set |this|'s [=DOMException/name=] to `"WebTransportError"`.
+1. Set |this|'s [=DOMException/message=] to |message|.
 1. Set |this|'s internal slots as follows:
     : {{WebTransportError/[[Source]]}}
     :: |options|.{{WebTransportErrorOptions/source}}
     : {{WebTransportError/[[StreamErrorCode]]}}
     :: |options|.{{WebTransportErrorOptions/streamErrorCode}}
-1. Run the [=DOMException/new DOMException(message, name)=] constructor steps on
-   [=this=] with |message| and `"WebTransportError"`.
 
    Note: This name does not have a mapping to a legacy code, so [=this=]'s {{DOMException/code}}
    is 0.

--- a/index.bs
+++ b/index.bs
@@ -1833,7 +1833,7 @@ object |transport|, and a |sendOrder|, run these steps.
 <pre class="idl">
 [Exposed=(Window,Worker), Serializable, SecureContext]
 interface WebTransportError : DOMException {
-  constructor(optional DOMString message = "", WebTransportErrorOptions options = {});
+  constructor(optional DOMString message = "", optional WebTransportErrorOptions options = {});
 
   readonly attribute WebTransportErrorSource source;
   readonly attribute octet? streamErrorCode;
@@ -1876,12 +1876,15 @@ A {{WebTransportError}} has the following internal slots.
 ## Constructor ##  {#web-transport-error-constructor1}
 
 <div algorithm>
+
 To <dfn for="WebTransportError">create</dfn> a {{WebTransportError}} error with a
 {{WebTransportErrorSource}} |source| and optionally a |streamErrorCode| defaulting
 to `null`, run these steps:
+
 1. Let |message| be an [=implementation-defined=] string.
 1. Let |options| be `{source, streamErrorCode}`.
 1. Return a new {{WebTransportError/constructor()}} with |message| and |options|.
+
 </div>
 
 <div algorithm>
@@ -1912,8 +1915,6 @@ constructor steps are:
 
 ## Serialization ## {#web-transport-error-serialization}
 
-<div algorithm>
-
 {{WebTransportError}} objects are [=serializable objects=].
 Their [=serialization steps=], given |value| and |serialized|, are:
 
@@ -1926,8 +1927,6 @@ Their [=deserialization steps=], given |serialized| and |value|, are:
 1. Run the {{DOMException}} [=deserialization steps=] given |serialized| and |value|.
 1. Set |value|.{{WebTransportError/[[Source]]}} to |serialized|.`[[Source]]`.
 1. Set |value|.{{WebTransportError/[[StreamErrorCode]]}} |serialized|.`[[StreamErrorCode]]`.
-
-</div>
 
 # Protocol Mappings # {#protocol-mapping}
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/425, https://github.com/w3c/webtransport/issues/458, https://github.com/w3c/webtransport/issues/459.

See https://whatpr.org/webidl/1211.html#example-domexception-derived-interface for guidance.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/460.html" title="Last updated on Jan 25, 2023, 5:52 PM UTC (213189c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/460/bb7a74b...jan-ivar:213189c.html" title="Last updated on Jan 25, 2023, 5:52 PM UTC (213189c)">Diff</a>