### PR TITLE
Make streamErrorCode 32-bit long

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1915,12 +1915,12 @@ interface WebTransportError : DOMException {
   constructor(optional DOMString message = "", optional WebTransportErrorOptions options = {});
 
   readonly attribute WebTransportErrorSource source;
-  readonly attribute octet? streamErrorCode;
+  readonly attribute unsigned long? streamErrorCode;
 };
 
 dictionary WebTransportErrorOptions {
   WebTransportErrorSource source = "stream";
-  [Clamp] octet? streamErrorCode = null;
+  [Clamp] unsigned long? streamErrorCode = null;
 };
 
 enum WebTransportErrorSource {


### PR DESCRIPTION
See ietf-wg-webtrans/draft-ietf-webtrans-http3#115 for the corresponding protocol change.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vasilvv/web-transport/pull/509.html" title="Last updated on May 9, 2023, 5:21 AM UTC (fc0d9ea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/509/7bb74aa...vasilvv:fc0d9ea.html" title="Last updated on May 9, 2023, 5:21 AM UTC (fc0d9ea)">Diff</a>