### PR TITLE
Make estimatedSendRate be `null` instead of `undefined`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1395,8 +1395,8 @@ The dictionary SHALL have the following attributes:
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
    and is calculated by the congestion control algorithm (potentially chosen by
    {{WebTransport/congestionControl}}). If the user agent does not
-   currently have an estimate, the member MUST be [=map/exist|absent=].
-   The member can be absent even if present in previous results.
+   currently have an estimate, the member MUST be the ECMAScript `null` value.
+   The member can be `null` even if it was not `null` in previous results.
 
 
 ## `WebTransportDatagramStats` Dictionary ##  {#web-transport-datagram-stats}

--- a/index.bs
+++ b/index.bs
@@ -1395,7 +1395,7 @@ The dictionary SHALL have the following attributes:
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
    and is calculated by the congestion control algorithm (potentially chosen by
    {{WebTransport/congestionControl}}). If the user agent does not
-   currently have an estimate, the member MUST be the ECMAScript `null` value.
+   currently have an estimate, the member MUST be the `null` value.
    The member can be `null` even if it was not `null` in previous results.
 
 


### PR DESCRIPTION
Fixes #554


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/vasilvv/web-transport/pull/573.html" title="Last updated on Nov 21, 2023, 3:27 PM UTC (0794b98)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/573/c177c1e...vasilvv:0794b98.html" title="Last updated on Nov 21, 2023, 3:27 PM UTC (0794b98)">Diff</a>