### PR TITLE
Add note about retransmissions and send order

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1743,7 +1743,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      [=implementation-defined=].
 
      Note: Ordering of retransmissions is [=implementation-defined=],
-     but user agents are strongly advised to prioritize retransmissions of data with
+     but user agents are encouraged to prioritize retransmissions of data with
      higher {{[[SendOrder]]}} values.
 
      This sending MUST NOT starve otherwise,

--- a/index.bs
+++ b/index.bs
@@ -1743,7 +1743,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      [=implementation-defined=].
 
      Note: Ordering of retransmissions is [=implementation-defined=],
-     but user agents are encouraged to prioritize retransmissions of data with
+     but user agents are strongly encouraged to prioritize retransmissions of data with
      higher {{[[SendOrder]]}} values.
 
      This sending MUST NOT starve otherwise,

--- a/index.bs
+++ b/index.bs
@@ -1742,6 +1742,11 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      respond to live updates of these values during sending, though the details are
      [=implementation-defined=].
 
+     Note: User agents are encouraged to retransmit lost data at a higher priority
+     than sending new data. Ordering of retransmissions is [=implementation-defined=],
+     but user agents are strongly advised to prioritize retransmissions of data with
+     higher {{[[SendOrder]]}} values.
+
      This sending MUST NOT starve otherwise,
      except for [=flow control=] reasons or [=WritableStream/Error | error=].
 

--- a/index.bs
+++ b/index.bs
@@ -1742,8 +1742,7 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
      respond to live updates of these values during sending, though the details are
      [=implementation-defined=].
 
-     Note: User agents are encouraged to retransmit lost data at a higher priority
-     than sending new data. Ordering of retransmissions is [=implementation-defined=],
+     Note: Ordering of retransmissions is [=implementation-defined=],
      but user agents are strongly advised to prioritize retransmissions of data with
      higher {{[[SendOrder]]}} values.
 


### PR DESCRIPTION
Fixes https://github.com/w3c/webtransport/issues/523.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/nidhijaju/webtransport/pull/595.html" title="Last updated on Mar 26, 2024, 11:27 PM UTC (a71f242)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/595/9dd3692...nidhijaju:a71f242.html" title="Last updated on Mar 26, 2024, 11:27 PM UTC (a71f242)">Diff</a>