### PR TITLE
Update normative RFC references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -28,14 +28,14 @@ Boilerplate: omit conformance
     "authors": ["Jana Iyengar", "Martin Thomson"],
     "href": "https://www.rfc-editor.org/rfc/rfc9000",
     "title": "QUIC: A UDP-Based Multiplexed and Secure Transport",
-    "status": "Internet-Draft",
+    "status": "Proposed Standard",
     "publisher": "IETF"
   },
   "quic-datagram": {
     "authors": ["Tommy Pauly", "Eric Kinnear", "David Schinazi"],
     "href": "https://www.rfc-editor.org/rfc/rfc9221",
     "title": "An Unreliable Datagram Extension to QUIC",
-    "status": "Internet-Draft",
+    "status": "Proposed Standard",
     "publisher": "IETF"
   },
   "web-transport-overview": {


### PR DESCRIPTION
Update normative RFC references to replace "Internet Draft" status with "Proposed Standard"


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/594.html" title="Last updated on Feb 28, 2024, 3:36 PM UTC (1e3cb0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/594/2272f05...1e3cb0a.html" title="Last updated on Feb 28, 2024, 3:36 PM UTC (1e3cb0a)">Diff</a>