### PR TITLE
Provide guidance on displaying a human readable error message without language info

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1092,7 +1092,7 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
   1. If |reasonBytes| is given, set |closeInfo|'s {{WebTransportCloseInfo/reason}} to |reasonBytes|,
      [=UTF-8 decoded=].
      
-     Note: no language or direction metadata is available with |reasonBytes|. 
+     Note: No language or direction metadata is available with |reasonBytes|. 
      First-strong heuristics can be used for direction when displaying the value.
   1. [=Cleanup=] |transport| with |error| and |closeInfo|.
 

--- a/index.bs
+++ b/index.bs
@@ -1090,8 +1090,10 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
   1. Let |closeInfo| be a [=new=] {{WebTransportCloseInfo}}.
   1. If |code| is given, set |closeInfo|'s {{WebTransportCloseInfo/closeCode}} to |code|.
   1. If |reasonBytes| is given, set |closeInfo|'s {{WebTransportCloseInfo/reason}} to |reasonBytes|,
-     [=UTF-8 decoded=]. Note that no language or direction metadata is available with |reasonBytes| and 
-     that first-strong heuristics should be used for direction when displaying the value.
+     [=UTF-8 decoded=].
+     
+     Note: no language or direction metadata is available with |reasonBytes|. 
+     First-strong heuristics can be used for direction when displaying the value.
   1. [=Cleanup=] |transport| with |error| and |closeInfo|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -1090,7 +1090,8 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
   1. Let |closeInfo| be a [=new=] {{WebTransportCloseInfo}}.
   1. If |code| is given, set |closeInfo|'s {{WebTransportCloseInfo/closeCode}} to |code|.
   1. If |reasonBytes| is given, set |closeInfo|'s {{WebTransportCloseInfo/reason}} to |reasonBytes|,
-     [=UTF-8 decoded=].
+     [=UTF-8 decoded=]. Note that no language or direction metadata is available with |reasonBytes| and 
+     that first-strong heuristics should be used for direction when displaying the value.
   1. [=Cleanup=] |transport| with |error| and |closeInfo|.
 
 </div>


### PR DESCRIPTION
Fixes #414


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/513.html" title="Last updated on May 17, 2023, 5:27 PM UTC (c2186a9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/513/cb131a6...c2186a9.html" title="Last updated on May 17, 2023, 5:27 PM UTC (c2186a9)">Diff</a>