### PR TITLE
Redirection treated as a network error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -828,7 +828,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 1. Let |request| be a new [=/request=] whose [=request/URL=] is |url|, [=request/client=] is
    |client|, [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
-[=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
+   [=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
 
 Note: redirects are intentionally not exposed to the application. In cross-origin contexts, this
 would reveal information that would normally be blocked by CORS. In same-origin contexts, it 

--- a/index.bs
+++ b/index.bs
@@ -830,9 +830,8 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
    [=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
 
-Note: redirects are intentionally not exposed to the application. In cross-origin contexts, this
-would reveal information that would normally be blocked by CORS. In same-origin contexts, it 
-would encourage users to abuse the handshake as a vector for passing information. 
+Note: Redirects are not followed. Network errors caused by redirection are intentionally indistinguishable from other network errors.  In cross-origin contexts, this would reveal information that would normally be blocked
+by CORS. In same-origin contexts, it would encourage users to abuse the handshake as a vector for passing information. 
 
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns

--- a/index.bs
+++ b/index.bs
@@ -857,12 +857,10 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-     
-	Note: Redirects are not followed. Network errors caused by redirection are intentionally
-        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
-        information that would normally be blocked by CORS. In same-origin contexts, it would
-        encourage users to abuse the handshake as a vector for passing information. 
-
+       <div class="note">Redirects are not followed. Network errors caused by redirection are intentionally
+       indistinguishable from other network errors.  In cross-origin contexts, this would reveal
+       information that would normally be blocked by CORS. In same-origin contexts, it would
+       encourage users to abuse the handshake as a vector for passing information.</div>
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't

--- a/index.bs
+++ b/index.bs
@@ -857,10 +857,12 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
+
        Note: Redirects are not followed. Network errors caused by redirection are intentionally
        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
        information that would normally be blocked by CORS. In same-origin contexts, it would
        encourage users to abuse the handshake as a vector for passing information.
+
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't

--- a/index.bs
+++ b/index.bs
@@ -828,7 +828,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 1. Let |request| be a new [=/request=] whose [=request/URL=] is |url|, [=request/client=] is
    |client|, [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
-   and [=request/origin=] is |origin|.
+[=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns
    <b>"Blocked"</b>, or if |request| [=block bad port|should be blocked due to a bad port=]

--- a/index.bs
+++ b/index.bs
@@ -857,10 +857,10 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-       <div class="note">Note: Redirects are not followed. Network errors caused by redirection are intentionally
+       Note: Redirects are not followed. Network errors caused by redirection are intentionally
        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
        information that would normally be blocked by CORS. In same-origin contexts, it would
-       encourage users to abuse the handshake as a vector for passing information.</div>
+       encourage users to abuse the handshake as a vector for passing information.
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't

--- a/index.bs
+++ b/index.bs
@@ -857,7 +857,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-       <div class="note">Redirects are not followed. Network errors caused by redirection are intentionally
+       <div class="note">NOTE: Redirects are not followed. Network errors caused by redirection are intentionally
        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
        information that would normally be blocked by CORS. In same-origin contexts, it would
        encourage users to abuse the handshake as a vector for passing information.</div>

--- a/index.bs
+++ b/index.bs
@@ -829,10 +829,6 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
    |client|, [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
    [=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
-
-Note: Redirects are not followed. Network errors caused by redirection are intentionally indistinguishable from other network errors.  In cross-origin contexts, this would reveal information that would normally be blocked
-by CORS. In same-origin contexts, it would encourage users to abuse the handshake as a vector for passing information. 
-
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns
    <b>"Blocked"</b>, or if |request| [=block bad port|should be blocked due to a bad port=]
@@ -861,6 +857,12 @@ by CORS. In same-origin contexts, it would encourage users to abuse the handshak
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
+     
+	Note: Redirects are not followed. Network errors caused by redirection are intentionally
+        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
+        information that would normally be blocked by CORS. In same-origin contexts, it would
+        encourage users to abuse the handshake as a vector for passing information. 
+
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.
   1. If |settings| doesn't contain SETTINGS_ENABLE_WEBTRANPORT with a value of 1, or it doesn't

--- a/index.bs
+++ b/index.bs
@@ -860,8 +860,8 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
 
        Note: Redirects are not followed. Network errors caused by redirection are intentionally
        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
-       information that would normally be blocked by CORS. In same-origin contexts, it would
-       encourage users to abuse the handshake as a vector for passing information.
+       information that would normally be blocked by CORS. In same-origin contexts, it might
+       encourage applications to abuse the handshake as a vector for passing information.
 
   1. Wait for |connection| to receive the first SETTINGS frame, and let |settings| be a dictionary that
      represents the SETTINGS frame.

--- a/index.bs
+++ b/index.bs
@@ -829,6 +829,11 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
    |client|, [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is an empty string,
 [=request/origin=] is |origin| and [=request/redirect mode=] is "error". 
+
+Note: redirects are intentionally not exposed to the application. In cross-origin contexts, this
+would reveal information that would normally be blocked by CORS. In same-origin contexts, it 
+would encourage users to abuse the handshake as a vector for passing information. 
+
 1. Run <a>report Content Security Policy violations for |request|</a>.
 1. If [=should request be blocked by Content Security Policy?=] with |request| returns
    <b>"Blocked"</b>, or if |request| [=block bad port|should be blocked due to a bad port=]

--- a/index.bs
+++ b/index.bs
@@ -857,7 +857,7 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
     1. Let |error| be a newly [=DOMException/created=] {{WebTransportError}} whose
        {{WebTransportErrorOptions/source}} is `"session"`.
     1. [=Cleanup=] |transport| with |error|.
-       <div class="note">NOTE: Redirects are not followed. Network errors caused by redirection are intentionally
+       <div class="note">Note: Redirects are not followed. Network errors caused by redirection are intentionally
        indistinguishable from other network errors.  In cross-origin contexts, this would reveal
        information that would normally be blocked by CORS. In same-origin contexts, it would
        encourage users to abuse the handshake as a vector for passing information.</div>


### PR DESCRIPTION
Updates connection algorithm so that any HTTP redirection response is treated as a network error and is indistinguishable from any 3XX,5XX error. Adds note with motivation for why this being done. 

Fixes: #499


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/612.html" title="Last updated on Aug 27, 2024, 2:13 PM UTC (97ddea4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/612/d5781c2...97ddea4.html" title="Last updated on Aug 27, 2024, 2:13 PM UTC (97ddea4)">Diff</a>