### PR TITLE
Reject promise if state is not "connected" in pullUni/BidirectionalStream

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -861,6 +861,8 @@ these steps.
 1. If |transport|.{{[[State]]}} is `"connecting"`, then return the result of performing the
    following steps [=upon fulfillment=] of |transport|.{{[[Ready]]}}:
   1. Return the result of [=pullBidirectionalStream=] with |transport|.
+1. If |transport|.{{[[State]]}} is not `"connected"`, then return a new [=rejected=] promise with
+   an {{InvalidStateError}}.
 1. Let |session| be |transport|.{{[[Session]]}}.
 1. Let |p| be a new promise.
 1. Run the following steps [=in parallel=]:
@@ -883,6 +885,8 @@ these steps.
 1. If |transport|.{{[[State]]}} is `"connecting"`, then return the result of performing the
    following steps [=upon fulfillment=] of |transport|.{{[[Ready]]}}:
   1. Return the result of [=pullUnidirectionalStream=] with |transport|.
+1. If |transport|.{{[[State]]}} is not `"connected"`, then return a new [=rejected=] promise with
+   an {{InvalidStateError}}.
 1. Let |session| be |transport|.{{[[Session]]}}.
 1. Let |p| be a new promise.
 1. Run the following steps [=in parallel=]:


### PR DESCRIPTION
This PR adds an extra check for the [state](https://www.w3.org/TR/webtransport/#dom-webtransport-state-slot) in the [pullUnidirectionalStream](https://www.w3.org/TR/webtransport/#pullunidirectionalstream) and [pullBidirectionalStream](https://www.w3.org/TR/webtransport/#pullbidirectionalstream) algorithms to reduce ambiguity.

Fixes https://github.com/w3c/webtransport/issues/452.