### PR TITLE
Add writer.atomicWrite() method.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1594,10 +1594,6 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
 1. Let |inFlightWriteRequest| be
    |stream|.<a href="https://streams.spec.whatwg.org/#writablestream-inflightwriterequest">inFlightWriteRequest</a>.
-
-   Note: Find a [better way](https://streams.spec.whatwg.org/#other-specs) to integrate
-   with the streams spec to identify the write request in flight.
-
 1. Let |atomic| be true if |inFlightWriteRequest| [=list/exists=]
    in [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}, otherwise false.
 1. Run the following steps [=in parallel=]:
@@ -1616,7 +1612,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      except for [=flow control=] reasons or [=WritableStream/Error | error=].
 
      If the sending of |bytes| cannot be completed in its entirety within the current
-     [=flow control=] window, and |atomic| is true, then give up on sending |bytes| and
+     [=flow control=] window, and |atomic| is true, then stop sending |bytes| and
      [=queue a network task=] with |transport| to [=abort all atomic write requests=]
      on |stream|, before proceeding immediately to the next step without failing.
 

--- a/index.bs
+++ b/index.bs
@@ -2770,7 +2770,7 @@ async function receiveText(url, createWritableStreamForTextData) {
 
 *This section is non-normative.*
 
-Sending a transactional piece of data on a one-way stream only if it can be done
+Sending a transactional piece of data on a unidirectional stream, only if it can be done
 entirely without blocking on [=flow control=], can be achieved by using the
 {{WebTransportSendStream/getWriter}} function and the resulting writer.
 

--- a/index.bs
+++ b/index.bs
@@ -1598,7 +1598,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
   1. [=Queue a network task=] with |transport| to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
     1. If |atomic| is true, [=map/remove=] |inFlightWriteRequest| from
-       |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+       |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
     1. [=Resolve=] |promise| with undefined.
 1. Return |promise|.
 
@@ -2073,7 +2073,10 @@ on a {{WebTransportSendStream}} |stream|, given |chunk|, run these steps:
 1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
     on {{WritableStreamDefaultWriter}} with |chunk|.
 1. Set |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} to |p|.
-1. Return |p|.
+1. Return the result of [=reacting=] to |p| with the following steps:
+   1. [=map/Remove=] |p| from |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
+   1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.
+   1. Return undefined.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1501,7 +1501,7 @@ A {{WebTransportSendStream}} has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[AtomicWriteRequests]]`</dfn>
-   <td class="non-normative">A [=list=] of promises, each representing an in-flight atomic
+   <td class="non-normative">An [=ordered set=] of promises, each representing an in-flight atomic
     write request to be processed by the underlying sink.
   </tr>
  <tbody>
@@ -2072,7 +2072,7 @@ To <dfn export for="WebTransportWriter" lt="write atomically">write atomically</
 on a {{WebTransportSendStream}} |stream|, given |chunk|, run these steps:
 1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
     on {{WritableStreamDefaultWriter}} with |chunk|.
-1. Set |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} to |p|.
+1. [=set/Append=] |p| to |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
 1. Return the result of [=reacting=] to |p| with the following steps:
    1. [=map/Remove=] |p| from |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
    1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.

--- a/index.bs
+++ b/index.bs
@@ -70,7 +70,6 @@ spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 spec:infra; type:dfn; for:/; text:ASCII case-insensitive
 spec:infra; type:dfn; text:list
-spec:streams; type:dict-member; text:write
 </pre>
 <pre class="anchors">
 url: https://html.spec.whatwg.org/multipage/origin.html#concept-origin; type: dfn; text: origin; for:/

--- a/index.bs
+++ b/index.bs
@@ -1594,8 +1594,8 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
 1. Let |inFlightWriteRequest| be
    |stream|.<a href="https://streams.spec.whatwg.org/#writablestream-inflightwriterequest">inFlightWriteRequest</a>.
-1. Let |atomic| be true if |inFlightWriteRequest| [=list/exists=]
-   in [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}, otherwise false.
+1. Let |atomic| be true if [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}
+   [=list/contains=] |inFlightWriteRequest|, otherwise false.
 1. Run the following steps [=in parallel=]:
   1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the
      operation to complete.
@@ -1634,8 +1634,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
   1. Otherwise, [=queue a network task=] with |transport|
      to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
-    1. [=map/Remove=] |inFlightWriteRequest| from
-       |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
+    1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} [=list/contains=] |inFlightWriteRequest|, [=list/remove=] |inFlightWriteRequest|.
     1. [=Resolve=] |promise| with undefined.
 1. Return |promise|.
 
@@ -1691,7 +1690,7 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 <div algorithm>
 To <dfn for="WebTransportSendStream">abort all atomic write requests</dfn> on a {{WebTransportSendStream}} |stream|, run these steps:
   1. Let |requestsToAbort| be [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
-  1. [=map/Clear=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+  1. [=list/Empty=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
   1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{AbortError}}.
   1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the
      [=stream/send|sending=] of bytes associated with |promise|.
@@ -2202,7 +2201,8 @@ on a {{WebTransportSendStream}} |stream|, given |chunk|, run these steps:
     on {{WritableStreamDefaultWriter}} with |chunk|.
 1. [=set/Append=] |p| to |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
 1. Return the result of [=reacting=] to |p| with the following steps:
-   1. [=map/Remove=] |p| from |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
+   1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} [=list/contains=] |p|,
+      [=list/remove=] |p|.
    1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.
    1. Return undefined.
 

--- a/index.bs
+++ b/index.bs
@@ -2170,7 +2170,8 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
 
    Note: Atomic writes can still block if queued behind non-atomic writes. If
    the write is rejected, everything queued behind it will be rejected as well,
-   including non-atomic writes. Applications are therefore encouraged to always
+   including non-atomic writes, which are enqueued as atomic writes when an
+   atomic write is outstanding. Applications are therefore encouraged to always
    await atomic writes.
 
    When called, return the result of [=writing atomically=] on the

--- a/index.bs
+++ b/index.bs
@@ -1708,7 +1708,11 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 
 <div algorithm>
 To <dfn for="WebTransportSendStream">abort all atomic write requests</dfn> on a {{WebTransportSendStream}} |stream|, run these steps:
+  1. Let |writeRequests| be
+     |stream|.<a href="https://streams.spec.whatwg.org/#writablestream-writerequests">writeRequests</a>.
   1. Let |requestsToAbort| be [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+  1. If |writeRequests| [=list/contains=] a promise not in |requestsToAbort|, then
+     [=WritableStream/error=] |stream| with {{AbortError}}, and abort these steps.
   1. [=list/Empty=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
   1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{AbortError}}.
   1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the
@@ -2143,7 +2147,7 @@ object |transport|, and a |sendOrder|, run these steps.
 # `WebTransportWriter` Interface #  {#web-transport-writer-procedures-interface}
 
 {{WebTransportWriter}} is a subclass of {{WritableStreamDefaultWriter}} that
-overloads one method and adds another.
+adds one method.
 
 A {{WebTransportWriter}} is always created by the
 [=WebTransportWriter/create=] procedure.
@@ -2151,45 +2155,39 @@ A {{WebTransportWriter}} is always created by the
 <pre class="idl">
 [Exposed=*, SecureContext]
 interface WebTransportWriter : WritableStreamDefaultWriter {
-  Promise&lt;undefined&gt; write(optional any chunk);
   Promise&lt;undefined&gt; atomicWrite(optional any chunk);
 };
 </pre>
 
 ## Methods ##  {#web-transport-writer-procedures-methods}
 
-: <dfn for="WebTransportWriter" method>write(chunk)</dfn>
-:: The {{write}} method will not reject on [=flow control=] blockage
-   unless queued behind one or more outstanding calls to {{atomicWrite}}.
-   This behavior is designed to satisfy most applications.
-
-   When called, run the following steps:
-   1. Let |stream| be the {{WebTransportSendStream}} associated with [=this=].
-   1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} is not empty,
-      then return the result of [=writing atomically=] on |stream| with |chunk|.
-   1. Return the result of {{WritableStreamDefaultWriter/write(chunk)}}
-      on {{WritableStreamDefaultWriter}} with |chunk|.
-
 : <dfn for="WebTransportWriter" method>atomicWrite(chunk)</dfn>
 :: The {{atomicWrite}} method will reject if the |chunk| given to it
-   cannot be sent in its entirety within the [=flow control=] window that
-   is current at the time of sending. In other words, the sending of |chunk|
-   is all or nothing. This behavior is designed to satisfy niche transactional
-   applications sensitive to [=flow control=] deadlocks ([[RFC9308]]
+   could not be sent in its entirety within the [=flow control=] window that
+   is current at the time of sending. This behavior is designed to satisfy niche
+   transactional applications sensitive to [=flow control=] deadlocks ([[RFC9308]]
    [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
 
-   Note: {{atomicWrite}} does not guarantee atomicity on the wire (e.g. MTU) or
-   at the server, nor does it prevent interleaving of data with other send
-   requests. Only the client will know if it failed.
+   Note: {{atomicWrite}} might have partially sent a chunk before rejecting. It
+   does not guarantee atomicity on the wire (e.g. MTU) or at the server, nor does
+   it prevent interleaving of data with other send requests. Only the client will
+   know if it failed.
 
    Note: Atomic writes can still block if queued behind non-atomic writes. If
-   the write is rejected, everything queued behind it will be rejected as well,
-   including non-atomic writes, which are enqueued as atomic writes when an
-   atomic write is outstanding. Applications are therefore encouraged to always
-   await atomic writes.
+   the atomic write is rejected, everything queued behind it at that moment
+   will be rejected as well. Any non-atomic writes rejected in this way will
+   [=WritableStream/error=] the stream. Applications are therefore encouraged to
+   always await atomic writes.
 
-   When called, return the result of [=writing atomically=] on the
-   {{WebTransportSendStream}} associated with [=this=], with |chunk|.
+   When atomicWrite is called, the user agent MUST run the following steps:
+   1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
+       on {{WritableStreamDefaultWriter}} with |chunk|.
+   1. [=set/Append=] |p| to |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+   1. Return the result of [=reacting=] to |p| with the following steps:
+      1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} [=list/contains=] |p|,
+         [=list/remove=] |p|.
+      1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.
+      1. Return undefined.
 
 ## Procedures ##  {#web-transport-writer-procedures-procedures}
 
@@ -2204,22 +2202,6 @@ steps:
 1. Return |writer|.
 
 </div>
-
-<div algorithm="write atomically">
-
-To <dfn export for="WebTransportWriter" lt="write atomically">write atomically</dfn>
-on a {{WebTransportSendStream}} |stream|, given |chunk|, run these steps:
-1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
-    on {{WritableStreamDefaultWriter}} with |chunk|.
-1. [=set/Append=] |p| to |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
-1. Return the result of [=reacting=] to |p| with the following steps:
-   1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} [=list/contains=] |p|,
-      [=list/remove=] |p|.
-   1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.
-   1. Return undefined.
-
-</div>
-
 
 # `WebTransportError` Interface #  {#web-transport-error-interface}
 
@@ -2804,7 +2786,7 @@ async function sendTransactionalData(wt, bytes) {
   } catch (e) {
     if (e.name != "AbortError") throw e;
     // rejected to avoid blocking on flow control
-    // The writable remains un-errored unlike with regular writes
+    // The writable remains un-errored provided no non-atomic writes are pending
   } finally {
     writer.releaseLock();
   }

--- a/index.bs
+++ b/index.bs
@@ -2167,8 +2167,8 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
 
    Note: {{atomicWrite}} does not guarantee atomicity on the wire (e.g. MTU) or
-   at the receiver, nor does it prevent interleaving of data with other send
-   requests. Only the sender will know if it failed.
+   at the server, nor does it prevent interleaving of data with other send
+   requests. Only the client will know if it failed.
 
    Note: Atomic writes can still block if queued behind non-atomic writes. If
    the write is rejected, everything queued behind it will be rejected as well,

--- a/index.bs
+++ b/index.bs
@@ -1619,8 +1619,8 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
     respond to live updates of these values during sending, though the details are
     [=implementation-defined=].
 
-     If the the current [=flow control=] window ends before |bytes| can be sent in
-     their entirety, and |atomic| is true, then stop sending |bytes|.
+     Stop sending |bytes| if |atomic| is true and the current [=flow control=] window
+     ends before |bytes| can be sent in their entirety.
 
   1. If the previous step failed due to a network error, abort the remaining steps.
 
@@ -2166,6 +2166,10 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    is all or nothing. This behavior is designed to satisfy niche transactional
    applications sensitive to [=flow control=] deadlocks ([[RFC9308]]
    [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
+
+   Note: {{atomicWrite}} does not guarantee atomicity on the wire (e.g. MTU) or
+   at the receiver, nor does it prevent interleaving of data with other send
+   requests. Only the sender will know if it failed.
 
    Note: Atomic writes can still block if queued behind non-atomic writes. If
    the write is rejected, everything queued behind it will be rejected as well,

--- a/index.bs
+++ b/index.bs
@@ -2167,10 +2167,11 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    transactional applications sensitive to [=flow control=] deadlocks ([[RFC9308]]
    [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
 
-   Note: {{atomicWrite}} might have partially sent a chunk before rejecting. It
-   does not guarantee atomicity on the wire (e.g. MTU) or at the server, nor does
-   it prevent interleaving of data with other send requests. Only the client will
-   know if it failed.
+   Note: {{atomicWrite}} can still reject after sending some data. Though it
+   provides atomicity with respect to flow control, other errors may occur. 
+   {{atomicWrite}} does not prevent data from being split between packets
+   or being interleaved with other data. Only the sender learns if
+   {{atomicWrite}} fails due to lack of available flow control credit.
 
    Note: Atomic writes can still block if queued behind non-atomic writes. If
    the atomic write is rejected, everything queued behind it at that moment

--- a/index.bs
+++ b/index.bs
@@ -2156,7 +2156,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
 };
 </pre>
 
-## Methods ##  {#web-transport-writer-procedures-methods}
+## Methods ##  {#web-transport-writer-methods}
 
 : <dfn for="WebTransportWriter" method>atomicWrite(chunk)</dfn>
 :: The {{atomicWrite}} method will reject if the |chunk| given to it

--- a/index.bs
+++ b/index.bs
@@ -2787,7 +2787,7 @@ async function sendTransactionalData(wt, bytes) {
   try {
     await writer.atomicWrite(bytes);
   } catch (e) {
-    if (e.name != "TransactionInactiveError") throw e;
+    if (e.name != "AbortError") throw e;
     // rejected to avoid blocking on flow control
     // The writable remains un-errored unlike with regular writes
   } finally {

--- a/index.bs
+++ b/index.bs
@@ -1513,7 +1513,7 @@ The {{WebTransportSendStream}}'s [=transfer steps=] and
      1. Return |p|.
 
 : <dfn for="WebTransportSendStream" method>getWriter()</dfn>
-:: This method must be implemented the same as {{WritableStream/getWriter}}
+:: This method must be implemented in the same manner as {{WritableStream/getWriter}}
    inherited from {{WritableStream}}, except in place of creating a
    {{WritableStreamDefaultWriter}}, it must instead
    [=WebTransportWriter/create=] a {{WebTransportWriter}} with [=this=].

--- a/index.bs
+++ b/index.bs
@@ -2141,7 +2141,7 @@ object |transport|, and a |sendOrder|, run these steps.
 
 </div>
 
-# `WebTransportWriter` Interface #  {#web-transport-writer-procedures-interface}
+# `WebTransportWriter` Interface #  {#web-transport-writer-interface}
 
 {{WebTransportWriter}} is a subclass of {{WritableStreamDefaultWriter}} that
 adds one method.

--- a/index.bs
+++ b/index.bs
@@ -1655,8 +1655,8 @@ To <dfn for="WebTransportSendStream">abort all atomic write requests</dfn> on a 
   1. Let |requestsToAbort| be [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
   1. [=map/Clear=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
   1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{AbortError}}.
-  1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the sending of data
-     associated with |promise|.
+  1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the
+     [=stream/send|sending=] of bytes associated with |promise|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1611,11 +1611,6 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      This sending MUST NOT starve otherwise,
      except for [=flow control=] reasons or [=WritableStream/Error | error=].
 
-     If the sending of |bytes| cannot be completed in its entirety within the current
-     [=flow control=] window, and |atomic| is true, then stop sending |bytes| and
-     [=queue a network task=] with |transport| to [=abort all atomic write requests=]
-     on |stream|, before proceeding immediately to the next step without failing.
-
      The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
 
      Note: The definition of fairness here is [=implementation-defined=].
@@ -1624,14 +1619,22 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
     respond to live updates of these values during sending, though the details are
     [=implementation-defined=].
 
-  1. If the previous step failed, abort the remaining steps.
+     If the the current [=flow control=] window ends before |bytes| can be sent in
+     their entirety, and |atomic| is true, then stop sending |bytes|.
+
+  1. If the previous step failed due to a network error, abort the remaining steps.
 
     Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps
     error |stream| and reject the result of this write operation.
 
-  1. [=Queue a network task=] with |transport| to run these steps:
+  1. If |bytes| were not sent in their entirety, [=queue a network task=] with |transport|
+     to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
-    1. If |atomic| is true, [=map/remove=] |inFlightWriteRequest| from
+    1. [=Abort all atomic write requests=] on |stream|.
+  1. Otherwise, [=queue a network task=] with |transport|
+     to run these steps:
+    1. Set |stream|.{{[[PendingOperation]]}} to null.
+    1. [=map/Remove=] |inFlightWriteRequest| from
        |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} if it exists.
     1. [=Resolve=] |promise| with undefined.
 1. Return |promise|.

--- a/index.bs
+++ b/index.bs
@@ -1501,8 +1501,8 @@ A {{WebTransportSendStream}} has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[AtomicWriteRequests]]`</dfn>
-   <td class="non-normative">An [=ordered set=] of promises, each representing an in-flight atomic
-    write request to be processed by the underlying sink.
+   <td class="non-normative">An [=ordered set=] of promises, keeping track of the subset of
+    write requests that are atomic among those queued be processed by the underlying sink.
   </tr>
  <tbody>
 </table>
