### PR TITLE
Add more conditions for garbage collection

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,7 +66,7 @@ spec:infra; type:dfn; for:set; text:for each
 spec:infra; type:dfn; for:/; text:set
 spec:streams; type:interface; text:ReadableStream
 spec:fetch; type:dfn; for:/; text:fetch
-spec:fetch; type:dfn; text:credentials
+spec:fetch; type:dfn; for:/; text:credentials
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 spec:infra; type:dfn; for:/; text:ASCII case-insensitive

--- a/index.bs
+++ b/index.bs
@@ -1207,16 +1207,16 @@ This specification defines <dfn>context cleanup steps</dfn> as the following ste
 
 A {{WebTransport}} object whose {{[[State]]}} is `"connecting"` must not be garbage collected if
 {{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
-{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{[[Readable]]}} is [=ReadableStream/locked=],
-or if the {{ready}}, {{draining}}, or {{closed}} promise is being awaited.
+{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+is [=ReadableStream/locked=], or if the {{ready}}, {{draining}}, or {{closed}} promise is being observed.
 
 A {{WebTransport}} object whose {{[[State]]}} is `"connected"` must not be garbage collected if
 {{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
-{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{[[Readable]]}} is [=ReadableStream/locked=],
-or if the {{draining}} or {{closed}} promise is being awaited.
+{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+is [=ReadableStream/locked=], or if the {{draining}} or {{closed}} promise is being observed.
 
 A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbage
-collected if the {{closed}} promise is being awaited.
+collected if the {{closed}} promise is being observed.
 
 A {{WebTransport}} object with an [=session/established=] [=WebTransport session=]
 that has data queued to be transmitted to the network, including datagrams in

--- a/index.bs
+++ b/index.bs
@@ -1208,12 +1208,12 @@ This specification defines <dfn>context cleanup steps</dfn> as the following ste
 A {{WebTransport}} object whose {{[[State]]}} is `"connecting"` must not be garbage collected if
 {{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
 {{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
-is [=ReadableStream/locked=], or if the {{ready}}, {{draining}}, or {{closed}} promise is being observed.
+are [=ReadableStream/locked=], or if the {{ready}}, {{draining}}, or {{closed}} promise is being observed.
 
 A {{WebTransport}} object whose {{[[State]]}} is `"connected"` must not be garbage collected if
 {{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
 {{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
-is [=ReadableStream/locked=], or if the {{draining}} or {{closed}} promise is being observed.
+are [=ReadableStream/locked=], or if the {{draining}} or {{closed}} promise is being observed.
 
 A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbage
 collected if the {{closed}} promise is being observed.

--- a/index.bs
+++ b/index.bs
@@ -1205,8 +1205,27 @@ This specification defines <dfn>context cleanup steps</dfn> as the following ste
 
 ## Garbage Collection ## {#web-transport-gc}
 
-The user agent MUST NOT garbage collect a {{WebTransport}} object whose {{[[State]]}} is either
-`"connecting"` or `"connected"`.
+A {{WebTransport}} object whose {{[[State]]}} is `"connecting"` must not be garbage collected if
+{{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
+{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{[[Readable]]}} is [=ReadableStream/locked=],
+or if the {{ready}}, {{draining}}, or {{closed}} promise is being awaited.
+
+A {{WebTransport}} object whose {{[[State]]}} is `"connected"` must not be garbage collected if
+{{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
+{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{[[Readable]]}} is [=ReadableStream/locked=],
+or if the {{draining}} or {{closed}} promise is being awaited.
+
+A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbage
+collected if the {{closed}} promise is being awaited.
+
+A {{WebTransport}} object with an [=session/established=] [=WebTransport session=]
+that has data queued to be transmitted to the network, including datagrams in
+{{[[Datagrams]]}}.{{[[OutgoingDatagramsQueue]]}}, must not be garbage collected.
+
+If a {{WebTransport}} object is garbage collected while the [=underlying connection=]
+is still open, the user agent must 
+<a href="https://www.ietf.org/archive/id/draft-ietf-webtrans-overview-06.html#section-4.1-2.4.1">terminate the WebTransport session</a>
+with an Application Error Code of `0` and Application Error Message of `""`.
 
 ## Configuration ##  {#web-transport-configuration}
 

--- a/index.bs
+++ b/index.bs
@@ -66,6 +66,7 @@ spec:infra; type:dfn; for:set; text:for each
 spec:infra; type:dfn; for:/; text:set
 spec:streams; type:interface; text:ReadableStream
 spec:fetch; type:dfn; for:/; text:fetch
+spec:fetch; type:dfn; text:credentials
 spec:url; type:dfn; text:scheme
 spec:url; type:dfn; text:fragment
 spec:infra; type:dfn; for:/; text:ASCII case-insensitive
@@ -997,11 +998,11 @@ these steps.
          1. If |transport|.{{[[State]]}} is `"connecting"`, wait until it changes.
          1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
             {{InvalidStateError}} and abort these steps.
-	 1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
-	    the most recent stats available for the connection and abort these
-	    steps. The exact point at which those stats are collected is
-	    [=implementation-defined=].
-	 1. Gather the stats from the [=underlying connection=], including stats on datagrams.
+   1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
+      the most recent stats available for the connection and abort these
+      steps. The exact point at which those stats are collected is
+      [=implementation-defined=].
+   1. Gather the stats from the [=underlying connection=], including stats on datagrams.
          1. [=Queue a network task=] with |transport| to run the following steps:
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object representing the gathered stats.
            1. [=Resolve=] |p| with |stats|.

--- a/index.bs
+++ b/index.bs
@@ -1215,8 +1215,10 @@ A {{WebTransport}} object whose {{[[State]]}} is `"connected"` must not be garba
 {{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
 are [=ReadableStream/locked=], or if the {{draining}} or {{closed}} promise is being observed.
 
-A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbage
-collected if the {{closed}} promise is being observed.
+A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbage collected if
+{{[[IncomingBidirectionalStreams]]}}, {{[[IncomingUnidirectionalStreams]]}}, any
+{{WebTransportReceiveStream}}, or {{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[Readable]]}}
+are [=ReadableStream/locked=], or if the {{closed}} promise is being observed.
 
 A {{WebTransport}} object with an [=session/established=] [=WebTransport session=]
 that has data queued to be transmitted to the network, including datagrams in

--- a/index.bs
+++ b/index.bs
@@ -998,11 +998,11 @@ these steps.
          1. If |transport|.{{[[State]]}} is `"connecting"`, wait until it changes.
          1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
             {{InvalidStateError}} and abort these steps.
-   1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
-      the most recent stats available for the connection and abort these
-      steps. The exact point at which those stats are collected is
-      [=implementation-defined=].
-   1. Gather the stats from the [=underlying connection=], including stats on datagrams.
+         1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
+            the most recent stats available for the connection and abort these
+            steps. The exact point at which those stats are collected is
+            [=implementation-defined=].
+         1. Gather the stats from the [=underlying connection=], including stats on datagrams.
          1. [=Queue a network task=] with |transport| to run the following steps:
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object representing the gathered stats.
            1. [=Resolve=] |p| with |stats|.

--- a/index.bs
+++ b/index.bs
@@ -998,11 +998,11 @@ these steps.
          1. If |transport|.{{[[State]]}} is `"connecting"`, wait until it changes.
          1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
             {{InvalidStateError}} and abort these steps.
-         1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
-            the most recent stats available for the connection and abort these
-            steps. The exact point at which those stats are collected is
-            [=implementation-defined=].
-         1. Gather the stats from the [=underlying connection=], including stats on datagrams.
+	 1. If |transport|.{{[[State]]}} is `"closed"`, [=resolve=] |p| with
+	    the most recent stats available for the connection and abort these
+	    steps. The exact point at which those stats are collected is
+	    [=implementation-defined=].
+	 1. Gather the stats from the [=underlying connection=], including stats on datagrams.
          1. [=Queue a network task=] with |transport| to run the following steps:
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object representing the gathered stats.
            1. [=Resolve=] |p| with |stats|.


### PR DESCRIPTION
This PR allows more aggressive garbage collection, by not allowing it only if there is a lock on readable streams or if there is a relevant promise that is still being awaited.

Fixes https://github.com/w3c/webtransport/issues/560.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/587.html" title="Last updated on Feb 14, 2024, 1:54 AM UTC (25b7202)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/587/363c152...nidhijaju:25b7202.html" title="Last updated on Feb 14, 2024, 1:54 AM UTC (25b7202)">Diff</a>