### PR TITLE
Add estimatedSendRate to stats.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1280,7 +1280,7 @@ dictionary WebTransportStats {
   DOMHighResTimeStamp rttVariation;
   DOMHighResTimeStamp minRtt;
   WebTransportDatagramStats datagrams;
-  unsigned long long estimatedSendRate;
+  unsigned long long? estimatedSendRate;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1320,9 +1320,9 @@ The dictionary SHALL have the following attributes:
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
    and is calculated by the congestion control algorithm (potentially chosen by
    {{WebTransport/congestionControl}}). If this [=WebTransport session=] is
-   pooled with others in a shared [=connection=], the value is undefined.
-   If the user agent does not have an estimate, the value is undefined.
-   The value change from defined to undefined or undefined to defined at any time.
+   pooled with others in a shared [=connection=], or if the user agent does not
+   currently have an estimate, the member MUST be [=map/exist|absent=].
+   The member can be absent even if present in previous results.
 
 
 ## `WebTransportDatagramStats` Dictionary ##  {#web-transport-stats}

--- a/index.bs
+++ b/index.bs
@@ -1280,6 +1280,7 @@ dictionary WebTransportStats {
   DOMHighResTimeStamp rttVariation;
   DOMHighResTimeStamp minRtt;
   WebTransportDatagramStats datagrams;
+  unsigned long long estimatedSendRate;
 };
 </pre>
 
@@ -1314,6 +1315,15 @@ The dictionary SHALL have the following attributes:
    [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
 : <dfn for="WebTransportStats" dict-member>minRtt</dfn>
 :: The minimum round-trip time observed on the entire connection.
+: <dfn for="WebTransportStats" dict-member>estimatedSendRate</dfn>
+:: The estimated rate at which queued data will be sent by the user agent, in bits per second.
+   This rate applies to all streams and datagrams that share a [=WebTransport session=]
+   and is calculated by the congestion control algorithm (potentially chosen by
+   {{WebTransport/congestionControl}}). If this [=WebTransport session=] is
+   pooled with others in a shared [=connection=], the value is undefined.
+   If the user agent does not have an estimate, the value is undefined.
+   The value change from defined to undefined or undefined to defined at any time.
+
 
 ## `WebTransportDatagramStats` Dictionary ##  {#web-transport-stats}
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/484.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/pthatcher/webtransport/pull/494.html" title="Last updated on Apr 11, 2023, 1:41 PM UTC (3c7ed34)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/494/5e8422f...pthatcher:3c7ed34.html" title="Last updated on Apr 11, 2023, 1:41 PM UTC (3c7ed34)">Diff</a>