### PR TITLE
Throwing serverCertificateHashes related errors

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -792,7 +792,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
      |networkPartitionKey|, |url|, false, |newConnection|, and |http3Only|. If the user agent
      supports more than one congestion control algorithm, choose one appropriate for
      |congestionControl| for sending of data on this |connection|. When obtaining a connection, if
-     |serverCertificateHashes| is specified instead of the default certificate version algorithm,
+     |serverCertificateHashes| is specified instead of the default certificate verification algorithm,
      validate the certificate against [=custom certificate requirements=], and then
      [=verify a certificate hash|verify the certificate hash=] against |serverCertificateHashes|.
      The certificate is considered valid if and only if both of those checks pass.
@@ -1192,11 +1192,10 @@ To <dfn>verify a certificate hash</dfn>, given a |certificate| and an array of h
 perform the following steps:
 1. Let |referenceHash| be the result of [=computing a certificate hash=] with |certificate|.
 1. For every hash |hash| in |hashes|:
-   1. If |hash|.{{WebTransportHash/value}} is not null:
+   1. If |hash|.{{WebTransportHash/value}} is not null and |hash|.{{WebTransportHash/algorithm}}
+      is an [=ASCII case-insensitive=] match with "sha-256":
      1. Let |hashValue| be the byte sequence which |hash|.{{WebTransportHash/value}} represents.
-     1. If |hash|.{{WebTransportHash/algorithm}} is an [=ASCII case-insensitive=] match with
-        "sha-256", and |hashValue| is equal to |referenceHash|, the |certificate| is valid.
-        Return true.
+     1. If |hashValue| is equal to |referenceHash|, return true.
 1. Return false.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -795,7 +795,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
      |serverCertificateHashes| is specified instead of the default certificate version algorithm,
      validate the certificate against [=custom certificate requirements=], and then
      [=verify a certificate hash|verify the certificate hash=] against |serverCertificateHashes|.
-     The certificate is considered valid only if both of those checks pass.
+     The certificate is considered valid if and only if both of those checks pass.
   1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
      |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -802,7 +802,9 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
      |serverCertificateHashes| returns false or the certificate does not satisfy [=custom certificate requirements=],
      then abort the remaining steps and [=queue a network task=] with |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-    1. [=Cleanup=] |transport| with a {{SecurityError}}.
+    1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+       {{WebTransportErrorOptions/source}} is `"session"`.
+    1. [=Cleanup=] |transport| with |error|.
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't

--- a/index.bs
+++ b/index.bs
@@ -1197,7 +1197,7 @@ perform the following steps:
      1. Let |hashValue| be the byte sequence which |hash|.{{WebTransportHash/value}} represents.
      1. If |hash|.{{WebTransportHash/algorithm}} is an [=ASCII case-insensitive=] match with
         "sha-256", and |hashValue| is equal to |referenceHash|, the |certificate| is valid.
-	Return true.
+        Return true.
 1. Return false.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -795,6 +795,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
      |serverCertificateHashes| is specified instead of the default certificate version algorithm,
      validate the certificate against [=custom certificate requirements=], and then
      [=verify a certificate hash|verify the certificate hash=] against |serverCertificateHashes|.
+     The certificate is considered valid only if both of those checks pass.
   1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
      |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -791,16 +791,12 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
   1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
      |networkPartitionKey|, |url|, false, |newConnection|, and |http3Only|. If the user agent
      supports more than one congestion control algorithm, choose one appropriate for
-     |congestionControl| for sending of data on this |connection|.
+     |congestionControl| for sending of data on this |connection|. When obtaining a connection, if
+     |serverCertificateHashes| is specified instead of the default certificate version algorithm,
+     validate the certificate against [=custom certificate requirements=], and then
+     [=verify a certificate hash|verify the certificate hash=] against |serverCertificateHashes|.
   1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
      |transport| to run these steps:
-    1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
-    1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
-       {{WebTransportErrorOptions/source}} is `"session"`.
-    1. [=Cleanup=] |transport| with |error|.
-  1. If [=verify a certificate hash|verifying the certificate hash=] from |connection| against
-     |serverCertificateHashes| returns false or the certificate does not satisfy [=custom certificate requirements=],
-     then abort the remaining steps and [=queue a network task=] with |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.

--- a/index.bs
+++ b/index.bs
@@ -702,7 +702,7 @@ agent MUST run the following steps:
 1. Let |serverCertificateHashes| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/serverCertificateHashes}} if it exists, and null otherwise.
 1. If |dedicated| is false and |serverCertificateHashes| is non-null, then [=throw=] a
