### PR TITLE
Add protocols constructor argument to WebTransport + protocol read arg

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -181,7 +181,7 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
 </table>
 
 To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin| and a
-|protocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
+|subprotocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
 [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1),
 with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
 as the [:Origin:] header of the request.

--- a/index.bs
+++ b/index.bs
@@ -904,9 +904,9 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
       1. Abort these steps.
     1. Set |transport|.{{[[State]]}} to `"connected"`.
     1. Set |transport|.{{[[Session]]}} to |session|.
-    1. If the connection is an HTTP/3 connection, set |transport|'s {{[[Reliability]]}} to `"supports-unreliable"`,
-       and set {{[[Protocol]]}} to the `WebTransport-Subprotocol` header field in the 2xx response to the
-       CONNECT request if present, following [[!WEB-TRANSPORT-HTTP3]]
+    1. If the connection is an HTTP/3 connection, set |transport|.{{[[Reliability]]}} to `"supports-unreliable"`,
+       and set |transport|.{{[[Protocol]]}} to the `WebTransport-Subprotocol` header field in the 2xx response to
+       the CONNECT request if present, following [[!WEB-TRANSPORT-HTTP3]]
        [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
     1. If the connection is an HTTP/2 connection [[!WEB-TRANSPORT-HTTP2]], set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
     1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.

--- a/index.bs
+++ b/index.bs
@@ -181,8 +181,7 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
 </table>
 
 To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin| and a
-|protocols| array,
-follow [[!WEB-TRANSPORT-OVERVIEW]]
+|protocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
 [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1),
 with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
 as the [:Origin:] header of the request.
@@ -907,7 +906,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Set |transport|.{{[[Session]]}} to |session|.
     1. If the connection is an HTTP/3 connection, set |transport|'s {{[[Reliability]]}} to `"supports-unreliable"`,
        and set {{[[Protocol]]}} to the `WebTransport-Subprotocol` header field in the 2xx response to the
-       CONNECT request, following [[!WEB-TRANSPORT-HTTP3]]
+       CONNECT request if present, following [[!WEB-TRANSPORT-HTTP3]]
        [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
     1. If the connection is an HTTP/2 connection [[!WEB-TRANSPORT-HTTP2]], set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
     1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.

--- a/index.bs
+++ b/index.bs
@@ -188,8 +188,8 @@ as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
 Additionally, if the [=underlying connection=] is using HTTP/3 and the |protocols| array is non-empty,
-add a `WebTransport-Subprotocols-Available` header field containing [=isomorphic encoded=] |protocols|
-in the CONNECT request following [[!WEB-TRANSPORT-HTTP3]]
+add a `WebTransport-Subprotocols-Available` header field to the CONNECT request, containing
+[=isomorphic encoded=] protocols from |protocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
 [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
@@ -764,7 +764,7 @@ agent MUST run the following steps:
 1. If any of the values in |protocols| occur more than once, fail to match
    the requirements for elements that comprise the value of `WebTransport-Subprotocol`
    fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
-   length exceeding 512, [=throw=] a {{SyntaxError}} exception.
+   length of 0 or exceeding 512, [=throw=] a {{SyntaxError}} exception.
    [[!WEB-TRANSPORT-HTTP3]]
    [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 1. Let |anticipatedConcurrentIncomingUnidirectionalStreams| be {{WebTransport/constructor(url, options)/options}}'s

--- a/index.bs
+++ b/index.bs
@@ -180,13 +180,18 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
  </tbody>
 </table>
 
-To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin|,
+To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin| and a
+|protocols| array,
 follow [[!WEB-TRANSPORT-OVERVIEW]]
 [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1),
 with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
+Additionally, if the [=underlying connection=] is using HTTP/3 and the |protocols| array is non-empty,
+add a `WebTransport-Subprotocols-Available` header field containing [=isomorphic encoded=] |protocols|
+in the CONNECT request following [[!WEB-TRANSPORT-HTTP3]]
+[Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 [=CONNECT stream=] receives an [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when a
@@ -610,6 +615,7 @@ interface WebTransport {
   readonly attribute WebTransportCongestionControl congestionControl;
   [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams;
   [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingBidirectionalStreams;
+  readonly attribute DOMString protocol;
 
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
   readonly attribute Promise&lt;undefined&gt; draining;
@@ -704,6 +710,11 @@ A {{WebTransport}} object has the following internal slots.
    [=bidirectional=] streams the application anticipates the server creating, or null.
   </tr>
   <tr>
+   <td><dfn>`[[Protocol]]`</dfn>
+   <td class="non-normative">A string indicating the subprotocol selected by the server,
+   if any. Initially an empty string.
+  </tr>
+  <tr>
    <td><dfn>`[[Closed]]`</dfn>
    <td class="non-normative">A promise fulfilled when the associated {{WebTransport}} object is
    closed gracefully, or rejected when it is closed abruptly or failed on initialization.
@@ -749,6 +760,14 @@ agent MUST run the following steps:
    congestion control algorithms that optimize for |congestionControl|, as allowed by
    [[!RFC9002]] [Section 7](https://www.rfc-editor.org/rfc/rfc9002#section-7),
    then set |congestionControl| to `"default"`.
+1. Let |protocols| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/protocols}}
+1. If any of the values in |protocols| occur more than once, fail to match
+   the requirements for elements that comprise the value of `WebTransport-Subprotocol`
+   fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
+   length exceeding 512, [=throw=] a {{SyntaxError}} exception.
+   [[!WEB-TRANSPORT-HTTP3]]
+   [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 1. Let |anticipatedConcurrentIncomingUnidirectionalStreams| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/anticipatedConcurrentIncomingUnidirectionalStreams}}.
 1. Let |anticipatedConcurrentIncomingBidirectionalStreams| be {{WebTransport/constructor(url, options)/options}}'s
@@ -779,6 +798,8 @@ agent MUST run the following steps:
     :: |anticipatedConcurrentIncomingUnidirectionalStreams|
     : {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}}
     :: |anticipatedConcurrentIncomingBidirectionalStreams|
+    : {{[[Protocol]]}}
+    :: an empty string
     : {{[[Closed]]}}
     :: a new promise
     : {{[[Draining]]}}
@@ -811,7 +832,7 @@ This will ensure the stream is not errored due to a datagram being larger than t
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated|,
-   |requireUnreliable|, |congestionControl|, and |serverCertificateHashes|.
+   |requireUnreliable|, |congestionControl|, |protocols|, and |serverCertificateHashes|.
 1. Return |transport|.
 
 </div>
@@ -819,7 +840,8 @@ This will ensure the stream is not errored due to a datagram being larger than t
 <div algorithm>
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 <var>transport</var>, a [=URL record=] |url|, a boolean |dedicated|, a boolean
-|http3Only|, a {{WebTransportCongestionControl}} |congestionControl|, and a
+|http3Only|, a {{WebTransportCongestionControl}} |congestionControl|,
+a |protocols| array, and a
 sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
@@ -865,7 +887,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-  1. [=session/Establish=] a [=WebTransport session=] with |origin| on |connection|.
+  1. [=session/Establish=] a [=WebTransport session=] with |origin| and |protocols| on |connection|.
 
     Note: This step also contains the transport parameter exchange specified in [[!QUIC-DATAGRAM]].
 
@@ -883,7 +905,10 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
       1. Abort these steps.
     1. Set |transport|.{{[[State]]}} to `"connected"`.
     1. Set |transport|.{{[[Session]]}} to |session|.
-    1. If the connection is an HTTP/3 connection, set |transport|'s {{[[Reliability]]}} to `"supports-unreliable"`.
+    1. If the connection is an HTTP/3 connection, set |transport|'s {{[[Reliability]]}} to `"supports-unreliable"`,
+       and set {{[[Protocol]]}} to the `WebTransport-Subprotocol` header field in the 2xx response to the
+       CONNECT request, following [[!WEB-TRANSPORT-HTTP3]]
+       [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
     1. If the connection is an HTTP/2 connection [[!WEB-TRANSPORT-HTTP2]], set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
     1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.
 
@@ -1004,6 +1029,12 @@ these steps.
 Note: Setting {{WebTransport/anticipatedConcurrentIncomingUnidirectionalStreams}} or
 {{WebTransport/anticipatedConcurrentIncomingBidirectionalStreams}} does not guarantee
 the application will receive the number of streams it anticipates.
+
+: <dfn for="WebTransport" attribute>protocol</dfn>
+:: Once a [=WebTransport session=] has been established and the {{protocols}}
+   constructor option was used to provide a non-empty array, returns the subprotocol
+   selected by the server, if any. Otherwise, an empty string.
+   The getter steps are to return [=this=]'s {{[[Protocol]]}}.
 
 ## Methods ##  {#webtransport-methods}
 
@@ -1294,6 +1325,7 @@ dictionary WebTransportOptions {
   WebTransportCongestionControl congestionControl = "default";
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams = null;
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams = null;
+  sequence&lt;DOMString&gt; protocols = [];
 };
 
 enum WebTransportCongestionControl {
@@ -1356,6 +1388,10 @@ that determine how the [=WebTransport session=] is established and used.
    If not null, the user agent SHOULD attempt to reduce round-trips by taking
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its
    negotiations with the server.
+
+: <dfn for="WebTransportOptions" dict-member>protocols</dfn>
+:: An optionally provided array of subprotocol names. The connection will only be established if
+   the server reports that it has selected one of these subprotocols.
 
 <div algorithm>
 To <dfn>compute a certificate hash</dfn>, given a |certificate|, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -131,7 +131,7 @@ specification uses that specification and terminology.
 There are two main protocol concepts for WebTransport: sessions and streams. Each [=WebTransport
 session=] can contain multiple [=WebTransport streams=].
 
-These should not be confused with [=subprotocol names=] which is an application-level API construct.
+These should not be confused with [=protocol names=] which is an application-level API construct.
 
 ## WebTransport session ## {#webtransport-session}
 
@@ -183,15 +183,15 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
 </table>
 
 To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin| and a
-|subprotocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
+|protocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
 [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1),
 with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
-Additionally, if the |subprotocols| array is non-empty,
+Additionally, if the |protocols| array is non-empty,
 add a `WT-Available-Protocols` header field to the CONNECT request, containing
-[=isomorphic encoded=] subprotocols from |subprotocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
+[=isomorphic encoded=] protocols from |protocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
 [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 <div class="note">
   This should reference [[!WEB-TRANSPORT-OVERVIEW]] instead pending
@@ -716,7 +716,7 @@ A {{WebTransport}} object has the following internal slots.
   </tr>
   <tr>
    <td><dfn>`[[Protocol]]`</dfn>
-   <td class="non-normative">A string indicating the subprotocol selected by the server,
+   <td class="non-normative">A string indicating the application-level protocol selected by the server,
    if any. Initially an empty string.
   </tr>
   <tr>
@@ -766,9 +766,9 @@ agent MUST run the following steps:
    congestion control algorithms that optimize for |congestionControl|, as allowed by
    [[!RFC9002]] [Section 7](https://www.rfc-editor.org/rfc/rfc9002#section-7),
    then set |congestionControl| to `"default"`.
-1. Let |subprotocols| be {{WebTransport/constructor(url, options)/options}}'s
+1. Let |protocols| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/protocols}}
-1. If any of the values in |subprotocols| occur more than once, fail to match
+1. If any of the values in |protocols| occur more than once, fail to match
    the requirements for elements that comprise the value of `WT-Protocol`
    fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
    length of 0 or exceeding 512, [=throw=] a {{SyntaxError}} exception.
@@ -838,7 +838,7 @@ This will ensure the stream is not errored due to a datagram being larger than t
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated|,
-   |requireUnreliable|, |congestionControl|, |subprotocols|, and |serverCertificateHashes|.
+   |requireUnreliable|, |congestionControl|, |protocols|, and |serverCertificateHashes|.
 1. Return |transport|.
 
 </div>
@@ -847,7 +847,7 @@ This will ensure the stream is not errored due to a datagram being larger than t
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 <var>transport</var>, a [=URL record=] |url|, a boolean |dedicated|, a boolean
 |requireUnreliable|, a {{WebTransportCongestionControl}} |congestionControl|,
-a |subprotocols| array, and a
+a |protocols| array, and a
 sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
@@ -893,7 +893,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-  1. [=session/Establish=] a [=WebTransport session=] with |origin| and |subprotocols| on |connection|.
+  1. [=session/Establish=] a [=WebTransport session=] with |origin| and |protocols| on |connection|.
 
     Note: This step also contains the transport parameter exchange specified in [[!QUIC-DATAGRAM]].
 
@@ -1403,9 +1403,9 @@ that determine how the [=WebTransport session=] is established and used.
    negotiations with the server.
 
 : <dfn for="WebTransportOptions" dict-member>protocols</dfn>
-:: An optionally provided array of application-level <dfn>subprotocol names</dfn>. The connection
+:: An optionally provided array of application-level <dfn>protocol names</dfn>. The connection
    will only be established if the server reports that it has selected one of these
-   application-level subprotocols.
+   application-level protocols.
 
 <div algorithm>
 To <dfn>compute a certificate hash</dfn>, given a |certificate|, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -1043,7 +1043,7 @@ the application will receive the number of streams it anticipates.
 
 : <dfn for="WebTransport" attribute>protocol</dfn>
 :: Once a [=WebTransport session=] has been established and the {{protocols}}
-   constructor option was used to provide a non-empty array, returns the subprotocol
+   constructor option was used to provide a non-empty array, returns the application-level protocol
    selected by the server, if any. Otherwise, an empty string.
    The getter steps are to return [=this=]'s {{[[Protocol]]}}.
 

--- a/index.bs
+++ b/index.bs
@@ -187,9 +187,9 @@ with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomo
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
-Additionally, if the [=underlying connection=] is using HTTP/3 and the |protocols| array is non-empty,
+Additionally, if the [=underlying connection=] is using HTTP/3 and the |subprotocols| array is non-empty,
 add a `WebTransport-Subprotocols-Available` header field to the CONNECT request, containing
-[=isomorphic encoded=] protocols from |protocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
+[=isomorphic encoded=] subprotocols from |subprotocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
 [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
@@ -760,9 +760,9 @@ agent MUST run the following steps:
    congestion control algorithms that optimize for |congestionControl|, as allowed by
    [[!RFC9002]] [Section 7](https://www.rfc-editor.org/rfc/rfc9002#section-7),
    then set |congestionControl| to `"default"`.
-1. Let |protocols| be {{WebTransport/constructor(url, options)/options}}'s
-   {{WebTransportOptions/protocols}}
-1. If any of the values in |protocols| occur more than once, fail to match
+1. Let |subprotocols| be {{WebTransport/constructor(url, options)/options}}'s
+   {{WebTransportOptions/subprotocols}}
+1. If any of the values in |subprotocols| occur more than once, fail to match
    the requirements for elements that comprise the value of `WebTransport-Subprotocol`
    fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
    length of 0 or exceeding 512, [=throw=] a {{SyntaxError}} exception.
@@ -832,7 +832,7 @@ This will ensure the stream is not errored due to a datagram being larger than t
    [=ReadableStream/set up/pullAlgorithm=] set to |pullUnidirectionalStreamAlgorithm|, and
    [=ReadableStream/set up/highWaterMark=] set to 0.
 1. [=Initialize WebTransport over HTTP=] with |transport|, |parsedURL|, |dedicated|,
-   |requireUnreliable|, |congestionControl|, |protocols|, and |serverCertificateHashes|.
+   |requireUnreliable|, |congestionControl|, |subprotocols|, and |serverCertificateHashes|.
 1. Return |transport|.
 
 </div>
@@ -841,7 +841,7 @@ This will ensure the stream is not errored due to a datagram being larger than t
 To <dfn>initialize WebTransport over HTTP</dfn>, given a {{WebTransport}} object
 <var>transport</var>, a [=URL record=] |url|, a boolean |dedicated|, a boolean
 |requireUnreliable|, a {{WebTransportCongestionControl}} |congestionControl|,
-a |protocols| array, and a
+a |subprotocols| array, and a
 sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 
 1. Let |client| be |transport|'s [=relevant settings object=].
@@ -887,7 +887,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-  1. [=session/Establish=] a [=WebTransport session=] with |origin| and |protocols| on |connection|.
+  1. [=session/Establish=] a [=WebTransport session=] with |origin| and |subprotocols| on |connection|.
 
     Note: This step also contains the transport parameter exchange specified in [[!QUIC-DATAGRAM]].
 
@@ -1031,7 +1031,7 @@ Note: Setting {{WebTransport/anticipatedConcurrentIncomingUnidirectionalStreams}
 the application will receive the number of streams it anticipates.
 
 : <dfn for="WebTransport" attribute>protocol</dfn>
-:: Once a [=WebTransport session=] has been established and the {{protocols}}
+:: Once a [=WebTransport session=] has been established and the {{subprotocols}}
    constructor option was used to provide a non-empty array, returns the subprotocol
    selected by the server, if any. Otherwise, an empty string.
    The getter steps are to return [=this=]'s {{[[Protocol]]}}.
@@ -1327,7 +1327,7 @@ dictionary WebTransportOptions {
   WebTransportCongestionControl congestionControl = "default";
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams = null;
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams = null;
-  sequence&lt;DOMString&gt; protocols = [];
+  sequence&lt;DOMString&gt; subprotocols = [];
 };
 
 enum WebTransportCongestionControl {
@@ -1391,7 +1391,7 @@ that determine how the [=WebTransport session=] is established and used.
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its
    negotiations with the server.
 
-: <dfn for="WebTransportOptions" dict-member>protocols</dfn>
+: <dfn for="WebTransportOptions" dict-member>subprotocols</dfn>
 :: An optionally provided array of subprotocol names. The connection will only be established if
    the server reports that it has selected one of these subprotocols.
 

--- a/index.bs
+++ b/index.bs
@@ -131,6 +131,8 @@ specification uses that specification and terminology.
 There are two main protocol concepts for WebTransport: sessions and streams. Each [=WebTransport
 session=] can contain multiple [=WebTransport streams=].
 
+These should not be confused with [=subprotocol names=] which is an application-level API construct.
+
 ## WebTransport session ## {#webtransport-session}
 
 A <dfn for="protocol">WebTransport session</dfn> is a session of WebTransport over an HTTP/3
@@ -187,10 +189,14 @@ with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomo
 as the [:Origin:] header of the request.
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
-Additionally, if the [=underlying connection=] is using HTTP/3 and the |subprotocols| array is non-empty,
-add a `WebTransport-Subprotocols-Available` header field to the CONNECT request, containing
+Additionally, if the |subprotocols| array is non-empty,
+add a `WT-Available-Protocols` header field to the CONNECT request, containing
 [=isomorphic encoded=] subprotocols from |subprotocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
 [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
+<div class="note">
+  This should reference [[!WEB-TRANSPORT-OVERVIEW]] instead pending
+  [issue 15](https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-overview/issues/15).
+</div>
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 [=CONNECT stream=] receives an [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when a
@@ -763,7 +769,7 @@ agent MUST run the following steps:
 1. Let |subprotocols| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/protocols}}
 1. If any of the values in |subprotocols| occur more than once, fail to match
-   the requirements for elements that comprise the value of `WebTransport-Subprotocol`
+   the requirements for elements that comprise the value of `WT-Protocol`
    fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
    length of 0 or exceeding 512, [=throw=] a {{SyntaxError}} exception.
    [[!WEB-TRANSPORT-HTTP3]]
@@ -905,10 +911,15 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
       1. Abort these steps.
     1. Set |transport|.{{[[State]]}} to `"connected"`.
     1. Set |transport|.{{[[Session]]}} to |session|.
-    1. If the connection is an HTTP/3 connection, set |transport|.{{[[Reliability]]}} to `"supports-unreliable"`,
-       and set |transport|.{{[[Protocol]]}} to the `WebTransport-Subprotocol` header field in the 2xx response to
-       the CONNECT request if present, following [[!WEB-TRANSPORT-HTTP3]]
-       [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
+    1. Set |transport|.{{[[Protocol]]}} to either the string value of the `WT-Protocol` header field
+       in the 2xx response to the CONNECT request if present, following [[!WEB-TRANSPORT-HTTP3]]
+       [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4),
+       or `""` if not present.
+       <div class="note">
+         This should reference [[!WEB-TRANSPORT-OVERVIEW]] instead pending
+         [issue 15](https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-overview/issues/15).
+       </div>
+    1. If the connection is an HTTP/3 connection, set |transport|.{{[[Reliability]]}} to `"supports-unreliable"`.
     1. If the connection is an HTTP/2 connection [[!WEB-TRANSPORT-HTTP2]], set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
     1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.
 
@@ -1392,8 +1403,9 @@ that determine how the [=WebTransport session=] is established and used.
    negotiations with the server.
 
 : <dfn for="WebTransportOptions" dict-member>protocols</dfn>
-:: An optionally provided array of subprotocol names. The connection will only be established if
-   the server reports that it has selected one of these subprotocols.
+:: An optionally provided array of application-level <dfn>subprotocol names</dfn>. The connection
+   will only be established if the server reports that it has selected one of these
+   application-level subprotocols.
 
 <div algorithm>
 To <dfn>compute a certificate hash</dfn>, given a |certificate|, perform the following steps:

--- a/index.bs
+++ b/index.bs
@@ -761,7 +761,7 @@ agent MUST run the following steps:
    [[!RFC9002]] [Section 7](https://www.rfc-editor.org/rfc/rfc9002#section-7),
    then set |congestionControl| to `"default"`.
 1. Let |subprotocols| be {{WebTransport/constructor(url, options)/options}}'s
-   {{WebTransportOptions/subprotocols}}
+   {{WebTransportOptions/protocols}}
 1. If any of the values in |subprotocols| occur more than once, fail to match
    the requirements for elements that comprise the value of `WebTransport-Subprotocol`
    fields as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
@@ -1031,7 +1031,7 @@ Note: Setting {{WebTransport/anticipatedConcurrentIncomingUnidirectionalStreams}
 the application will receive the number of streams it anticipates.
 
 : <dfn for="WebTransport" attribute>protocol</dfn>
-:: Once a [=WebTransport session=] has been established and the {{subprotocols}}
+:: Once a [=WebTransport session=] has been established and the {{protocols}}
    constructor option was used to provide a non-empty array, returns the subprotocol
    selected by the server, if any. Otherwise, an empty string.
    The getter steps are to return [=this=]'s {{[[Protocol]]}}.
@@ -1327,7 +1327,7 @@ dictionary WebTransportOptions {
   WebTransportCongestionControl congestionControl = "default";
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams = null;
   [EnforceRange] unsigned short? anticipatedConcurrentIncomingBidirectionalStreams = null;
-  sequence&lt;DOMString&gt; subprotocols = [];
+  sequence&lt;DOMString&gt; protocols = [];
 };
 
 enum WebTransportCongestionControl {
@@ -1391,7 +1391,7 @@ that determine how the [=WebTransport session=] is established and used.
    {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}} into consideration in its
    negotiations with the server.
 
-: <dfn for="WebTransportOptions" dict-member>subprotocols</dfn>
+: <dfn for="WebTransportOptions" dict-member>protocols</dfn>
 :: An optionally provided array of subprotocol names. The connection will only be established if
    the server reports that it has selected one of these subprotocols.
 


### PR DESCRIPTION
Fixes #536. Right now this seems only defined for HTTP/3, so that's what I went with. Is this what we want?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/598.html" title="Last updated on Sep 17, 2024, 3:13 AM UTC (6b82382)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/598/55eb163...jan-ivar:6b82382.html" title="Last updated on Sep 17, 2024, 3:13 AM UTC (6b82382)">Diff</a>