### PR TITLE
Remove dependency on Data Recvd signals in cleanup

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1155,13 +1155,10 @@ series of steps |steps|, run these steps:
 Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} |transport| is
 [=session/terminated=] with optionally |code| and |reasonBytes|, run these steps:
 
-1. Let |cleanly| be a boolean representing whether |transport|.{{[[Session]]}}'s [=CONNECT stream=]
-   is in the "Data Recvd" state. [[!QUIC]]
 1. [=Queue a network task=] with |transport| to run these steps:
   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, abort these steps.
   1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
      {{WebTransportErrorOptions/source}} is `"session"`.
-  1. If |cleanly| is false, then [=cleanup=] |transport| with |error|, and abort these steps.
   1. Let |closeInfo| be a [=new=] {{WebTransportCloseInfo}}.
   1. If |code| is given, set |closeInfo|'s {{WebTransportCloseInfo/closeCode}} to |code|.
   1. If |reasonBytes| is given, set |closeInfo|'s {{WebTransportCloseInfo/reason}} to |reasonBytes|,


### PR DESCRIPTION
This is a simplification, which will cause applications to see errors more often, but I think that it is a good one.

Closes #581.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/webtransport/pull/582.html" title="Last updated on Jan 23, 2024, 11:38 PM UTC (8be3017)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/582/607bfa8...martinthomson:8be3017.html" title="Last updated on Jan 23, 2024, 11:38 PM UTC (8be3017)">Diff</a>