### PR TITLE
Removing language that indicates the sendRate estimate must be absent when pooled.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1341,8 +1341,7 @@ The dictionary SHALL have the following attributes:
 :: The estimated rate at which queued data will be sent by the user agent, in bits per second.
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
    and is calculated by the congestion control algorithm (potentially chosen by
-   {{WebTransport/congestionControl}}). If this [=WebTransport session=] is
-   pooled with others in a shared [=connection=], or if the user agent does not
+   {{WebTransport/congestionControl}}). If the user agent does not
    currently have an estimate, the member MUST be [=map/exist|absent=].
    The member can be absent even if present in previous results.
 


### PR DESCRIPTION
Fixes #497


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/514.html" title="Last updated on May 17, 2023, 3:49 PM UTC (982c674)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/514/cb131a6...982c674.html" title="Last updated on May 17, 2023, 3:49 PM UTC (982c674)">Diff</a>