### PR TITLE
RESET_STREAM handling

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2084,7 +2084,7 @@ frame is not always indicated to the application. Receipt of the
 RESET_STREAM can be signaled immediately, interrupting delivery of
 stream data with any data not consumed being discarded. However,
 immediate signaling is not required. Also, if stream data
-is completely received and is buffered to be read by the
+is completely received but has not yet been read by the
 application, the RESET_STREAM signal can be suppressed.
   
   <table class="data">

--- a/index.bs
+++ b/index.bs
@@ -2079,6 +2079,14 @@ converted to an httpErrorCode, and vice versa, as specified in [[!WEB-TRANSPORT-
     </tbody>
   </table>
   
+Note: As discussed in [[QUIC]] Section 3.2, receipt of a RESET_STREAM
+frame is not always be indicated to the application. Receipt of the
+RESET_STREAM can be signaled immediately, interrupting delivery of
+stream data with any data not consumed being discarded. However,
+immediate signaling is not required. Also, if stream data
+is completely received and is buffered to be read by the
+application, the RESET_STREAM signal can be suppressed.
+  
   <table class="data">
     <colgroup class="header"><col></colgroup>
     <colgroup><col></colgroup>

--- a/index.bs
+++ b/index.bs
@@ -2080,7 +2080,7 @@ converted to an httpErrorCode, and vice versa, as specified in [[!WEB-TRANSPORT-
   </table>
   
 Note: As discussed in [[QUIC]] Section 3.2, receipt of a RESET_STREAM
-frame is not always be indicated to the application. Receipt of the
+frame is not always indicated to the application. Receipt of the
 RESET_STREAM can be signaled immediately, interrupting delivery of
 stream data with any data not consumed being discarded. However,
 immediate signaling is not required. Also, if stream data


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/422

Rebase of https://github.com/w3c/webtransport/pull/490


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/491.html" title="Last updated on Apr 11, 2023, 2:14 PM UTC (fad80c6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/491/5e8422f...fad80c6.html" title="Last updated on Apr 11, 2023, 2:14 PM UTC (fad80c6)">Diff</a>