### PR TITLE
Default to allow the server to create >= 100 uni and >=100 bidi streams.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1342,6 +1342,8 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingUnidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=incoming unidirectional=] streams it anticipates the server creating.
+   If null, the user agent MUST from the outset allow at least 100 [=incoming unidirectional=]
+   streams from the server.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingUnidirectionalStreams]]}} into consideration in its
    negotiations with the server.
@@ -1349,6 +1351,8 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingBidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=bidirectional=] streams it anticipates a server creating.
+   If null, the user agent MUST from the outset allow the server to create at least 100
+   [=bidirectional=] streams.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its
    negotiations with the server.

--- a/index.bs
+++ b/index.bs
@@ -1342,7 +1342,7 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingUnidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=incoming unidirectional=] streams it anticipates the server creating.
-   If null, the user agent MUST from the outset allow at least 100 [=incoming unidirectional=]
+   The user agent MUST from the outset allow at least 100 [=incoming unidirectional=]
    streams from the server.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingUnidirectionalStreams]]}} into consideration in its

--- a/index.bs
+++ b/index.bs
@@ -1351,7 +1351,7 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingBidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=bidirectional=] streams it anticipates a server creating.
-   If null, the user agent MUST from the outset allow the server to create at least 100
+   The user agent MUST from the outset allow the server to create at least 100
    [=bidirectional=] streams.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its

--- a/index.bs
+++ b/index.bs
@@ -1342,7 +1342,7 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingUnidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=incoming unidirectional=] streams it anticipates the server creating.
-   The user agent MUST from the outset allow at least 100 [=incoming unidirectional=]
+   The user agent MUST initially allow at least 100 [=incoming unidirectional=]
    streams from the server.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingUnidirectionalStreams]]}} into consideration in its

--- a/index.bs
+++ b/index.bs
@@ -1351,7 +1351,7 @@ that determine how the [=WebTransport session=] is established and used.
 : <dfn for="WebTransportOptions" dict-member>anticipatedConcurrentIncomingBidirectionalStreams</dfn>
 :: Optionally lets an application specify the number of concurrently open
    [=bidirectional=] streams it anticipates a server creating.
-   The user agent MUST from the outset allow the server to create at least 100
+   The user agent MUST initially allow the server to create at least 100
    [=bidirectional=] streams.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its


### PR DESCRIPTION
Fixes #541.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/593.html" title="Last updated on Feb 28, 2024, 12:41 AM UTC (6133b23)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/593/8db4c49...jan-ivar:6133b23.html" title="Last updated on Feb 28, 2024, 12:41 AM UTC (6133b23)">Diff</a>