### PR TITLE
Adjust estimatedSendRate definition to exclude framing overhead

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1587,8 +1587,9 @@ The dictionary SHALL have the following attributes:
 :: The estimated rate at which queued data will be sent by the user agent, in bits per second.
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
    and is calculated by the congestion control algorithm (potentially chosen by
-   {{WebTransport/congestionControl}}). If the user agent does not
-   currently have an estimate, the member MUST be the `null` value.
+   {{WebTransport/congestionControl}}). This estimate excludes any framing overhead and
+   represents the rate at which an application payload might be sent. If the user agent
+   does not currently have an estimate, the member MUST be the `null` value.
    The member can be `null` even if it was not `null` in previous results.
 : <dfn for="WebTransportConnectionStats" dict-member>atSendCapacity</dfn>
 :: A value of false indicates the {{estimatedSendRate}} might be application limited,


### PR DESCRIPTION
Fixes #615


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/632.html" title="Last updated on Feb 22, 2025, 8:18 PM UTC (40449bb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/632/a806432...40449bb.html" title="Last updated on Feb 22, 2025, 8:18 PM UTC (40449bb)">Diff</a>