### PR TITLE
Support BYOB Readers for Datagrams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -490,9 +490,9 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
         with |error|.
     1. Return [=a promise rejected with=] |error|.
   1. Set |offset| to |view|.\[[ByteOffset]].
-  1. Set |maxBytes| to |view|'s [=BufferSource/byte length=].
+  1. Set |maxBytes| to the size of |datagram|.
   1. Set |buffer| to |view|'s [=BufferSource/underlying buffer=].
-  1. Set |chunk| to |view|.
+  1. Set |chunk| to a new {{Uint8Array}} object with |buffer|, |offset|, and the size of |datagram|.
 1. Otherwise:
   1. Set |offset| to 0.
   1. Set |maxBytes| to the size of |datagram|.

--- a/index.bs
+++ b/index.bs
@@ -494,7 +494,7 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
     1. Set |chunk| to |view|.
 1. Otherwise:
   1. Set |offset| to 0.
-  1. Set |maxBytes| to an [=implementation-defined=] size.
+  1. Set |maxBytes| to the size of |bytes|.
   1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
      {{ArrayBuffer}} fails, return [=a promise rejected with=] a {{RangeError}}.
   1. Set |chunk| to a new {{Uint8Array}} object with |buffer| and |offset|.
@@ -766,6 +766,7 @@ agent MUST run the following steps:
 Note: Using 64kB buffers with datagrams is recommended because the effective
 maximum WebTransport datagram frame size has an upper bound of the QUIC maximum datagram frame size
 which is recommended to be 64kB (See [[!QUIC-DATAGRAM]] [Section 3](https://datatracker.ietf.org/doc/html/rfc9221#section-3)).
+This will ensure the stream is not errored due to a datagram being larger than the buffer.
 
 1. [=ReadableStream/Set up with byte reading support=] |incomingDatagrams| with
    [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to

--- a/index.bs
+++ b/index.bs
@@ -484,19 +484,12 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
    [=ReadableStream/current BYOB request view=] is not null, then:
   1. Let |view| be |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
      [=ReadableStream/current BYOB request view=].
-  1. If |view|'s [=BufferSource/byte length=] is less than the size of |datagram|, then:
-    1. Let |error| be a new {{RangeError}} exception.
-    1. [=ReadableStream/Error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
-        with |error|.
-    1. Return [=a promise rejected with=] |error|.
+  1. If |view|'s [=BufferSource/byte length=] is less than the size of |datagram|, return
+     [=a promise rejected with=] a {{RangeError}}.
   1. Let |elementSize| be the element size specified in [=the typed array constructors table=] for
      |view|.\[[TypedArrayName]]. If |view| does not have a \[[TypedArrayName]] internal slot
      (i.e. it is a {{DataView}}), let |elementSize| be 0.
-  1. If |elementSize| is not 1, then:
-    1. Let |error| be a new {{TypeError}} exception.
-    1. [=ReadableStream/Error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
-        with |error|.
-    1. Return [=a promise rejected with=] |error|.
+  1. If |elementSize| is not 1, return [=a promise rejected with=] a {{TypeError}}.
 1. [=ReadableStream/Pull from bytes=] |datagram| into |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Return [=a promise resolved with=] undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -478,13 +478,13 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
 1. If |queue| is empty, then:
   1. Set |datagrams|.{{[[IncomingDatagramsPullPromise]]}} to a new promise.
   1. Return |datagrams|.{{[[IncomingDatagramsPullPromise]]}}.
-1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
+1. Let |datagram| and |timestamp| be the result of [=dequeuing=] |queue|.
 1. Let |buffer|, |offset|, |maxBytes|, and |chunk| be null.
 1. If |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
    [=ReadableStream/current BYOB request view=] is not null, then:
   1. Let |view| be |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
      [=ReadableStream/current BYOB request view=].
-  1. If |view|'s [=BufferSource/byte length=] is less than the size of |bytes|,
+  1. If |view|'s [=BufferSource/byte length=] is less than the size of |datagram|,
      [=ReadableStream/error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
      with a {{RangeError}}.
   1. Otherwise:
@@ -494,11 +494,11 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
     1. Set |chunk| to |view|.
 1. Otherwise:
   1. Set |offset| to 0.
-  1. Set |maxBytes| to the size of |bytes|.
+  1. Set |maxBytes| to the size of |datagram|.
   1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
      {{ArrayBuffer}} fails, return [=a promise rejected with=] a {{RangeError}}.
   1. Set |chunk| to a new {{Uint8Array}} object with |buffer| and |offset|.
-1. Write |bytes| into |buffer| with offset |offset|, up to |maxBytes| bytes.
+1. Write |datagram| into |buffer| with offset |offset|, up to |maxBytes| bytes.
 1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Return [=a promise resolved with=] undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -479,8 +479,27 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
   1. Set |datagrams|.{{[[IncomingDatagramsPullPromise]]}} to a new promise.
   1. Return |datagrams|.{{[[IncomingDatagramsPullPromise]]}}.
 1. Let |bytes| and |timestamp| be the result of [=dequeuing=] |queue|.
-1. Let |chunk| be a new {{Uint8Array}} object representing |bytes|.
-1. [=ReadableStream/Enqueue=] |chunk| to |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
+1. Let |buffer|, |offset|, |maxBytes|, and |chunk| be null.
+1. If |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
+   [=ReadableStream/current BYOB request view=] is not null, then:
+  1. Let |view| be |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
+     [=ReadableStream/current BYOB request view=].
+  1. If |view|'s [=BufferSource/byte length=] is less than the size of |bytes|,
+     [=ReadableStream/error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+     with a {{RangeError}}.
+  1. Otherwise:
+    1. Set |offset| to |view|.\[[ByteOffset]].
+    1. Set |maxBytes| to |view|'s [=BufferSource/byte length=].
+    1. Set |buffer| to |view|'s [=BufferSource/underlying buffer=].
+    1. Set |chunk| to |view|.
+1. Otherwise:
+  1. Set |offset| to 0.
+  1. Set |maxBytes| to an [=implementation-defined=] size.
+  1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
+     {{ArrayBuffer}} fails, return [=a promise rejected with=] a {{RangeError}}.
+  1. Set |chunk| to a new {{Uint8Array}} object with |buffer| and |offset|.
+1. Write |bytes| into |buffer| with offset |offset|, up to |maxBytes| bytes.
+1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Return [=a promise resolved with=] undefined.
 
 To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:
@@ -743,8 +762,14 @@ agent MUST run the following steps:
     :: null
 1. Let |pullDatagramsAlgorithm| be an action that runs [=pullDatagrams=] with |transport|.
 1. Let |writeDatagramsAlgorithm| be an action that runs [=writeDatagrams=] with |transport|.
-1. [=ReadableStream/Set up=] |incomingDatagrams| with [=ReadableStream/set up/pullAlgorithm=]
-   set to |pullDatagramsAlgorithm|, and [=ReadableStream/set up/highWaterMark=] set to 0.
+
+Note: Using 64kB buffers with datagrams is recommended because the effective
+maximum WebTransport datagram frame size has an upper bound of the QUIC maximum datagram frame size
+which is recommended to be 64kB (See [[!QUIC-DATAGRAM]] [Section 3](https://datatracker.ietf.org/doc/html/rfc9221#section-3)).
+
+1. [=ReadableStream/Set up with byte reading support=] |incomingDatagrams| with
+   [=ReadableStream/set up with byte reading support/pullAlgorithm=] set to
+   |pullDatagramsAlgorithm|, and [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=WritableStream/Set up=] |outgoingDatagrams| with [=WritableStream/set up/writeAlgorithm=]
    set to |writeDatagramsAlgorithm|.
 1. Let |pullBidirectionalStreamAlgorithm| be an action that runs [=pullBidirectionalStream=]

--- a/index.bs
+++ b/index.bs
@@ -484,14 +484,15 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
    [=ReadableStream/current BYOB request view=] is not null, then:
   1. Let |view| be |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
      [=ReadableStream/current BYOB request view=].
-  1. If |view|'s [=BufferSource/byte length=] is less than the size of |datagram|,
-     [=ReadableStream/error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
-     with a {{RangeError}}.
-  1. Otherwise:
-    1. Set |offset| to |view|.\[[ByteOffset]].
-    1. Set |maxBytes| to |view|'s [=BufferSource/byte length=].
-    1. Set |buffer| to |view|'s [=BufferSource/underlying buffer=].
-    1. Set |chunk| to |view|.
+  1. If |view|'s [=BufferSource/byte length=] is less than the size of |datagram|, then:
+    1. Let |error| be a new {{RangeError}} exception.
+    1. [=ReadableStream/Error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+        with |error|.
+    1. Return [=a promise rejected with=] |error|.
+  1. Set |offset| to |view|.\[[ByteOffset]].
+  1. Set |maxBytes| to |view|'s [=BufferSource/byte length=].
+  1. Set |buffer| to |view|'s [=BufferSource/underlying buffer=].
+  1. Set |chunk| to |view|.
 1. Otherwise:
   1. Set |offset| to 0.
   1. Set |maxBytes| to the size of |datagram|.

--- a/index.bs
+++ b/index.bs
@@ -79,6 +79,7 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: pending; url: sec-promise-objects
     text: resolved; url: sec-promise-objects
     text: settled; url: sec-promise-objects
+    text: the typed array constructors table; url: #table-49
 urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
   type: dfn
     text: created; for:DOMException; url: dfn-create-exception
@@ -479,7 +480,6 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
   1. Set |datagrams|.{{[[IncomingDatagramsPullPromise]]}} to a new promise.
   1. Return |datagrams|.{{[[IncomingDatagramsPullPromise]]}}.
 1. Let |datagram| and |timestamp| be the result of [=dequeuing=] |queue|.
-1. Let |buffer|, |offset|, |maxBytes|, and |chunk| be null.
 1. If |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
    [=ReadableStream/current BYOB request view=] is not null, then:
   1. Let |view| be |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}'s
@@ -489,18 +489,15 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
     1. [=ReadableStream/Error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
         with |error|.
     1. Return [=a promise rejected with=] |error|.
-  1. Set |offset| to |view|.\[[ByteOffset]].
-  1. Set |maxBytes| to the size of |datagram|.
-  1. Set |buffer| to |view|'s [=BufferSource/underlying buffer=].
-  1. Set |chunk| to a new {{Uint8Array}} object with |buffer|, |offset|, and the size of |datagram|.
-1. Otherwise:
-  1. Set |offset| to 0.
-  1. Set |maxBytes| to the size of |datagram|.
-  1. Set |buffer| be a [=new=] {{ArrayBuffer}} with |maxBytes| size. If allocating the
-     {{ArrayBuffer}} fails, return [=a promise rejected with=] a {{RangeError}}.
-  1. Set |chunk| to a new {{Uint8Array}} object with |buffer| and |offset|.
-1. Write |datagram| into |buffer| with offset |offset|, up to |maxBytes| bytes.
-1. [=ReadableStream/Enqueue=] |chunk| to |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
+  1. Let |elementSize| be the element size specified in [=the typed array constructors table=] for
+     |view|.\[[TypedArrayName]]. If |view| does not have a [[TypedArrayName]] internal slot
+     (i.e. it is a {{DataView}}), let |elementSize| be 0.
+  1. If |elementSize| is not 1, then:
+    1. Let |error| be a new {{TypeError}} exception.
+    1. [=ReadableStream/Error=] |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+        with |error|.
+    1. Return [=a promise rejected with=] |error|.
+1. [=ReadableStream/Pull from bytes=] |datagram| into |datagrams|.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Return [=a promise resolved with=] undefined.
 
 To <dfn>receiveDatagrams</dfn>, given a {{WebTransport}} object |transport|, run these steps:

--- a/index.bs
+++ b/index.bs
@@ -490,7 +490,7 @@ To <dfn>pullDatagrams</dfn>, given a {{WebTransport}} object |transport|, run th
         with |error|.
     1. Return [=a promise rejected with=] |error|.
   1. Let |elementSize| be the element size specified in [=the typed array constructors table=] for
-     |view|.\[[TypedArrayName]]. If |view| does not have a [[TypedArrayName]] internal slot
+     |view|.\[[TypedArrayName]]. If |view| does not have a \[[TypedArrayName]] internal slot
      (i.e. it is a {{DataView}}), let |elementSize| be 0.
   1. If |elementSize| is not 1, then:
     1. Let |error| be a new {{TypeError}} exception.


### PR DESCRIPTION
This change adds support for BYOB readers for datagrams in the spec, similar to WebTransportReceiveStreams.

Fixes https://github.com/w3c/webtransport/issues/480.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/487.html" title="Last updated on Apr 24, 2023, 4:14 AM UTC (3ffe59d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/487/b2b4b07...nidhijaju:3ffe59d.html" title="Last updated on Apr 24, 2023, 4:14 AM UTC (3ffe59d)">Diff</a>