### PR TITLE
Reject getStats() promise when the connection is closed/failed.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -987,6 +987,8 @@ these steps.
      1. Run the following steps [=in parallel=]:
          1. Gather the stats from the [=underlying connection=], including stats on datagrams.
          1. [=Queue a network task=] with |transport| to run the following steps:
+           1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
+              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object representing the gathered stats.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.

--- a/index.bs
+++ b/index.bs
@@ -984,11 +984,18 @@ these steps.
    When getStats is called, the user agent MUST run the following steps:
      1. Let |transport| be [=this=].
      1. Let |p| be a new promise.
+     1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
+        {{InvalidStateError}} and abort these steps.
      1. Run the following steps [=in parallel=]:
-         1. Gather the stats from the [=underlying connection=], including stats on datagrams.
+         1. If |transport|.{{[[State]]}} is `"connecting"`, wait until it changes.
+         1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
+            {{InvalidStateError}} and abort these steps.
+	 1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
+	    the most recent stats available for the connection and abort these
+	    steps. The exact point at which those stats are collected is
+	    [=implementation-defined=].
+	 1. Gather the stats from the [=underlying connection=], including stats on datagrams.
          1. [=Queue a network task=] with |transport| to run the following steps:
-           1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
-              [=reject=] |p| with an {{InvalidStateError}} and abort these steps.
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object representing the gathered stats.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.


### PR DESCRIPTION
Fixes #557


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vasilvv/web-transport/pull/558.html" title="Last updated on Nov 20, 2023, 10:57 AM UTC (5dae276)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/558/967a740...vasilvv:5dae276.html" title="Last updated on Nov 20, 2023, 10:57 AM UTC (5dae276)">Diff</a>