### PR TITLE
Cleanup Datagram Streams

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1043,12 +1043,18 @@ To <dfn for="WebTransport">cleanup</dfn> a {{WebTransport}} |transport| with |er
 optionally |closeInfo|, run these steps:
 1. Let |sendStreams| be a copy of |transport|.{{[[SendStreams]]}}.
 1. Let |receiveStreams| be a copy of |transport|.{{[[ReceiveStreams]]}}.
+1. Let |outgoingDatagrams| be |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Writable]]}}.
+1. Let |incomingDatagrams| be |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}.
 1. Let |ready| be |transport|.{{[[Ready]]}}.
 1. Let |closed| be |transport|.{{[[Closed]]}}.
 1. Let |incomingBidirectionalStreams| be |transport|.{{[[IncomingBidirectionalStreams]]}}.
 1. Let |incomingUnidirectionalStreams| be |transport|.{{[[IncomingUnidirectionalStreams]]}}.
 1. Set |transport|.{{[[SendStreams]]}} to an empty [=set=].
 1. Set |transport|.{{[[ReceiveStreams]]}} to an empty [=set=].
+1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[OutgoingDatagramsQueue]]}}
+   to an empty [=queue=].
+1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[IncomingDatagramsQueue]]}}
+   to an empty [=queue=].
 1. If |closeInfo| is given, then set |transport|.{{[[State]]}} to `"closed"`.
    Otherwise, set |transport|.{{[[State]]}} to `"failed"`.
 1. [=For each=] |sendStream| in |sendStreams|, [=WritableStream/error=] |sendStream| with |error|.
@@ -1064,11 +1070,15 @@ optionally |closeInfo|, run these steps:
   1. Assert: |ready| is [=settled=].
   1. [=ReadableStream/Close=] |incomingBidirectionalStreams|.
   1. [=ReadableStream/Close=] |incomingUnidirectionalStreams|.
+  1. [=WritableStream/Close=] |outgoingDatagrams|.
+  1. [=ReadableStream/Close=] |incomingDatagrams|.
 1. Otherwise:
   1. [=Reject=] |closed| with |error|.
   1. [=Reject=] |ready| with |error|.
   1. [=ReadableStream/Error=] |incomingBidirectionalStreams| with |error|.
   1. [=ReadableStream/Error=] |incomingUnidirectionalStreams| with |error|.
+  1. [=WritableStream/Error=] |outgoingDatagrams| with |error|.
+  1. [=ReadableStream/Error=] |incomingDatagrams| with |error|.
 
 </div>
 


### PR DESCRIPTION
The [cleanup](https://w3c.github.io/webtransport/#webtransport-cleanup) steps currently only cleans up the incoming bi- and unidirectional streams, and [[[SendStreams]] ](https://w3c.github.io/webtransport/#dom-webtransport-sendstreams-slot)and [[[ReceiveStreams]]](https://w3c.github.io/webtransport/#dom-webtransport-receivestreams-slot). This PR adds steps to cleanup the [datagrams](https://www.w3.org/TR/webtransport/#dom-webtransport-datagrams-slot) as well.

Fixes https://github.com/w3c/webtransport/issues/524.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/526.html" title="Last updated on Jul 10, 2023, 9:30 AM UTC (e935d61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/526/72763a0...nidhijaju:e935d61.html" title="Last updated on Jul 10, 2023, 9:30 AM UTC (e935d61)">Diff</a>