### PR TITLE
Add examples for reading with BYOB readers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2704,10 +2704,9 @@ async function receiveDatagrams(url) {
 
 *This section is non-normative.*
 
-As {{WebTransport/datagrams}} are [=ReadableStream/readable byte streams=],
-you can acquire a [=ReadableStream/BYOB reader=] for them, which allows more
-precise control over buffer allocation in order to avoid copies. This example
-reads the datagram into a 64kB memory buffer.
+As {{WebTransport/datagrams}} are [=readable byte streams=], you can acquire a
+[=BYOB reader=] for them, which allows more precise control over buffer allocation
+in order to avoid copies. This example reads the datagram into a 64kB memory buffer.
 
 <pre class="example" highlight="js">
 const wt = new WebTransport(url);
@@ -2824,10 +2823,10 @@ async function receiveText(url, createWritableStreamForTextData) {
 
 *This section is non-normative.*
 
-As {{WebTransportReceiveStream}}s are [=ReadableStream/readable byte streams=], you
-can acquire a [=ReadableStream/BYOB reader=] for them, which allows more precise
-control over buffer allocation in order to avoid copies. This example reads the
-first 1024 bytes from a {{WebTransportReceiveStream}} into a single memory buffer.
+As {{WebTransportReceiveStream}}s are [=readable byte streams=], you can acquire a
+[=BYOB reader=] for them, which allows more precise control over buffer allocation
+in order to avoid copies. This example reads the first 1024 bytes from a
+{{WebTransportReceiveStream}} into a single memory buffer.
 
 <pre class="example" highlight="js">
 const wt = new WebTransport(url);

--- a/index.bs
+++ b/index.bs
@@ -2700,6 +2700,42 @@ async function receiveDatagrams(url) {
 }
 </pre>
 
+## Receiving datagrams with a BYOB reader ## {#example-datagrams-byob}
+
+*This section is non-normative.*
+
+As {{WebTransport/datagrams}} are [=ReadableStream/readable byte streams=],
+you can acquire a [=ReadableStream/BYOB reader=] for them, which allows more
+precise control over buffer allocation in order to avoid copies. This example
+reads the datagram into a 64kB memory buffer.
+
+<pre class="example" highlight="js">
+const wt = new WebTransport(url);
+
+for await (const datagram of wt.datagrams.readable) {
+  const reader = datagram.getReader({ mode: "byob" });
+  
+  let array_buffer = new ArrayBuffer(65536);
+  const buffer = await readInto(array_buffer);
+}
+
+async function readInto(buffer) {
+  let offset = 0;
+
+  while (offset < buffer.byteLength) {
+    const {value: view, done} = await reader.read(
+        new Uint8Array(buffer, offset, buffer.byteLength - offset));
+    buffer = view.buffer;
+    if (done) {
+      break;
+    }
+    offset += view.byteLength;
+  }
+
+  return buffer;
+}
+</pre>
+
 ## Sending a stream ##  {#example-sending-stream}
 
 *This section is non-normative.*
@@ -2781,6 +2817,42 @@ async function receiveText(url, createWritableStreamForTextData) {
       console.error(e);
     }
   }
+}
+</pre>
+
+## Receiving a stream with a BYOB reader ## {#example-stream-byob}
+
+*This section is non-normative.*
+
+As {{WebTransportReceiveStream}}s are [=ReadableStream/readable byte streams=], you
+can acquire a [=ReadableStream/BYOB reader=] for them, which allows more precise
+control over buffer allocation in order to avoid copies. This example reads the
+first 1024 bytes from a {{WebTransportReceiveStream}} into a single memory buffer.
+
+<pre class="example" highlight="js">
+const wt = new WebTransport(url);
+
+const reader = wt.incomingUnidirectionalStreams.getReader();
+const { value: recv_stream, done } = await reader.read();
+const byob_reader = recv_stream.getReader({ mode: "byob" });
+
+let array_buffer = new ArrayBuffer(1024);
+const buffer = await readInto(array_buffer);
+
+async function readInto(buffer) {
+  let offset = 0;
+
+  while (offset < buffer.byteLength) {
+    const {value: view, done} = await reader.read(
+        new Uint8Array(buffer, offset, buffer.byteLength - offset));
+    buffer = view.buffer;
+    if (done) {
+      break;
+    }
+    offset += view.byteLength;
+  }
+
+  return buffer;
 }
 </pre>
 


### PR DESCRIPTION
This PR adds an example for reading datagrams and one for receive streams with a BYOB reader.

Fixes https://github.com/w3c/webtransport/issues/131.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/584.html" title="Last updated on Jan 31, 2024, 1:09 AM UTC (69988a2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/584/3d22dbb...nidhijaju:69988a2.html" title="Last updated on Jan 31, 2024, 1:09 AM UTC (69988a2)">Diff</a>