### PR TITLE
Add reference for "first-strong"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1168,7 +1168,8 @@ Whenever a [=WebTransport session=] which is associated with a {{WebTransport}} 
      [=UTF-8 decoded=].
      
      Note: No language or direction metadata is available with |reasonBytes|. 
-     First-strong heuristics can be used for direction when displaying the value.
+     <a href=https://www.w3.org/TR/string-meta/#firststrong>First-strong</a> heuristics can be used
+     for direction when displaying the value.
   1. [=Cleanup=] |transport| with |error| and |closeInfo|.
 
 </div>


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/583.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/588.html" title="Last updated on Jan 30, 2024, 4:22 AM UTC (fcc0d0d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/588/607bfa8...nidhijaju:fcc0d0d.html" title="Last updated on Jan 30, 2024, 4:22 AM UTC (fcc0d0d)">Diff</a>