### PR TITLE
Add WebTransport.supportsReliableOnly boolean.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -951,7 +951,7 @@ these steps.
    The getter steps are to return [=this=]'s {{[[CongestionControl]]}}.
 
 : <dfn for="WebTransport" attribute>supportsReliableOnly</dfn>
-:: Returns true if the user agent supports [=WebTransport sessions=] over exclusively reliable  [=connections=].
+:: Returns true if the user agent supports [=WebTransport sessions=] over exclusively reliable [=connections=].
    [=connections=], otherwise false.
 
 ## Methods ##  {#webtransport-methods}

--- a/index.bs
+++ b/index.bs
@@ -622,6 +622,8 @@ interface WebTransport {
   /* a ReadableStream of WebTransportReceiveStream objects */
   readonly attribute ReadableStream incomingUnidirectionalStreams;
   WebTransportSendGroup createSendGroup();
+
+  static readonly attribute boolean supportsReliableOnly;
 };
 
 enum WebTransportReliabilityMode {
@@ -947,6 +949,10 @@ these steps.
    throughput or low latency for sending on this connection. If a preference was
    requested but not satisfied, then the value is `"default"`
    The getter steps are to return [=this=]'s {{[[CongestionControl]]}}.
+
+: <dfn for="WebTransport" attribute>supportsReliableOnly</dfn>
+:: Returns true if the user agent supports [=WebTransport sessions=] over HTTP/2
+   [=connections=], otherwise false.
 
 ## Methods ##  {#webtransport-methods}
 

--- a/index.bs
+++ b/index.bs
@@ -951,7 +951,7 @@ these steps.
    The getter steps are to return [=this=]'s {{[[CongestionControl]]}}.
 
 : <dfn for="WebTransport" attribute>supportsReliableOnly</dfn>
-:: Returns true if the user agent supports [=WebTransport sessions=] over HTTP/2
+:: Returns true if the user agent supports [=WebTransport sessions=] over exclusively reliable  [=connections=].
    [=connections=], otherwise false.
 
 ## Methods ##  {#webtransport-methods}

--- a/index.bs
+++ b/index.bs
@@ -951,7 +951,7 @@ these steps.
    The getter steps are to return [=this=]'s {{[[CongestionControl]]}}.
 
 : <dfn for="WebTransport" attribute>supportsReliableOnly</dfn>
-:: Returns true if the user agent supports [=WebTransport sessions=] over exclusively reliable [=connections=].
+:: Returns true if the user agent supports [=WebTransport sessions=] over exclusively reliable
    [=connections=], otherwise false.
 
 ## Methods ##  {#webtransport-methods}


### PR DESCRIPTION
Fixes #518, overtaking https://github.com/w3c/webtransport/pull/568#issuecomment-1821168537.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/575.html" title="Last updated on Dec 6, 2023, 12:38 AM UTC (6fe5ddd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/575/af7ea01...jan-ivar:6fe5ddd.html" title="Last updated on Dec 6, 2023, 12:38 AM UTC (6fe5ddd)">Diff</a>