### PR TITLE
Add expiredIncoming

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1440,21 +1440,26 @@ on datagram transmission over the [=underlying connection=].
 
 <pre class="idl">
 dictionary WebTransportDatagramStats {
-  unsigned long long expiredOutgoing;
   unsigned long long droppedIncoming;
+  unsigned long long expiredIncoming;
+  unsigned long long expiredOutgoing;
   unsigned long long lostOutgoing;
 };
 </pre>
 
 The dictionary SHALL have the following attributes:
 
-: <dfn for="WebTransportDatagramStats" dict-member>expiredOutgoing</dfn>
-:: The number of datagrams queued for sending that were dropped, due to being
-   older than {{outgoingMaxAge}} before they were able to be sent.
 : <dfn for="WebTransportDatagramStats" dict-member>droppedIncoming</dfn>
-:: The number of incoming datagrams that were dropped, due to the application not reading
+:: The number of incoming datagrams that were dropped due to the application not reading
   from {{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}
   before new datagrams overflow the receive queue.
+: <dfn for="WebTransportDatagramStats" dict-member>expiredIncoming</dfn>
+:: The number of incoming datagrams that were dropped due to being older than
+  {{incomingMaxAge}} before they were read from {{WebTransport/datagrams}}'
+  {{WebTransportDatagramDuplexStream/readable}}.
+: <dfn for="WebTransportDatagramStats" dict-member>expiredOutgoing</dfn>
+:: The number of datagrams queued for sending that were dropped due to being
+   older than {{outgoingMaxAge}} before they were able to be sent.
 : <dfn for="WebTransportDatagramStats" dict-member>lostOutgoing</dfn>
 :: The number of sent datagrams that were declared lost, as defined in
    [[!RFC9002]] [Section 6.1](https://www.rfc-editor.org/rfc/rfc9002#section-6.1).


### PR DESCRIPTION
This PR adds the `expiredIncoming` stat and formats the section a little bit.

Fixes https://github.com/w3c/webtransport/issues/553.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/585.html" title="Last updated on Jan 29, 2024, 3:18 AM UTC (fd3181a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/585/607bfa8...nidhijaju:fd3181a.html" title="Last updated on Jan 29, 2024, 3:18 AM UTC (fd3181a)">Diff</a>