### PR TITLE
Add stat bytesLost

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1325,6 +1325,7 @@ dictionary WebTransportStats {
   DOMHighResTimeStamp timestamp;
   unsigned long long bytesSent;
   unsigned long long packetsSent;
+  unsigned long long bytesLost;
   unsigned long long packetsLost;
   unsigned long numOutgoingStreamsCreated;
   unsigned long numIncomingStreamsCreated;
@@ -1348,6 +1349,9 @@ The dictionary SHALL have the following attributes:
    Does not include UDP or any other outer framing.
 : <dfn for="WebTransportStats" dict-member>packetsSent</dfn>
 :: The number of packets sent on the QUIC connection, including those that are determined to have been lost.
+: <dfn for="WebTransportStats" dict-member>bytesLost</dfn>
+:: The number of bytes lost on the QUIC connection (does not monotonically increase, because packets that are declared lost can subsequently be received).
+   Does not include UDP or any other outer framing.
 : <dfn for="WebTransportStats" dict-member>packetsLost</dfn>
 :: The number of packets lost on the QUIC connection (does not monotonically increase, because packets that are declared lost can subsequently be received).
 : <dfn for="WebTransportStats" dict-member>numOutgoingStreamsCreated</dfn>


### PR DESCRIPTION
As discussed in https://github.com/w3c/webtransport/issues/537.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/546.html" title="Last updated on Sep 25, 2023, 7:09 PM UTC (8c4fdbf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/546/d0e87c9...jan-ivar:8c4fdbf.html" title="Last updated on Sep 25, 2023, 7:09 PM UTC (8c4fdbf)">Diff</a>