### PR TITLE
Add automated glass-glass latency calculation via RVFC

### DIFF
--- a/samples/webcodecs-echo/index.html
+++ b/samples/webcodecs-echo/index.html
@@ -11,7 +11,7 @@
     <meta id="theme-color" name="theme-color" content="#ffffff">
     <base target="_blank">
 
-    <title>WebTransport Echo with WebCodecs in Worker</title>
+    <title>WebTransport Echo with WebCodecs in Worker + RVFC</title>
     <link rel="stylesheet" href="css/main.css">
 
     <style>
@@ -57,7 +57,7 @@
 
 <body>
 <div>
-  <h2>WebTransport Echo with WebCodecs in Worker</h2>
+  <h2>WebTransport Echo with WebCodecs in Worker + RVFC</h2>
   <div class="input-line">
     <label for="url">URL:</label>
     <input type="text" name="url" id="url" size="40"
@@ -150,17 +150,21 @@
 
 <div id="chart_div" style="width: 900px; height: 500px;"></div>
 
+<div id="chart2_div" style="width: 900px; height: 500px;"></div>
+
 <div class="select">
    <label for="videoSource">Video source: </label><select id="videoSource"></select>
 </div>
 
 <video height="50%" id="inputVideo" autoplay muted></video>
 <br/>Local Video</br>
-<br/></br><video height="50%" id="outputVideo" autoplay muted></video>
+<br/></br>
+<video height="50%" id="outputVideo" autoplay muted></video>
 <br/>Encoded (and Decoded) Video via the WT Echo Server</br>
 <br/></br>
 <button id="connect">Start</button>
 <button id="stop">Stop</button>
+<br/></br>
 <script src="https://www.gstatic.com/charts/loader.js"></script>
 <script src="js/main.js"></script>
 </body>

--- a/samples/webcodecs-echo/js/main.js
+++ b/samples/webcodecs-echo/js/main.js
@@ -58,13 +58,13 @@ function metrics_report() {
   let j = 0;
   for (let i = 0; i < len ; i++ ) {
     if (metrics.all[i].output == 1) {
-      let frameno = metrics.all[i].presentedFrames;
-      let g2g = metrics.all[i].expectedDisplayTime - metrics.all[i-1].captureTime;
-      let mediaTime = metrics.all[i].mediaTime;
-      let captureTime = metrics.all[i-1].captureTime;
-      let expectedDisplayTime = metrics.all[i].expectedDisplayTime;
-      let delay = metrics.all[i].expectedDisplayTime - metrics.all[i-1].expectedDisplayTime;
-      let data = [frameno, g2g];
+      const frameno = metrics.all[i].presentedFrames;
+      const g2g = metrics.all[i].expectedDisplayTime - metrics.all[i-1].captureTime;
+      const mediaTime = metrics.all[i].mediaTime;
+      const captureTime = metrics.all[i-1].captureTime;
+      const expectedDisplayTime = metrics.all[i].expectedDisplayTime;
+      const delay = metrics.all[i].expectedDisplayTime - metrics.all[i-1].expectedDisplayTime;
+      const data = [frameno, g2g];
       e2e.all.push(data);
     }
   }
@@ -323,7 +323,7 @@ document.addEventListener('DOMContentLoaded', async function(event) {
     let paint_count = 0;
     let start_time = 0.0;
 
-    const doSomething = (now, metadata) => {
+    const recordOutputFrames = (now, metadata) => {
       metadata.output = 1.;
       metadata.time = now;
       if( start_time == 0.0 ) start_time = now;
@@ -331,12 +331,12 @@ document.addEventListener('DOMContentLoaded', async function(event) {
       let fps = (++paint_count / elapsed).toFixed(3);
       metadata.fps = fps;
       metrics_update(metadata);
-      outputVideo.requestVideoFrameCallback(doSomething);
+      outputVideo.requestVideoFrameCallback(recordOutputFrames);
     };
 
-    outputVideo.requestVideoFrameCallback(doSomething);
+    outputVideo.requestVideoFrameCallback(recordOutputFrames);
 
-    const doSomeOtherthing = (now, metadata) => {
+    const recordInputFrames = (now, metadata) => {
       metadata.output = 0;
       metadata.time = now;
       if( start_time == 0.0 ) start_time = now;
@@ -344,10 +344,10 @@ document.addEventListener('DOMContentLoaded', async function(event) {
       let fps = (++paint_count / elapsed).toFixed(3);
       metadata.fps = fps;
       metrics_update(metadata);
-      inputVideo.requestVideoFrameCallback(doSomeOtherthing);
+      inputVideo.requestVideoFrameCallback(recordInputFrames);
     };
 
-    inputVideo.requestVideoFrameCallback(doSomeOtherthing);
+    inputVideo.requestVideoFrameCallback(recordInputFrames);
 
     //Create video Encoder configuration
     const vConfig = {


### PR DESCRIPTION
This PR uses the RVFC API to calculate glass-glass latency as using (presentationTime - captureTime) returned from RVFC. A chart of glass-glass latency versus output frame number is displayed. 

A live demo is here:  https://webrtc.internaut.com/wc/wtSender12/