### PR TITLE
Add note about unavailability of stats

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1381,6 +1381,9 @@ on the same [=connection=] all receive the same information, i.e. the informatio
 is disclosed across pooled [=WebTransport sessions | sessions=] holding the
 same [[fetch#network-partition-keys|network partition key]].
 
+Note: The availability of underlying transport stats may differ for each platform.
+Unavailable entries will be absent from the {{WebTransportConnectionStats}} dictionary.
+
 <pre class="idl">
 dictionary WebTransportConnectionStats {
   unsigned long long bytesSent;

--- a/index.bs
+++ b/index.bs
@@ -1381,8 +1381,7 @@ on the same [=connection=] all receive the same information, i.e. the informatio
 is disclosed across pooled [=WebTransport sessions | sessions=] holding the
 same [[fetch#network-partition-keys|network partition key]].
 
-Note: The availability of underlying transport stats may differ for each platform.
-Unavailable entries will be absent from the {{WebTransportConnectionStats}} dictionary.
+Note: Any unavailable stats will be [=map/exists|absent=] from the {{WebTransportConnectionStats}} dictionary.
 
 <pre class="idl">
 dictionary WebTransportConnectionStats {


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/567.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/586.html" title="Last updated on Jan 31, 2024, 12:48 AM UTC (3937549)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/586/607bfa8...nidhijaju:3937549.html" title="Last updated on Jan 31, 2024, 12:48 AM UTC (3937549)">Diff</a>