### PR TITLE
Reject create(Uni|Bi)directionalStream() on stream ID exhaustion.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -996,8 +996,10 @@ these steps.
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
       [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
       1. Let |streamId| be a new stream ID that is valid and unique for
-         |transport|.{{[[Session]]}}. If one is not immediately available due to exhaustion,
-         [=reject=] |p| with a {{QuotaExceededError}} and abort these steps. [[!QUIC]]
+         |transport|.{{[[Session]]}}, as defined in [[!QUIC]]
+         [Section 19.11](https://www.rfc-editor.org/rfc/rfc9000#section-19.11). If one is not
+         immediately available due to exhaustion, [=reject=] |p| with a {{QuotaExceededError}}
+         and abort these steps.
       1. Let |internalStream| be the result of [=creating a bidirectional stream=] with
            |transport|.{{[[Session]]}} and |streamId|.
       1. [=Queue a network task=] with |transport| to run the following steps:
@@ -1026,8 +1028,10 @@ these steps.
         {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
         [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
         1. Let |streamId| be a new stream ID that is valid and unique for
-           |transport|.{{[[Session]]}}. If one is not immediately available due to exhaustion,
-           [=reject=] |p| with a {{QuotaExceededError}} and abort these steps. [[!QUIC]]
+           |transport|.{{[[Session]]}}, as defined in [[!QUIC]]
+           [Section 19.11](https://www.rfc-editor.org/rfc/rfc9000#section-19.11). If one is not
+           immediately available due to exhaustion, [=reject=] |p| with a {{QuotaExceededError}}
+           and abort these steps.
         1. Let |internalStream| be the result of [=creating an outgoing unidirectional stream=] with
            |transport|.{{[[Session]]}} and |streamId|.
         1. [=Queue a network task=] with |transport| to run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -995,10 +995,11 @@ these steps.
    1. Run the following steps [=in parallel=], but [=abort when=] |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
       [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
+      1. Let |streamId| be a new stream ID that is valid and unique for
+         |transport|.{{[[Session]]}}. If one is not immediately available due to exhaustion,
+         [=reject=] |p| with a {{QuotaExceededError}} and abort these steps. [[!QUIC]]
       1. Let |internalStream| be the result of [=creating a bidirectional stream=] with
-         |transport|.{{[[Session]]}}.
-
-        Note: This operation may take time, for example when the stream ID is exhausted. [[!QUIC]]
+           |transport|.{{[[Session]]}} and |streamId|.
       1. [=Queue a network task=] with |transport| to run the following steps:
         1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
            [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
@@ -1024,10 +1025,11 @@ these steps.
      1. Run the following steps [=in parallel=], but [=abort when=] |transport|'s
         {{[[State]]}} becomes `"closed"` or `"failed"`, and instead
         [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
+        1. Let |streamId| be a new stream ID that is valid and unique for
+           |transport|.{{[[Session]]}}. If one is not immediately available due to exhaustion,
+           [=reject=] |p| with a {{QuotaExceededError}} and abort these steps. [[!QUIC]]
         1. Let |internalStream| be the result of [=creating an outgoing unidirectional stream=] with
-           |transport|.{{[[Session]]}}.
-
-          Note: This operation may take time, for example when the stream ID is exhausted. [[!QUIC]]
+           |transport|.{{[[Session]]}} and |streamId|.
         1. [=Queue a network task=] with |transport| to run the following steps:
           1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/446.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Jul 19, 2023, 7:52 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fwebtransport%2Fb6eef8f292a437fcd1a878389e1fb1dd3c0de92f%2Findex.bs&md-warning=not%20ready)

```
<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">
<html><head>
<title>500 Internal Server Error</title>
</head><body>
<h1>Internal Server Error</h1>
<p>The server encountered an internal error or
misconfiguration and was unable to complete
your request.</p>
<p>Please contact the server administrator at 
 [no address given] to inform them of the time this error occurred,
 and the actions you performed just before this error.</p>
<p>More information about this error may be available
in the server error log.</p>
<hr>
<address>Apache/2.4.10 (Debian) Server at api.csswg.org Port 443</address>
</body></html>

```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/webtransport%23528.)._
</details>
