### PR TITLE
Fix wrong internal slot in a note about the datagrams queue.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -590,7 +590,7 @@ algorithm can make progress.
 Note: Writing datagrams while the transport's {{[[State]]}} is `"connecting"` is allowed. The
 datagrams are stored in {{[[OutgoingDatagramsQueue]]}}, and they can be discarded
 in the same manner as when in the `"connected"` state. Once the transport's {{[[State]]}} becomes
-`"connected"`, it will start sending the stored datagrams.
+`"connected"`, it will start sending the queued datagrams.
 
 # `WebTransport` Interface #  {#web-transport}
 

--- a/index.bs
+++ b/index.bs
@@ -588,9 +588,9 @@ The user agent SHOULD run [=sendDatagrams=] for any {{WebTransport}} object whos
 algorithm can make progress.
 
 Note: Writing datagrams while the transport's {{[[State]]}} is `"connecting"` is allowed. The
-datagrams are stored in {{[[OutgoingDatagramsExpirationDuration]]}}, and they can be discarded
-in the same manner as the `"connected"` case. Once the transport's {{[[State]]}} becomes
-`"connected"`, it will start sending stored datagrams.
+datagrams are stored in {{[[OutgoingDatagramsQueue]]}}, and they can be discarded
+in the same manner as when in the `"connected"` state. Once the transport's {{[[State]]}} becomes
+`"connected"`, it will start sending the stored datagrams.
 
 # `WebTransport` Interface #  {#web-transport}
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/556.html" title="Last updated on Oct 18, 2023, 6:56 PM UTC (b53b5d0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/556/967a740...jan-ivar:b53b5d0.html" title="Last updated on Oct 18, 2023, 6:56 PM UTC (b53b5d0)">Diff</a>