### PR TITLE
Update WebTransport Echo in samples directory with HEVC, display glass to glass delay

### DIFF
--- a/samples/webcodecs-echo/index.html
+++ b/samples/webcodecs-echo/index.html
@@ -71,7 +71,13 @@
 <div id="rateInput">
   <label for="rate">bitrate: </label>
   <input type="text" name="rate" id="rate" minlength=2 maxlength=8 size=8
-      value=100000>
+      value=300000>
+</div>
+
+<div id="frameInput">
+  <label for="framer">framerate: </label>
+  <input type="text" name="framer" id="framer" minlength=2 maxlength=3 size=3
+      value=30>
 </div>
 
 <div id="keyInput">
@@ -83,9 +89,9 @@
 <div id="codecButtons">
 <p>Codec:</p>
    <input type="radio" id="H264" name="codec" value="H264" onchange="getCodecValue(this)">
-   <label for="H.264">H.264</label><br>
+   <label for="H264">H.264</label><br>
    <input type="radio" id="H265" name="codec" value="H265" onchange="getCodecValue(this)">
-   <label for="H.265">H.265</label><br>
+   <label for="H265">H.265</label><br>
    <input type="radio" id="VP8"  name="codec" value="VP8" checked="checked" onchange="getCodecValue(this)">
    <label for="VP8">VP8</label><br>
    <input type="radio" id="VP9"  name="codec" value="VP9" onchange="getCodecValue(this)">
@@ -96,22 +102,22 @@
 
 <div id="encHwButtons">
 <p>Encoder Hardware Acceleration Preference:</p>
-   <input type="radio" id="hw" name="encHwAccel" value="prefer-hardware" onchange="getEncHwValue(this)">
-   <label for="hw">Prefer Hardware</label><br>
-   <input type="radio" id="sw"  name="encHwAccel" value="prefer-software" onchange="getEncHwValue(this)">
-   <label for="sw">Prefer Software</label><br>
-   <input type="radio" id="no-pref"  name="encHwAccel" value="no-preference" checked="checked" onchange="getEncHwValue(this)">
-   <label for="no-pref">No Preference</label><br>
+   <input type="radio" id="encHw" name="encHwAccel" value="prefer-hardware" onchange="getEncHwValue(this)">
+   <label for="encHw">Prefer Hardware</label><br>
+   <input type="radio" id="encSw"  name="encHwAccel" value="prefer-software" onchange="getEncHwValue(this)">
+   <label for="encSw">Prefer Software</label><br>
+   <input type="radio" id="encNo-pref"  name="encHwAccel" value="no-preference" checked="checked" onchange="getEncHwValue(this)">
+   <label for="encNo-pref">No Preference</label><br>
 </div>
 
 <div id="decHwButtons">
 <p>Decoder Hardware Acceleration Preference:</p>
-   <input type="radio" id="hw" name="decHwAccel" value="prefer-hardware" onchange="getDecHwValue(this)">
-   <label for="hw">Prefer Hardware</label><br>
-   <input type="radio" id="sw"  name="decHwAccel" value="prefer-software" onchange="getDecHwValue(this)">
-   <label for="sw">Prefer Software</label><br>
-   <input type="radio" id="no-pref"  name="decHwAccel" value="no-preference" checked="checked" onchange="getDecHwValue(this)">
-   <label for="no-pref">No Preference</label><br>
+   <input type="radio" id="decHw" name="decHwAccel" value="prefer-hardware" onchange="getDecHwValue(this)">
+   <label for="decHw">Prefer Hardware</label><br>
+   <input type="radio" id="decSw"  name="decHwAccel" value="prefer-software" onchange="getDecHwValue(this)">
+   <label for="decSw">Prefer Software</label><br>
+   <input type="radio" id="decNo-pref"  name="decHwAccel" value="no-preference" checked="checked" onchange="getDecHwValue(this)">
+   <label for="decNo-pref">No Preference</label><br>
 </div>
 
 <div id="prefButtons">
@@ -161,6 +167,10 @@
 <div id="chart_div" style="width: 900px; height: 500px;"></div>
 
 <div id="chart2_div" style="width: 900px; height: 500px;"></div>
+
+<div id="chart3_div" style="width: 900px; height: 500px;"></div>
+
+<div id="chart4_div" style="width: 900px; height: 500px;"></div>
 
 <div class="select">
    <label for="videoSource">Video source: </label><select id="videoSource"></select>

--- a/samples/webcodecs-echo/js/main.js
+++ b/samples/webcodecs-echo/js/main.js
@@ -62,22 +62,21 @@ function metrics_update(data) {
 
 function metrics_report() {
   metrics.all.sort((a, b) =>  {
-    return (100000 * (a.mediaTime - b.mediaTime) + a.output - b.output);
+    return (100000 * (b.mediaTime - a.mediaTime) + b.output - a.output);
   });
   const len = metrics.all.length;
   if (len < 2) return; 
-  for (let i = 1; i < len ; i++ ) {
-    if ((metrics.all[i].output == 1) && (metrics.all[i-1].output == 0)) {
+  for (let i = 0; i < len ; i++ ) {
+    if (metrics.all[i].output == 1) {
       const frameno = metrics.all[i].presentedFrames;
       const fps = metrics.all[i].fps;
       const time = metrics.all[i].elapsed;
-      const g2g = Math.max(0, metrics.all[i].expectedDisplayTime - metrics.all[i-1].captureTime);
       const mediaTime = metrics.all[i].mediaTime;
-      const captureTime = metrics.all[i-1].captureTime;
+      const captureTime = metrics.all[i].captureTime;
       const expectedDisplayTime = metrics.all[i].expectedDisplayTime;
-      const delay = metrics.all[i].expectedDisplayTime - metrics.all[i-1].expectedDisplayTime;
+      const g2g = Math.max(0, expectedDisplayTime - captureTime);
       const data = [frameno, g2g];
-      const info = {frameno: frameno, fps: fps, time: time, g2g: g2g, mediaTime: mediaTime, captureTime: captureTime, expectedDisplayTime: expectedDisplayTime, delay: delay};
+      const info = {frameno: frameno, fps: fps, time: time, g2g: g2g, mediaTime: mediaTime, captureTime: captureTime, expectedDisplayTime: expectedDisplayTime};
       e2e.all.push(data);
       display_metrics.all.push(info);
     }


### PR DESCRIPTION
The WebTransport Echo sample has been updated to support the following: 

- HEVC encode and decode. Works only on Chrome Canary with flags set: 
--enable-features=PlatformHEVCEncoderSupport,WebRtcAllowH265Send,WebRtcAllowH265Receive --force-fieldtrials="WebRTC-Video-H26xPacketBuffer/Enabled/"

- Glass-to-glass latency and encode time charts. This had been broken by changes to the WebCodecs and RVFC implementations on Chrome, but is now fixed. 

Revised sample live site: 
https://webrtc.internaut.com/wc/wtSender13/ 
