### PR TITLE
Move normative prose in send algortithms out of notes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1584,7 +1584,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
      sent.
 
-     Note: We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
+     We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
      respond to live updates of these values during sending, though the details are
      [=implementation-defined=].
 

--- a/index.bs
+++ b/index.bs
@@ -1574,11 +1574,19 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      This sending MAY be interleaved with sending of previously queued streams and datagrams,
      as well as streams and datagrams yet to be queued to be sent over this transport.
 
+     The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
+     SHOULD have a fixed upper limit, to carry the backpressure information to the user of the
+     {{WebTransportSendStream}}.
+
      This sending MUST starve
      until all bytes queued for sending on {{WebTransportSendStream}}s with the
      same {{[[SendGroup]]}} and a higher {{[[SendOrder]]}}, that are neither
      [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
      sent.
+
+     Note: We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
+     respond to live updates of these values during sending, though the details are
+     [=implementation-defined=].
 
      This sending MUST NOT starve otherwise,
      except for [=flow control=] reasons or [=WritableStream/Error | error=].
@@ -1586,10 +1594,6 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      The user agent SHOULD divide bandwidth fairly between all streams that aren't starved.
 
      Note: The definition of fairness here is [=implementation-defined=].
-
-    Note: We access |stream|.{{[[SendOrder]]}} [=in parallel=] here. User agents SHOULD
-    respond to live updates of these values during sending, though the details are
-    [=implementation-defined=].
 
   1. If the previous step failed, abort the remaining steps.
 
@@ -1601,9 +1605,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
     1. [=Resolve=] |promise| with undefined.
 1. Return |promise|.
 
-Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
-SHOULD have a fixed upper limit, to carry the backpressure information to the user of
-{{WebTransportSendStream}}. This also means the [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
+Note: The [=fulfilled|fulfillment=] of the promise returned from this algorithm (or,
 {{WritableStreamDefaultWriter/write|WritableStreamDefaultWriter.write}}) does **NOT** necessarily mean that the chunk is acked by
 the server [[!QUIC]]. It may just mean that the chunk is appended to the buffer. To make sure that
 the chunk arrives at the server, use an application-level protocol.
@@ -1900,7 +1902,8 @@ To <dfn for="WebTransportReceiveStream">pull bytes</dfn> from a {{WebTransportRe
      |buffer| with offset |offset|, up to |maxBytes| bytes. Wait until either at least one byte is
      read or FIN is received. Let |read| be the number of read bytes, and let |hasReceivedFIN| be
      whether FIN was accompanied.
-     Note: The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
+
+     The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
      SHOULD have a fixed upper limit, to carry the backpressure information to the server.
 
      Note: This operation may return before filling up all of |bytes|.


### PR DESCRIPTION
Fixes #569.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/570.html" title="Last updated on Nov 21, 2023, 3:20 PM UTC (e60f0d1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/570/c177c1e...jan-ivar:e60f0d1.html" title="Last updated on Nov 21, 2023, 3:20 PM UTC (e60f0d1)">Diff</a>