### PR TITLE
Update ranges of streamErrorCode

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1581,10 +1581,10 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 1. If |reason| is a {{WebTransportError}} and |reason|.{{WebTransportError/[[StreamErrorCode]]}} is not
    null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
-1. If |code| > 255, then set |code| to 255.
+1. If |code| > 4294967295, then set |code| to 4294967295.
 
-   Note: Valid values of |code| are from 0 to 255 inclusive. The code will be encoded to a number in
-         [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[!WEB-TRANSPORT-HTTP3]].
+   Note: Valid values of |code| are from 0 to 4294967295 inclusive. The code will be encoded to a
+   number in [0x52e4a40fa8db, 0x52e5ac983162] as decribed in [[!WEB-TRANSPORT-HTTP3]].
 
 1. Run the following steps [=in parallel=]:
   1. [=stream/Reset=] |stream|.{{WebTransportSendStream/[[InternalStream]]}} with |code|.
@@ -1602,8 +1602,8 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportSendStream}} 
 1. Let |transport| be |stream|.{{WebTransportSendStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the STOP_SENDING frame. [[!QUIC]]
 
-   Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in
-         [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[!WEB-TRANSPORT-HTTP3]].
+   Note: Valid values of |code| are from 0 to 4294967295 inclusive. The code has been decoded from a
+  number in [0x52e4a40fa8db, 0x52e5ac983162] as decribed in[[!WEB-TRANSPORT-HTTP3]].
 
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
@@ -1806,10 +1806,10 @@ steps.
 1. If |reason| is a {{WebTransportError}} and |reason|.{{WebTransportError/[[StreamErrorCode]]}} is not
    null, then set |code| to |reason|.{{WebTransportError/[[StreamErrorCode]]}}.
 1. If |code| < 0, then set |code| to 0.
-1. If |code| > 255, then set |code| to 255.
+1. If |code| > 4294967295, then set |code| to 4294967295.
 
-   Note: Valid values of |code| are from 0 to 255 inclusive. The code will be encoded to a number in
-         [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[!WEB-TRANSPORT-HTTP3]].
+   Note: Valid values of |code| are from 0 to 4294967295 inclusive. The code will be encoded to a
+   number in [0x52e4a40fa8db, 0x52e5ac983162] as decribed in [[!WEB-TRANSPORT-HTTP3]].
 
 1. [=set/Remove=] |stream| from |transport|.{{[[SendStreams]]}}.
 1. Run the following steps [=in parallel=]:
@@ -1834,8 +1834,8 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportReceiveStream
 1. Let |transport| be |stream|.{{WebTransportReceiveStream/[[Transport]]}}.
 1. Let |code| be the application protocol error code attached to the RESET_STREAM frame. [[!QUIC]]
 
-   Note: Valid values of |code| are from 0 to 255 inclusive. The code has been decoded from a number in
-         [0x52e4a40fa8db, 0x52e4a40fa9e2] as decribed in [[!WEB-TRANSPORT-HTTP3]].
+   Note: Valid values of |code| are from 0 to 4294967295 inclusive. The code has been decoded from a
+   number in [0x52e4a40fa8db, 0x52e5ac983162] as decribed in [[!WEB-TRANSPORT-HTTP3]].
 
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.


### PR DESCRIPTION
This is a follow-up of #509. Now streamErrorCode has values in the range [0, 4294967295].


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bashi/webtransport/pull/527.html" title="Last updated on Jul 18, 2023, 5:52 AM UTC (fb01b5e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/527/72763a0...bashi:fb01b5e.html" title="Last updated on Jul 18, 2023, 5:52 AM UTC (fb01b5e)">Diff</a>