### PR TITLE
Specify BFCache interaction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1097,8 +1097,13 @@ This specification defines [=unloading document cleanup steps=] as the following
 
 1. Let |window| be |document|'s [=relevant global object=].
 1. For each {{WebTransport}} |transport| whose [=relevant global object=] is |window|:
-  1. If |transport|.{{[[State]]}} is `"connected"`, set |transport|.{{[[State]]}} to `"failed"`
-     and [=session/terminate=] |transport|.{{[[Session]]}} [=in parallel=].
+  1. If |transport|.{{[[State]]}} is `"connected"`, then:
+    1. Set |transport|.{{[[State]]}} to `"failed"`.
+    1. [=In parallel=], [=session/terminate=] |transport|.{{[[Session]]}}.
+    1. [=Queue a network task=] with |transport| to run the following steps:
+      1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+         {{WebTransportErrorOptions/source}} is `"session"`.
+      1. [=Cleanup=] |transport| with |error|.
   1. If |transport|.{{[[State]]}} is `"connecting"`, set |transport|.{{[[State]]}} to
      `"failed"`.
 


### PR DESCRIPTION
The proposal for WebTransport interacting with BFCache is that we allow pages using WebTransport to enter the BFCache, but close the connection when navigating away. Then, the various promises will resolve if/when the page is navigated back to. 

The spec currently already terminates the session in the [unloading document cleanup steps](https://www.w3.org/TR/webtransport/#web-transport-context-cleanup-steps), but this PR adds a step to [queue a network task](https://www.w3.org/TR/webtransport/#webtransport-queue-a-network-task) to run [cleanup](https://www.w3.org/TR/webtransport/#webtransport-cleanup) on a WebTransport object. The network task queue will be paused when the page is navigated away from, and resumed when the page is navigated back to.

Fixes https://github.com/w3c/webtransport/issues/326.

cc @rakina


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/500.html" title="Last updated on Apr 25, 2023, 12:40 PM UTC (c52beb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/500/b2b4b07...nidhijaju:c52beb2.html" title="Last updated on Apr 25, 2023, 12:40 PM UTC (c52beb2)">Diff</a>