@@ -1525,7 +1525,7 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
     : {{WebTransportSendStream/[[SendOrder]]}}
     :: |sendOrder|
     : {{WebTransportSendStream/[[AtomicWriteRequests]]}}
-    :: An empty [=list=] of promises.
+    :: An empty [=ordered set=] of promises.
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
 1. Let |closeAlgorithm| be an action that [=closes=] |stream|.
 1. Let |abortAlgorithm| be an action that [=aborts=] |stream| with |reason|, given |reason|.
@@ -1576,11 +1576,10 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
      sent.
 
-     Whenever the sending of |bytes| becomes blocked by [=flow control=],
-     [=queue a network task=] with |transport| to [=abort all atomic write requests=] on |stream|.
-
-     If the sending of |bytes| becomes blocked by [=flow control=] and |atomic| is true,
-     then give up on sending |bytes| and proceed immediately to the next step without failing.
+     If the sending of |bytes| cannot be completed within the current [=flow control=]
+     window, and |atomic| is true, then give up on sending |bytes| and
+     [=queue a network task=] with |transport| to [=abort all atomic write requests=]
+     on |stream|, before proceeding immediately to the next step without failing.
 
      The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
 
@@ -1655,7 +1654,7 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
 To <dfn for="WebTransportSendStream">abort all atomic write requests</dfn> on a {{WebTransportSendStream}} |stream|, run these steps:
   1. Let |requestsToAbort| be [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
   1. [=map/Clear=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
-  1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{TransactionInactiveError}}.
+  1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{AbortError}}.
   1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the sending of data
      associated with |promise|.
 

