### PR TITLE
UA SHOULD divide bandwidth fairly between all streams that aren’t starved

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1275,13 +1275,15 @@ The dictionary SHALL have the following attributes:
 :: An send order number that, if provided, opts the created
    {{WebTransportSendStream}} in to participating in <dfn>strict ordering</dfn>.
    Bytes currently queued on [=strict ordering|strictly ordered=]
-   {{WebTransportSendStream}}s MUST be sent ahead of bytes currently queued on
+   {{WebTransportSendStream}}s will be sent ahead of bytes currently queued on
    other [=strict ordering|strictly ordered=] {{WebTransportSendStream}}s
    created with lower send order numbers.
 
    If no send order number is provided, then the order in which the
    user agent sends bytes from it relative to other {{WebTransportSendStream}}s
-   is [=implementation-defined=].
+   is [=implementation-defined=]. User agents are strongly encouraged however to
+   divide bandwidth fairly between all streams that aren't starved by lower send
+   order numbers.
 
    Note: This is sender-side data prioritization which does not guarantee
    reception order.
@@ -1523,6 +1525,8 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      non-null and higher {{[[SendOrder]]}}, that are neither
      [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
      sent.
+
+     The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
 
     Note: We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
     respond to live updates of these values during sending, though the details are

--- a/index.bs
+++ b/index.bs
@@ -1527,6 +1527,8 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      sent.
 
      The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
+     
+     Note: The definition of fairness here is [=implementation-defined=].
 
     Note: We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
     respond to live updates of these values during sending, though the details are


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/520.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/521.html" title="Last updated on Jun 20, 2023, 11:31 PM UTC (6c00f5a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/521/fefcd4d...jan-ivar:6c00f5a.html" title="Last updated on Jun 20, 2023, 11:31 PM UTC (6c00f5a)">Diff</a>