### PR TITLE
Set optimizeForLatency in decoder configuration

### DIFF
--- a/samples/webcodecs-echo/js/stream_worker.js
+++ b/samples/webcodecs-echo/js/stream_worker.js
@@ -719,6 +719,8 @@ SSRC = this.config.ssrc
              if (cfg.decoderConfig) {
                // self.postMessage({text: 'Decoder reconfig!'});
                cfg.decoderConfig.hardwareAcceleration = config.decHwAcceleration;
+               cfg.decoderConfig.optimizeForLatency = true;
+               if (config.latencyPref == 'quality') cfg.decoderConfig.optimizeForLatency = false;
                const decoderConfig = JSON.stringify(cfg.decoderConfig);
                // self.postMessage({text: 'Decoder configuration: ' + decoderConfig});
                const configChunk =

--- a/samples/webcodecs-echo/js/stream_worker.js
+++ b/samples/webcodecs-echo/js/stream_worker.js
@@ -719,8 +719,7 @@ SSRC = this.config.ssrc
              if (cfg.decoderConfig) {
                // self.postMessage({text: 'Decoder reconfig!'});
                cfg.decoderConfig.hardwareAcceleration = config.decHwAcceleration;
-               cfg.decoderConfig.optimizeForLatency = true;
-               if (config.latencyPref == 'quality') cfg.decoderConfig.optimizeForLatency = false;
+               cfg.decoderConfig.optimizeForLatency = !(config.latencyPref == 'quality');
                const decoderConfig = JSON.stringify(cfg.decoderConfig);
                // self.postMessage({text: 'Decoder configuration: ' + decoderConfig});
                const configChunk =

--- a/samples/webcodecs-echo/js/stream_worker.js
+++ b/samples/webcodecs-echo/js/stream_worker.js
@@ -719,7 +719,7 @@ SSRC = this.config.ssrc
              if (cfg.decoderConfig) {
                // self.postMessage({text: 'Decoder reconfig!'});
                cfg.decoderConfig.hardwareAcceleration = config.decHwAcceleration;
-               cfg.decoderConfig.optimizeForLatency = !(config.latencyPref == 'quality');
+               cfg.decoderConfig.optimizeForLatency = (config.latencyPref == "realtime");
                const decoderConfig = JSON.stringify(cfg.decoderConfig);
                // self.postMessage({text: 'Decoder configuration: ' + decoderConfig});
                const configChunk =

--- a/samples/webcodecs-echo/js/stream_worker.js
+++ b/samples/webcodecs-echo/js/stream_worker.js
@@ -719,7 +719,7 @@ SSRC = this.config.ssrc
              if (cfg.decoderConfig) {
                // self.postMessage({text: 'Decoder reconfig!'});
                cfg.decoderConfig.hardwareAcceleration = config.decHwAcceleration;
-               cfg.decoderConfig.optimizeForLatency = (config.latencyPref == "realtime");
+               cfg.decoderConfig.optimizeForLatency = (config.latencyMode == "realtime");
                const decoderConfig = JSON.stringify(cfg.decoderConfig);
                // self.postMessage({text: 'Decoder configuration: ' + decoderConfig});
                const configChunk =


### PR DESCRIPTION
When the WebCodecs encoder spits out a decoder configuration, set optimizeForLatency in the decoder configuration based on the encoder's configured latencyMode. This ensures that an encode latencyMode setting of "realtime" is paired with a decoder optimizeForLatency setting of true. This reduces decode times and glass-glass latency considerably (as much as 100 - 150ms) depending on the selected codec, resolution and number of temporal layers.   The effect is largest with the VP8 and AV1 codecs, but barely noticeable with H.264.  

When encoding AV1 at full-HD resolution and 30 fps with a target bitrate of 1 Mbps, glass-glass latency < 95 ms was observed between a client in Redmond, WA and an echo server in Santa Clara, CA. 