--- a/index.bs
+++ b/index.bs
@@ -2177,7 +2177,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    [=WritableStream/error=] the stream. Applications are therefore encouraged to
    always await atomic writes.
 
-   When atomicWrite is called, the user agent MUST run the following steps:
+   When {{atomicWrite}} is called, the user agent MUST run the following steps:
    1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
        on {{WritableStreamDefaultWriter}} with |chunk|.
    1. [=set/Append=] |p| to |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.

--- a/index.bs
+++ b/index.bs
@@ -2037,17 +2037,23 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    When called, run the following steps:
    1. Let |stream| be the {{WebTransportSendStream}} associated with [=this=].
    1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} is not empty,
-      return the result of [=writing atomically=] on |stream| with |chunk|.
+      then return the result of [=writing atomically=] on |stream| with |chunk|.
    1. Return the result of {{WritableStreamDefaultWriter/write(chunk)}}
       on {{WritableStreamDefaultWriter}} with |chunk|.
 
 : <dfn for="WebTransportWriter" method>atomicWrite(chunk)</dfn>
-:: The {{atomicWrite}} method will reject if the chunk given to it
-   cannot be sent in its entirety without blocking on [=flow control=].
-   This behavior is designed to satisfy niche transactional applications
-   sensitive to [=flow control=] deadlocks ([[RFC9308]]
+:: The {{atomicWrite}} method will reject if the |chunk| given to it
+   cannot be sent in its entirety within the [=flow control=] window that
+   is current at the time of sending. In other words, the sending of |chunk|
+   is all or nothing. This behavior is designed to satisfy niche transactional
+   applications sensitive to [=flow control=] deadlocks ([[RFC9308]]
    [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
-   
+
+   Note: Atomic writes can still block if queued behind non-atomic writes. If
+   the write is rejected, everything queued behind it will be rejected as well,
+   including non-atomic writes. Applications are therefore encouraged to always
+   await atomic writes.
+
    When called, return the result of [=writing atomically=] on the
    {{WebTransportSendStream}} associated with [=this=], with |chunk|.
 

--- a/index.bs
+++ b/index.bs
@@ -2150,7 +2150,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
 
 : <dfn for="WebTransportWriter" method>write(chunk)</dfn>
 :: The {{write}} method will not reject on [=flow control=] blockage
-   (unless queued behind one or more outstanding calls to {{atomicWrite}}).
+   unless queued behind one or more outstanding calls to {{atomicWrite}}.
    This behavior is designed to satisfy most applications.
 
    When called, run the following steps:

--- a/index.bs
+++ b/index.bs
@@ -1661,7 +1661,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 Note: The [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
 {{WritableStreamDefaultWriter/write(chunk)}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
-the chunk arrives at the server, use an application-level protocol.
+the chunk arrives at the server, the server needs to send some form of acknowledgment message.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -1538,7 +1538,7 @@ A {{WebTransportSendStream}} has the following internal slots.
   <tr>
    <td><dfn>`[[AtomicWriteRequests]]`</dfn>
    <td class="non-normative">An [=ordered set=] of promises, keeping track of the subset of
-    write requests that are atomic among those queued be processed by the underlying sink.
+    write requests that are atomic among those queued to be processed by the underlying sink.
   </tr>
  <tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -2187,7 +2187,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
       1. If |p| was rejected with reason |r|, then return [=a promise rejected with=] |r|.
       1. Return undefined.
 
-## Procedures ##  {#web-transport-writer-procedures-procedures}
+## Procedures ##  {#web-transport-writer-procedures}
 
 <div algorithm="create a writer">
 

--- a/index.bs
+++ b/index.bs
@@ -1613,8 +1613,13 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Let |atomic| be true if [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}
    [=list/contains=] |inFlightWriteRequest|, otherwise false.
 1. Run the following steps [=in parallel=]:
-  1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the
-     operation to complete.
+  1. If |atomic| is true and the current [=flow control=] window is too small for |bytes| to be sent
+     in its entirety, then abort the remaining steps and [=queue a network task=] with |transport|
+     to run these sub-steps:
+    1. Set |stream|.{{[[PendingOperation]]}} to null.
+    1. [=Abort all atomic write requests=] on |stream|.
+  1. Otherwise, [=stream/send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}}
+     and wait for the operation to complete.
      This sending MAY be interleaved with sending of previously queued streams and datagrams,
      as well as streams and datagrams yet to be queued to be sent over this transport.
 
@@ -1639,18 +1644,11 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 
      Note: The definition of fairness here is [=implementation-defined=].
 
-     Stop sending |bytes| if |atomic| is true and the current [=flow control=] window
-     ends before |bytes| can be sent in their entirety.
-
   1. If the previous step failed due to a network error, abort the remaining steps.
 
     Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps
     error |stream| and reject the result of this write operation.
 
-  1. If |bytes| were not sent in their entirety, [=queue a network task=] with |transport|
-     to run these steps:
-    1. Set |stream|.{{[[PendingOperation]]}} to null.
-    1. [=Abort all atomic write requests=] on |stream|.
   1. Otherwise, [=queue a network task=] with |transport|
      to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.

--- a/index.bs
+++ b/index.bs
@@ -1659,7 +1659,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 Note: The [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
 {{WritableStreamDefaultWriter/write(chunk)}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
-the chunk arrives at the server, the server needs to send some form of acknowledgment message.
+the chunk arrives at the server, the server needs to send an application-level acknowledgment message.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -69,6 +69,8 @@ spec:fetch; type:dfn; for:/; text:fetch
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 spec:infra; type:dfn; for:/; text:ASCII case-insensitive
+spec:infra; type:dfn; text:list
+spec:streams; type:dict-member; text:write
 </pre>
 <pre class="anchors">
 url: https://html.spec.whatwg.org/multipage/origin.html#concept-origin; type: dfn; text: origin; for:/
@@ -1426,6 +1428,7 @@ data to the server.
 interface WebTransportSendStream : WritableStream {
   attribute long long? sendOrder;
   Promise&lt;WebTransportSendStreamStats&gt; getStats();
+  WebTransportWriter getWriter();
 };
 </pre>
 
@@ -1461,6 +1464,12 @@ The {{WebTransportSendStream}}'s [=transfer steps=] and
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.
 
+: <dfn for="WebTransportSendStream" method>getWriter()</dfn>
+:: This method must be implemented the same as {{WritableStream/getWriter}}
+   inherited from {{WritableStream}}, except in place of creating a
+   {{WritableStreamDefaultWriter}}, it must instead
+   [=WebTransportWriter/create=] a {{WebTransportWriter}} with [=this=].
+
 ## Internal Slots ## {#send-stream-internal-slots}
 
 A {{WebTransportSendStream}} has the following internal slots.
@@ -1490,6 +1499,11 @@ A {{WebTransportSendStream}} has the following internal slots.
    <td><dfn>`[[SendOrder]]`</dfn>
    <td class="non-normative">An optional send order number, or null.
   </tr>
+  <tr>
+   <td><dfn>`[[AtomicWriteRequests]]`</dfn>
+   <td class="non-normative">A [=list=] of promises, each representing an in-flight atomic
+    write request to be processed by the underlying sink.
+  </tr>
  <tbody>
 </table>
 
@@ -1510,6 +1524,8 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
     :: |transport|
     : {{WebTransportSendStream/[[SendOrder]]}}
     :: |sendOrder|
+    : {{WebTransportSendStream/[[AtomicWriteRequests]]}}
+    :: An empty [=list=] of promises.
 1. Let |writeAlgorithm| be an action that [=writes=] |chunk| to |stream|, given |chunk|.
 1. Let |closeAlgorithm| be an action that [=closes=] |stream|.
 1. Let |abortAlgorithm| be an action that [=aborts=] |stream| with |reason|, given |reason|.
@@ -1537,6 +1553,14 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 1. Let |promise| be a new promise.
 1. Let |bytes| be a copy of the [=byte sequence=] which |chunk| represents.
 1. Set |stream|.{{[[PendingOperation]]}} to |promise|.
+1. Let |inFlightWriteRequest| be
+   |stream|.<a href="https://streams.spec.whatwg.org/#writablestream-inflightwriterequest">inFlightWriteRequest</a>.
+
+   Note: Find a [better way](https://streams.spec.whatwg.org/#other-specs) to integrate
+   with the streams spec to identify the write request in flight.
+
+1. Let |atomic| be true if |inFlightWriteRequest| [=list/exists=]
+   in [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}, otherwise false.
 1. Run the following steps [=in parallel=]:
   1. [=stream/Send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the
      operation to complete.
@@ -1551,6 +1575,12 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      non-null and higher {{[[SendOrder]]}}, that are neither
      [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
      sent.
+
+     Whenever the sending of |bytes| becomes blocked by [=flow control=],
+     [=queue a network task=] with |transport| to [=abort all atomic write requests=] on |stream|.
+
+     If the sending of |bytes| becomes blocked by [=flow control=] and |atomic| is true,
+     then give up on sending |bytes| and proceed immediately to the next step without failing.
 
      The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
 
@@ -1567,13 +1597,15 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
 
   1. [=Queue a network task=] with |transport| to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
+    1. If |atomic| is true, [=map/remove=] |inFlightWriteRequest| from
+       |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
     1. [=Resolve=] |promise| with undefined.
 1. Return |promise|.
 
 Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
 SHOULD have a fixed upper limit, to carry the backpressure information to the user of
 {{WebTransportSendStream}}. This also means the [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
-{{WritableStreamDefaultWriter/write|WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
+{{WritableStreamDefaultWriter/write(chunk)}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
 the chunk arrives at the server, use an application-level protocol.
 
@@ -1616,6 +1648,16 @@ To <dfn for="WebTransportSendStream">abort</dfn> a {{WebTransportSendStream}} |s
   1. [=stream/Reset=] |stream|.{{WebTransportSendStream/[[InternalStream]]}} with |code|.
   1. [=Queue a network task=] with |transport| to [=resolve=] |promise| with undefined.
 1. Return |promise|.
+
+</div>
+
+<div algorithm>
+To <dfn for="WebTransportSendStream">abort all atomic write requests</dfn> on a {{WebTransportSendStream}} |stream|, run these steps:
+  1. Let |requestsToAbort| be [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+  1. [=map/Clear=] [=stream=].{{WebTransportSendStream/[[AtomicWriteRequests]]}}.
+  1. [=For each=] |promise| in |requestsToAbort|, [=reject=] |promise| with {{TransactionInactiveError}}.
+  1. [=In parallel=], [=for each=] |promise| in |requestsToAbort|, abort the sending of data
+     associated with |promise|.
 
 </div>
 
@@ -1970,6 +2012,72 @@ object |transport|, and a |sendOrder|, run these steps.
 
 </div>
 
+# `WebTransportWriter` Interface #  {#web-transport-writer-procedures-interface}
+
+{{WebTransportWriter}} is a subclass of {{WritableStreamDefaultWriter}} that
+overloads one method and adds another.
+
+A {{WebTransportWriter}} is always created by the
+[=WebTransportWriter/create=] procedure.
+
+<pre class="idl">
+[Exposed=*, SecureContext]
+interface WebTransportWriter : WritableStreamDefaultWriter {
+  Promise&lt;undefined&gt; write(optional any chunk);
+  Promise&lt;undefined&gt; atomicWrite(optional any chunk);
+};
+</pre>
+
+## Methods ##  {#web-transport-writer-procedures-methods}
+
+: <dfn for="WebTransportWriter" method>write(chunk)</dfn>
+:: The {{write}} method will not reject on [=flow control=] blockage
+   (unless queued behind one or more outstanding calls to {{atomicWrite}}).
+   This behavior is designed to satisfy most applications.
+
+   When called, run the following steps:
+   1. Let |stream| be the {{WebTransportSendStream}} associated with [=this=].
+   1. If |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} is not empty,
+      return the result of [=writing atomically=] on |stream| with |chunk|.
+   1. Return the result of {{WritableStreamDefaultWriter/write(chunk)}}
+      on {{WritableStreamDefaultWriter}} with |chunk|.
+
+: <dfn for="WebTransportWriter" method>atomicWrite(chunk)</dfn>
+:: The {{atomicWrite}} method will reject if the chunk given to it
+   cannot be sent in its entirety without blocking on [=flow control=].
+   This behavior is designed to satisfy niche transactional applications
+   sensitive to [=flow control=] deadlocks ([[RFC9308]]
+   [Section 4.4](https://datatracker.ietf.org/doc/html/rfc9308#section-4.4)).
+   
+   When called, return the result of [=writing atomically=] on the
+   {{WebTransportSendStream}} associated with [=this=], with |chunk|.
+
+## Procedures ##  {#web-transport-writer-procedures-procedures}
+
+<div algorithm="create a writer">
+
+To <dfn export for="WebTransportWriter" lt="create|creating">create</dfn> a
+{{WebTransportWriter}}, with a {{WebTransportSendStream}} |stream|, run these
+steps:
+1. Let |writer| be a [=new=] {{WebTransportWriter}}.
+1. Run the [new WritableStreamDefaultWriter(stream)](https://streams.spec.whatwg.org/#default-writer-constructor)
+   constructor steps passing |writer| as this, and |stream| as the constructor argument.
+1. Return |writer|.
+
+</div>
+
+<div algorithm="write atomically">
+
+To <dfn export for="WebTransportWriter" lt="write atomically">write atomically</dfn>
+on a {{WebTransportSendStream}} |stream|, given |chunk|, run these steps:
+1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
+    on {{WritableStreamDefaultWriter}} with |chunk|.
+1. Set |stream|.{{WebTransportSendStream/[[AtomicWriteRequests]]}} to |p|.
+1. Return |p|.
+
+</div>
+
+
 # `WebTransportError` Interface #  {#web-transport-error-interface}
 
 <dfn interface>WebTransportError</dfn> is a subclass of {{DOMException}} that represents
@@ -2093,7 +2201,7 @@ converted to an httpErrorCode, and vice versa, as specified in [[!WEB-TRANSPORT-
         <td>[=stream/Send|sends=] STREAM with FIN bit set</td>
       </tr>
       <tr>
-        <td>{{WebTransportBidirectionalStream/writable}}.getWriter().{{WritableStreamDefaultWriter/write}}()</td>
+        <td>{{WebTransportBidirectionalStream/writable}}.getWriter().{{WritableStreamDefaultWriter/write(chunk)}}()</td>
         <td>[=stream/Send|sends=] STREAM</td>
       </tr>
       <tr>
@@ -2531,6 +2639,31 @@ async function receiveText(url, createWritableStreamForTextData) {
     } catch (e) {
       console.error(e);
     }
+  }
+}
+</pre>
+
+## Sending a transactional chunk on a stream ##  {#example-transactional-stream}
+
+*This section is non-normative.*
+
+Sending a transactional piece of data on a one-way stream only if it can be done
+entirely without blocking on [=flow control=], can be achieved by using the
+{{WebTransportSendStream/getWriter}} function and the resulting writer.
+
+<pre class="example" highlight="js">
+async function sendTransactionalData(wt, bytes) {
+  const writable = await wt.createUnidirectionalStream();
+  const writer = writable.getWriter();
+  await writer.ready;
+  try {
+    await writer.atomicWrite(bytes);
+  } catch (e) {
+    if (e.name != "TransactionInactiveError") throw e;
+    // rejected to avoid blocking on flow control
+    // The writable remains un-errored unlike with regular writes
+  } finally {
+    writer.releaseLock();
   }
 }
 </pre>


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/426, superseding #502.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/551.html" title="Last updated on Jan 30, 2024, 11:57 PM UTC (fbc834b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/551/af7ea01...jan-ivar:fbc834b.html" title="Last updated on Jan 30, 2024, 11:57 PM UTC (fbc834b)">Diff</a>