### PR TITLE
Linkify "fire an event" concept to clarify steps and interface

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1934,7 +1934,7 @@ it MUST [=queue a network task=] with |transport| to run these steps:
 
 1. Set |transport|.{{WebTransport/rateControlFeedback}}.{{WebTransportRateControlFeedback/[[SendRate]]}}
     to the new rate for [=WebTransport session=].
-1. Fire an event named {{WebTransport/ratecontrolfeedback}} at |transport|.
+1. [=Fire an event=] named {{WebTransport/ratecontrolfeedback}} at |transport|.
 
 </div>
 


### PR DESCRIPTION
This wraps the "Fire an event" term to its definition in the DOM spec. This is useful to clarify what this means and in particular that the event will use the `Event` interface.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/webtransport/pull/473.html" title="Last updated on Feb 16, 2023, 8:16 AM UTC (ef2efaa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/473/6e4b8b7...tidoust:ef2efaa.html" title="Last updated on Feb 16, 2023, 8:16 AM UTC (ef2efaa)">Diff</a>