### PR TITLE
Add required or =0 in WebIDL to document stats SHALL be present (except RTT ones)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1478,17 +1478,17 @@ Note: Any unavailable stats will be [=map/exists|absent=] from the {{WebTranspor
 
 <pre class="idl">
 dictionary WebTransportConnectionStats {
-  unsigned long long bytesSent;
-  unsigned long long packetsSent;
-  unsigned long long bytesLost;
-  unsigned long long packetsLost;
-  unsigned long long bytesReceived;
-  unsigned long long packetsReceived;
+  unsigned long long bytesSent = 0;
+  unsigned long long packetsSent = 0;
+  unsigned long long bytesLost = 0;
+  unsigned long long packetsLost = 0;
+  unsigned long long bytesReceived = 0;
+  unsigned long long packetsReceived = 0;
   DOMHighResTimeStamp smoothedRtt;
   DOMHighResTimeStamp rttVariation;
   DOMHighResTimeStamp minRtt;
-  WebTransportDatagramStats datagrams;
-  unsigned long long? estimatedSendRate;
+  required WebTransportDatagramStats datagrams;
+  required unsigned long long? estimatedSendRate;
 };
 </pre>
 
@@ -1535,10 +1535,10 @@ on datagram transmission over the [=underlying connection=].
 
 <pre class="idl">
 dictionary WebTransportDatagramStats {
-  unsigned long long droppedIncoming;
-  unsigned long long expiredIncoming;
-  unsigned long long expiredOutgoing;
-  unsigned long long lostOutgoing;
+  unsigned long long droppedIncoming = 0;
+  unsigned long long expiredIncoming = 0;
+  unsigned long long expiredOutgoing = 0;
+  unsigned long long lostOutgoing = 0;
 };
 </pre>
 
@@ -1863,9 +1863,9 @@ on stats specific to one {{WebTransportSendStream}}.
 
 <pre class="idl">
 dictionary WebTransportSendStreamStats {
-  unsigned long long bytesWritten;
-  unsigned long long bytesSent;
-  unsigned long long bytesAcknowledged;
+  unsigned long long bytesWritten = 0;
+  unsigned long long bytesSent = 0;
+  unsigned long long bytesAcknowledged = 0;
 };
 </pre>
 
@@ -2173,8 +2173,8 @@ information on stats specific to one {{WebTransportReceiveStream}}.
 
 <pre class="idl">
 dictionary WebTransportReceiveStreamStats {
-  unsigned long long bytesReceived;
-  unsigned long long bytesRead;
+  unsigned long long bytesReceived = 0;
+  unsigned long long bytesRead = 0;
 };
 </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -1484,9 +1484,9 @@ dictionary WebTransportConnectionStats {
   unsigned long long packetsLost = 0;
   unsigned long long bytesReceived = 0;
   unsigned long long packetsReceived = 0;
-  DOMHighResTimeStamp smoothedRtt;
-  DOMHighResTimeStamp rttVariation;
-  DOMHighResTimeStamp minRtt;
+  required DOMHighResTimeStamp smoothedRtt;
+  required DOMHighResTimeStamp rttVariation;
+  required DOMHighResTimeStamp minRtt;
   required WebTransportDatagramStats datagrams;
   required unsigned long long? estimatedSendRate;
 };


### PR DESCRIPTION
Fixes #607 (modulo https://github.com/w3c/webtransport/issues/608).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/609.html" title="Last updated on Jul 16, 2024, 10:46 PM UTC (419ab3f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/609/55eb163...jan-ivar:419ab3f.html" title="Last updated on Jul 16, 2024, 10:46 PM UTC (419ab3f)">Diff</a>