-   {{TypeError}}.
+   {{NotSupportedError}} exception.
 1. Let |requireUnreliable| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/requireUnreliable}}.
 1. Let |congestionControl| be {{WebTransport/constructor(url, options)/options}}'s
@@ -1175,22 +1175,23 @@ that determine how WebTransport connection is established and used.
    </div>
 
 <div algorithm>
-To <dfn>compute a certificate hash</dfn>, do the following:
-1. Let |cert| be the input certificate, represented as a DER encoding of
+To <dfn>compute a certificate hash</dfn>, given a |certificate|, perform the following steps:
+1. Let |cert| be |certificate|, represented as a DER encoding of
    Certificate message defined in [[!RFC5280]].
 1. Compute the SHA-256 hash of |cert| and return the computed value.
 
 </div>
 
 <div algorithm>
-To <dfn>verify a certificate hash</dfn>, do the following:
-1. Let |hashes| be the input array of hashes.
-1. Let |referenceHash| be the [=compute a certificate hash|computed hash=] of the input certificate.
+To <dfn>verify a certificate hash</dfn>, given a |certificate| and an array of hashes |hashes|,
+perform the following steps:
+1. Let |referenceHash| be the result of [=computing a certificate hash=] with |certificate|.
 1. For every hash |hash| in |hashes|:
    1. If |hash|.{{WebTransportHash/value}} is not null:
      1. Let |hashValue| be the byte sequence which |hash|.{{WebTransportHash/value}} represents.
-     1. If {{WebTransportHash/algorithm}} of |hash| is an [=ASCII case-insensitive=] match with "sha-256", and |hashValue| is equal
-        to |referenceHash|, the certificate is valid. Return true.
+     1. If |hash|.{{WebTransportHash/algorithm}} is an [=ASCII case-insensitive=] match with
+        "sha-256", and |hashValue| is equal to |referenceHash|, the |certificate| is valid.
+	Return true.
 1. Return false.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -792,10 +792,11 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
      |networkPartitionKey|, |url|, false, |newConnection|, and |http3Only|. If the user agent
      supports more than one congestion control algorithm, choose one appropriate for
      |congestionControl| for sending of data on this |connection|. When obtaining a connection, if
-     |serverCertificateHashes| is specified instead of the default certificate verification algorithm,
-     validate the certificate against [=custom certificate requirements=], and then
-     [=verify a certificate hash|verify the certificate hash=] against |serverCertificateHashes|.
-     The certificate is considered valid if and only if both of those checks pass.
+     |serverCertificateHashes| is specified, instead of using the default certificate verification
+     algorithm, consider the certificate valid if it meets the [=custom certificate
+     requirements=] and if [=verify a certificate hash|verifying the certificate hash=] against
+     |serverCertificateHashes| returns true. If either condition is not met, let |connection| be
+     failure.
   1. If |connection| is failure, then abort the remaining steps and [=queue a network task=] with
      |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.

--- a/index.bs
+++ b/index.bs
@@ -758,7 +758,7 @@ agent MUST run the following steps:
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated|,
-   |requireUnreliable|, and |congestionControl|.
+   |requireUnreliable|, |congestionControl|, and |serverCertificateHashes|.
 1. Return |transport|.
 
 </div>
@@ -766,7 +766,8 @@ agent MUST run the following steps:
 <div algorithm>
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 <var>transport</var>, a [=URL record=] |url|, a boolean |dedicated|, a boolean
-|http3Only|, and a {{WebTransportCongestionControl}} |congestionControl|, run these steps.
+|http3Only|, a {{WebTransportCongestionControl}} |congestionControl|, and a
+sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
 1. Let |origin| be |client|'s [=environment settings object/origin=].
@@ -797,6 +798,11 @@ To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
+  1. If [=verify a certificate hash|verifying the certificate hash=] from |connection| against
+     |serverCertificateHashes| returns false or the certificate does not satisfy [=custom certificate requirements=],
+     then abort the remaining steps and [=queue a network task=] with |transport| to run these steps:
+    1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
+    1. [=Cleanup=] |transport| with a {{SecurityError}}.
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't


### PR DESCRIPTION
This change specifies _where_ the NotSupportedError and trust errors should be thrown when handling [serverCertificateHashes](https://w3c.github.io/webtransport/#dom-webtransportoptions-servercertificatehashes). It also adds explicit parameters to the certificate hash algorithms.

Fixes https://github.com/w3c/webtransport/issues/456 and fixes https://github.com/w3c/webtransport/issues/359.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/489.html" title="Last updated on Apr 27, 2023, 1:33 AM UTC (e950163)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/489/85fc448...nidhijaju:e950163.html" title="Last updated on Apr 27, 2023, 1:33 AM UTC (e950163)">Diff</a>