### PR TITLE
Add example for server certificate hashes

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3014,7 +3014,7 @@ async function sendTransactionalData(wt, bytes) {
 A WebTransport session can override the default trust evaluation performed by
 the client with a check against the hash of the certificate provided to the
 server. In the example below, `hashValue` is a {{BufferSource}} containing the
-sha-256 hash of a server certificate that the [=underlying connection=] should
+SHA-256 hash of a server certificate that the [=underlying connection=] should
 consider to be valid.
 
 <pre class="example" highlight="js">

--- a/index.bs
+++ b/index.bs
@@ -3007,6 +3007,28 @@ async function sendTransactionalData(wt, bytes) {
 }
 </pre>
 
+## Using a server certificate hash ## {#example-server-certificate-hash}
+
+*This section is non-normative.*
+
+A WebTransport connection can override the default trust evaluation performed by
+the client with a check against the hash of the certificate provided to the
+server. In the example below, hashValue is a {{BufferSource}} containing the
+sha-256 hash of a server certificate that the WebTransport connection should
+consider to be valid.
+
+<pre class="example" highlight="js>
+const wt = new WebTransport(url, {
+  serverCertificateHashes: [
+    {
+      algorithm: "sha-256",
+      value: hashValue,
+    }
+  ]
+});
+await wt.ready;
+</pre>
+
 ## Complete example ##  {#example-complete}
 
 *This section is non-normative.*

--- a/index.bs
+++ b/index.bs
@@ -3017,7 +3017,7 @@ server. In the example below, hashValue is a {{BufferSource}} containing the
 sha-256 hash of a server certificate that the WebTransport connection should
 consider to be valid.
 
-<pre class="example" highlight="js>
+<pre class="example" highlight="js">
 const wt = new WebTransport(url, {
   serverCertificateHashes: [
     {

--- a/index.bs
+++ b/index.bs
@@ -3011,10 +3011,10 @@ async function sendTransactionalData(wt, bytes) {
 
 *This section is non-normative.*
 
-A WebTransport connection can override the default trust evaluation performed by
+A WebTransport session can override the default trust evaluation performed by
 the client with a check against the hash of the certificate provided to the
-server. In the example below, hashValue is a {{BufferSource}} containing the
-sha-256 hash of a server certificate that the WebTransport connection should
+server. In the example below, `hashValue` is a {{BufferSource}} containing the
+sha-256 hash of a server certificate that the [=underlying connection=] should
 consider to be valid.
 
 <pre class="example" highlight="js">


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/508.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/592.html" title="Last updated on Feb 27, 2024, 8:33 AM UTC (d502680)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/592/09dc62d...nidhijaju:d502680.html" title="Last updated on Feb 27, 2024, 8:33 AM UTC (d502680)">Diff</a>