### PR TITLE
Update BFCache interaction

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1092,20 +1092,18 @@ run these steps:
 
 ## Context cleanup steps ##  {#web-transport-context-cleanup-steps}
 
-This specification defines [=unloading document cleanup steps=] as the following steps, given a
-{{Document}} document:
+This specification defines <dfn>context cleanup steps</dfn> as the following steps, given
+{{WebTransport}} |transport|:
 
-1. Let |window| be |document|'s [=relevant global object=].
-1. For each {{WebTransport}} |transport| whose [=relevant global object=] is |window|:
-  1. If |transport|.{{[[State]]}} is `"connected"`, then:
-    1. Set |transport|.{{[[State]]}} to `"failed"`.
-    1. [=In parallel=], [=session/terminate=] |transport|.{{[[Session]]}}.
-    1. [=Queue a network task=] with |transport| to run the following steps:
-      1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
-         {{WebTransportErrorOptions/source}} is `"session"`.
-      1. [=Cleanup=] |transport| with |error|.
-  1. If |transport|.{{[[State]]}} is `"connecting"`, set |transport|.{{[[State]]}} to
-     `"failed"`.
+1. If |transport|.{{[[State]]}} is `"connected"`, then:
+  1. Set |transport|.{{[[State]]}} to `"failed"`.
+  1. [=In parallel=], [=session/terminate=] |transport|.{{[[Session]]}}.
+  1. [=Queue a network task=] with |transport| to run the following steps:
+    1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
+       {{WebTransportErrorOptions/source}} is `"session"`.
+    1. [=Cleanup=] |transport| with |error|.
+1. If |transport|.{{[[State]]}} is `"connecting"`, set |transport|.{{[[State]]}} to
+   `"failed"`.
 
   Issue: This needs to be done in workers too. See
   <a href="https://www.github.com/w3c/webtransport/issues/127">#127</a> and


### PR DESCRIPTION
As mentioned in https://github.com/w3c/webtransport/pull/500#issuecomment-1522656746, the [BFCache guidance](https://html.spec.whatwg.org/multipage/document-lifecycle.html#unloading-document-cleanup-steps) was recently updated to say we should define a stand-alone set of steps, that the HTML spec explicitly calls out to at unloading-document-cleanup time. This PR updates the spec based on this guidance, in coordination with https://github.com/whatwg/html/pull/9217.

cc @rakina


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/503.html" title="Last updated on Apr 26, 2023, 3:05 AM UTC (5bd2de8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/503/85fc448...nidhijaju:5bd2de8.html" title="Last updated on Apr 26, 2023, 3:05 AM UTC (5bd2de8)">Diff</a>