### PR TITLE
Reject in-flight write promise on network error.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1094,7 +1094,7 @@ optionally |closeInfo|, run these steps:
 1. [=For each=] |stream| in |sendStreams|, run the following steps:
   1. If |stream|.{{[[PendingOperation]]}} is not null, reject |stream|.{{[[PendingOperation]]}}
      with |error|.
-  1. [=WritableStream/Error=] |sendStream| with |error|.
+  1. [=WritableStream/Error=] |stream| with |error|.
 1. [=For each=] |stream| in |receiveStreams|, [=ReadableStream/error=] |stream|
    with |error|.
 

--- a/index.bs
+++ b/index.bs
@@ -1091,8 +1091,11 @@ optionally |closeInfo|, run these steps:
    to an empty [=queue=].
 1. If |closeInfo| is given, then set |transport|.{{[[State]]}} to `"closed"`.
    Otherwise, set |transport|.{{[[State]]}} to `"failed"`.
-1. [=For each=] |sendStream| in |sendStreams|, [=WritableStream/error=] |sendStream| with |error|.
-1. [=For each=] |receiveStream| in |receiveStreams|, [=ReadableStream/error=] |receiveStream|
+1. [=For each=] |stream| in |sendStreams|, run the following steps:
+  1. If |stream|.{{[[PendingOperation]]}} is not null, reject |stream|.{{[[PendingOperation]]}}
+     with |error|.
+  1. [=WritableStream/Error=] |sendStream| with |error|.
+1. [=For each=] |stream| in |receiveStreams|, [=ReadableStream/error=] |stream|
    with |error|.
 
   Note: Script authors can inject code which runs in Promise resolution synchronously. Hence
@@ -1594,7 +1597,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
   1. If the previous step failed, abort the remaining steps.
 
     Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps
-    error |stream| and reject the result of this write operation.
+    reject |stream|.{{[[PendingOperation]]}}.
 
   1. [=Queue a network task=] with |transport| to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
@@ -1668,6 +1671,8 @@ Whenever a [=WebTransport stream=] associated with a {{WebTransportSendStream}} 
   1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
      {{WebTransportErrorOptions/source}} is `"stream"` and
      {{WebTransportErrorOptions/streamErrorCode}} is |code|.
+  1. If |stream|.{{[[PendingOperation]]}} is not null, reject |stream|.{{[[PendingOperation]]}}
+     with |error|.
   1. [=WritableStream/Error=] |stream| with |error|.
 
 </div>
@@ -1908,7 +1913,7 @@ To <dfn for="WebTransportReceiveStream">pull bytes</dfn> from a {{WebTransportRe
   1. If the previous step failed, abort the remaining steps.
 
     Note: We don't reject |promise| here because we handle network errors elsewhere, and those steps
-    error |stream| and reject the result of this read operation.
+    [=ReadableStream/error=] |stream|, which rejects any read requests awaiting this pull.
 
   1. [=Queue a network task=] with |transport| to run these steps:
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/565.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/566.html" title="Last updated on Dec 5, 2023, 10:10 PM UTC (6db61c9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/566/c177c1e...jan-ivar:6db61c9.html" title="Last updated on Dec 5, 2023, 10:10 PM UTC (6db61c9)">Diff</a>