### PR TITLE
Receiving a GOAWAY frame or DRAIN_WEBTRANSPORT_SESSION capsule

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -174,7 +174,7 @@ A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
 [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when an HTTP/3
 [=session-signal/GOAWAY=] frame is received, as described in [[!WEB-TRANSPORT-HTTP3]]
-[section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
+[Section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
 |code| and an optional [=byte sequence=] |reason|, follow [[!WEB-TRANSPORT-HTTP3]]

--- a/index.bs
+++ b/index.bs
@@ -238,7 +238,6 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
  </tbody>
 </table>
 
-
 A [=WebTransport session=] has the following signals:
 
 <table class="data" dfn-for="session-signal">

--- a/index.bs
+++ b/index.bs
@@ -634,7 +634,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[State]]`</dfn>
    <td class="non-normative">An enum indicating the state of the transport. One of `"connecting"`,
-`  "connected"`, `"draining"`, `"closed"`, and `"failed"`.
+   `"connected"`, `"draining"`, `"closed"`, and `"failed"`.
   </tr>
   <tr>
    <td><dfn>`[[Ready]]`</dfn>

--- a/index.bs
+++ b/index.bs
@@ -170,6 +170,11 @@ with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomo
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 
+A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
+HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
+[=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, as described at [[!WEB-TRANSPORT-HTTP3]]
+[section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
+
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
 |code| and an optional [=byte sequence=] |reason|, follow [[!WEB-TRANSPORT-HTTP3]]
 [section 5](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-5).
@@ -229,6 +234,25 @@ A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn
    <td>No
    <td>Yes
    <td>Yes
+  </tr>
+ </tbody>
+</table>
+
+
+A [=WebTransport session=] has the following signals:
+
+<table class="data" dfn-for="session-signal">
+ <thead>
+  <tr>
+   <th>event
+   <th>definition
+  </tr>
+ </thead>
+ <tbody>
+  <tr>
+   <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
+   <td>[[!WEB-TRANSPORT-HTTP3]]
+   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
   </tr>
  </tbody>
 </table>
@@ -551,6 +575,7 @@ interface WebTransport : EventTarget {
   readonly attribute WebTransportReliabilityMode reliability;
   readonly attribute WebTransportCongestionControl congestionControl;
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
+  readonly attribute Promise&lt;undefined&gt; draining;
   undefined close(optional WebTransportCloseInfo closeInfo = {});
 
   readonly attribute WebTransportDatagramDuplexStream datagrams;
@@ -610,7 +635,7 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[State]]`</dfn>
    <td class="non-normative">An enum indicating the state of the transport. One of `"connecting"`,
-   `"connected"`, `"closed"`, and `"failed"`.
+`  "connected"`, `"draining"`, `"closed"`, and `"failed"`.
   </tr>
   <tr>
    <td><dfn>`[[Ready]]`</dfn>
@@ -645,6 +670,11 @@ A {{WebTransport}} object has the following internal slots.
    <td><dfn>`[[Closed]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
    closed gracefully, or rejected when it is closed abruptly or failed on initialization.
+  </tr>
+  <tr>
+   <td><dfn>`[[Draining]]`</dfn>
+   <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
+   receives a [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>
@@ -710,6 +740,8 @@ agent MUST run the following steps:
     : {{[[RateControlFeedback]]}}
     :: |rateControlFeedback|
     : {{[[Closed]]}}
+    :: a new promise
+    : {{[[Draining]]}}
     :: a new promise
     : {{[[Datagrams]]}}
     :: |datagrams|
@@ -851,6 +883,8 @@ these steps.
 :: On getting, it MUST return [=this=]'s {{[[Ready]]}}.
 : <dfn for="WebTransport" attribute>closed</dfn>
 :: On getting, it MUST return [=this=]'s {{[[Closed]]}}.
+: <dfn for="WebTransport" attribute>draining</dfn>
+:: On getting, it MUST return [=this=]'s {{[[Draining]]}}.
 : <dfn for="WebTransport" attribute>datagrams</dfn>
 :: A single duplex stream for sending and receiving datagrams over this session.
    The getter steps for the `datagrams` attribute SHALL be:
@@ -2127,6 +2161,23 @@ converted to an httpErrorCode, and vice versa, as specified in [[!WEB-TRANSPORT-
         <td>Network error<br>
         <td>(await wt.{{WebTransport/closed}}) rejects, and
           [=ReadableStream/error|errors=] open streams</td>
+      </tr>
+    </tbody>
+  </table>
+  
+  <table class="data">
+    <colgroup class="header"><col></colgroup>
+    <colgroup><col></colgroup>
+    <thead>
+      <tr>
+        <th>WebTransport Protocol Action</th>
+        <th>API Effect</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>received [=session-signal/DRAIN_WEBTRANSPORT_SESSION=]</td>
+        <td>await wt.{{WebTransport/draining}}</td>
       </tr>
     </tbody>
   </table>

--- a/index.bs
+++ b/index.bs
@@ -190,7 +190,7 @@ CONNECT request that initiated |session| is closed by the server, as described a
 A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn>,
 <dfn for=stream>outgoing unidirectional</dfn> or <dfn for=stream>bidirectional</dfn>.
 
-[=WebTransport stream=] has the following capabilities:
+A [=WebTransport stream=] has the following capabilities:
 
 <table class="data" dfn-for="stream">
  <thead>
@@ -256,7 +256,7 @@ A [=WebTransport session=] has the following signals:
  </tbody>
 </table>
 
-[=WebTransport stream=] has the following signals:
+A [=WebTransport stream=] has the following signals:
 
 <table class="data" dfn-for="stream-signal">
  <thead>

--- a/index.bs
+++ b/index.bs
@@ -257,7 +257,7 @@ A [=WebTransport session=] has the following signals:
   <tr>
    <td><dfn>GOAWAY</dfn>
    <td>[[!WEB-TRANSPORT-HTTP3]]
-   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
+   [Section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
   </tr>
  </tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -172,7 +172,8 @@ When establishing a session, the client MUST NOT provide any [=credentials=].
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
-[=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, as described at [[!WEB-TRANSPORT-HTTP3]]
+[=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when an HTTP/3
+[=session-signal/GOAWAY=] frame is received, as described at [[!WEB-TRANSPORT-HTTP3]]
 [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
@@ -250,6 +251,11 @@ A [=WebTransport session=] has the following signals:
  <tbody>
   <tr>
    <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
+   <td>[[!WEB-TRANSPORT-HTTP3]]
+   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
+  </tr>
+  <tr>
+   <td><dfn>GOAWAY</dfn>
    <td>[[!WEB-TRANSPORT-HTTP3]]
    [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
   </tr>
@@ -673,7 +679,8 @@ A {{WebTransport}} object has the following internal slots.
   <tr>
    <td><dfn>`[[Draining]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated [=WebTransport session=]
-   receives a [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule.
+   receives a [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule or a
+   [=session-signal/GOAWAY=] frame.
   </tr>
   <tr>
    <td><dfn>`[[Datagrams]]`</dfn>
@@ -2176,6 +2183,23 @@ converted to an httpErrorCode, and vice versa, as specified in [[!WEB-TRANSPORT-
     <tbody>
       <tr>
         <td>received [=session-signal/DRAIN_WEBTRANSPORT_SESSION=]</td>
+        <td>await wt.{{WebTransport/draining}}</td>
+      </tr>
+    </tbody>
+  </table>
+  
+  <table class="data">
+    <colgroup class="header"><col></colgroup>
+    <colgroup><col></colgroup>
+    <thead>
+      <tr>
+        <th>HTTP/3 Protocol Action</th>
+        <th>API Effect</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>received [=session-signal/GOAWAY=]</td>
         <td>await wt.{{WebTransport/draining}}</td>
       </tr>
     </tbody>

--- a/index.bs
+++ b/index.bs
@@ -252,7 +252,7 @@ A [=WebTransport session=] has the following signals:
   <tr>
    <td><dfn>DRAIN_WEBTRANSPORT_SESSION</dfn>
    <td>[[!WEB-TRANSPORT-HTTP3]]
-   [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
+   [Section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6)
   </tr>
   <tr>
    <td><dfn>GOAWAY</dfn>

--- a/index.bs
+++ b/index.bs
@@ -173,7 +173,7 @@ When establishing a session, the client MUST NOT provide any [=credentials=].
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 HTTP/3 stream associated with the CONNECT request that initiated |session| receives an
 [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when an HTTP/3
-[=session-signal/GOAWAY=] frame is received, as described at [[!WEB-TRANSPORT-HTTP3]]
+[=session-signal/GOAWAY=] frame is received, as described in [[!WEB-TRANSPORT-HTTP3]]
 [section 4.6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-4.6).
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer


### PR DESCRIPTION
Fixes #432 

Rebase of #437

Based on merged PR 79: https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http3/pull/79 which is now included in https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/482.html" title="Last updated on Mar 14, 2023, 4:17 AM UTC (8c4f7c0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/482/7d621a5...8c4f7c0.html" title="Last updated on Mar 14, 2023, 4:17 AM UTC (8c4f7c0)">Diff</a>