### PR TITLE
Update reference from RFC6125 to RFC9525.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2395,7 +2395,7 @@ willing to accept connections from the Web.
 
 Normally, a user agent authenticates a TLS connection between itself and a
 remote endpoint by verifying the validity of the TLS server certificate
-provided against the server name in the URL [[!RFC6125]].  This is accomplished
+provided against the server name in the URL [[!RFC9525]].  This is accomplished
 by chaining server certificates to one of the trust anchors maintained by the
 user agent; the trust anchors in question are responsible for authenticating
 the server names in the certificates.  We will refer to this system as Web PKI.


### PR DESCRIPTION
Fixes build error in https://github.com/w3c/webtransport/pull/575#issuecomment-1841673458.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/576.html" title="Last updated on Dec 5, 2023, 9:53 PM UTC (921bf2b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/576/af7ea01...jan-ivar:921bf2b.html" title="Last updated on Dec 5, 2023, 9:53 PM UTC (921bf2b)">Diff</a>