### PR TITLE
Add spec reference for datagrams definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -148,12 +148,12 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
  </thead>
  <tbody>
   <tr>
-   <td><dfn>send a datagram</dfn>
+   <td><dfn>send a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#name-datagrams)</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
    [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.2-6.2.1)
   </tr>
   <tr>
-   <td><dfn>receive a datagram</dfn>
+   <td><dfn>receive a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#name-datagrams)</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
    [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.2-6.4.1)
   </tr>


### PR DESCRIPTION
This PR links to the IETF webtransport overview doc's definition of datagrams for added clarification.

Fixes https://github.com/w3c/webtransport/issues/542.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/591.html" title="Last updated on Feb 24, 2024, 8:29 AM UTC (0e482d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/591/bef2379...nidhijaju:0e482d3.html" title="Last updated on Feb 24, 2024, 8:29 AM UTC (0e482d3)">Diff</a>