### PR TITLE
Fix missing |promise| reference in abortSignal algorithm.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1547,14 +1547,14 @@ To <dfn export for="WebTransportSendStream" lt="create|creating">create</dfn> a
 1. [=WritableStream/Set up=] |stream| with [=WritableStream/set up/writeAlgorithm=] set to
    |writeAlgorithm|, [=WritableStream/set up/closeAlgorithm=] set to |closeAlgorithm|,
    [=WritableStream/set up/abortAlgorithm=] set to |abortAlgorithm|.
-1. [=AbortSignal/Add=] the following steps to |stream|'s \[[controller]]'s \[[signal]].
-  1. If |stream|.{{[[PendingOperation]]}} is null, then abort these steps.
-  1. Let |reason| be |stream|'s \[[controller]]'s \[[signal]]'s [=AbortSignal/abort reason=].
-  1. Let |abortPromise| be the result of [=aborting=] stream with |reason|.
-  1. [=Upon fulfillment=] of |abortPromise|, [=reject=] |promise| with |reason|.
+1. Let |abortSignal| be |stream|'s \[[controller]].\[[abortController]].\[[signal]].
+1. [=AbortSignal/Add=] the following steps to |abortSignal|.
   1. Let |pendingOperation| be |stream|.{{[[PendingOperation]]}}.
+  1. If |pendingOperation| is null, then abort these steps.
   1. Set |stream|.{{[[PendingOperation]]}} to null.
-  1. [=Resolve=] |pendingOperation| with |promise|.
+  1. Let |reason| be |abortSignal|'s [=AbortSignal/abort reason=].
+  1. Let |promise| be the result of [=aborting=] stream with |reason|.
+  1. [=Upon fulfillment=] of |promise|, [=reject=] |pendingOperation| with |reason|.
 1. [=set/Append=] |stream| to |transport|.{{[[SendStreams]]}}.
 1. Return |stream|.
 


### PR DESCRIPTION
Fixes #563.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/564.html" title="Last updated on Nov 1, 2023, 10:49 PM UTC (6519594)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/564/c177c1e...jan-ivar:6519594.html" title="Last updated on Nov 1, 2023, 10:49 PM UTC (6519594)">Diff</a>