### PR TITLE
Rename "Data Recvd" to "all data committed"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1656,6 +1656,7 @@ To <dfn for="WebTransportSendStream">close</dfn> a {{WebTransportSendStream}} |s
 1. Run the following steps [=in parallel=]:
   1. [=stream/Send=] FIN on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the operation to
      complete.
+  1. Wait for |stream|.{{WebTransportSendStream/[[InternalStream]]}} to enter the "all data committed" state. [[!QUIC]]
   1. [=Queue a network task=] with |transport| to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
     1. [=Resolve=] |promise| with undefined.

--- a/index.bs
+++ b/index.bs
@@ -1656,7 +1656,6 @@ To <dfn for="WebTransportSendStream">close</dfn> a {{WebTransportSendStream}} |s
 1. Run the following steps [=in parallel=]:
   1. [=stream/Send=] FIN on |stream|.{{WebTransportSendStream/[[InternalStream]]}} and wait for the operation to
      complete.
-  1. Wait for |stream|.{{WebTransportSendStream/[[InternalStream]]}} to enter the "Data Recvd" state. [[!QUIC]]
   1. [=Queue a network task=] with |transport| to run these steps:
     1. Set |stream|.{{[[PendingOperation]]}} to null.
     1. [=Resolve=] |promise| with undefined.


### PR DESCRIPTION
As discussed in https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http2/issues/103

This is NOT the only place where this state is used.  That one needs a few more grey matter cycles before I have a resolution.  I'll open an issue instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/webtransport/pull/580.html" title="Last updated on Jan 14, 2025, 3:38 PM UTC (ba41dea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/580/607bfa8...martinthomson:ba41dea.html" title="Last updated on Jan 14, 2025, 3:38 PM UTC (ba41dea)">Diff</a>