### PR TITLE
Reference overview doc for protocol negotiation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -193,11 +193,6 @@ like the server to use in this session, in preference order, following
 [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09#section-3.1).
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
-<div class="note">
-  If the [=underlying connection=] is using HTTP/3, the protocols will be listed in the
-  `WT-Available-Protocols` header field of the CONNECT request, following [[!WEB-TRANSPORT-HTTP3]]
-  [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
-</div>
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the
 [=CONNECT stream=] receives an [=session-signal/DRAIN_WEBTRANSPORT_SESSION=] capsule, or when a

--- a/index.bs
+++ b/index.bs
@@ -185,18 +185,18 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
 
 To <dfn for=session>establish</dfn> a [=WebTransport session=] with an [=/origin=] |origin| and a
 |protocols| array, follow [[!WEB-TRANSPORT-OVERVIEW]]
-[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1),
-with using |origin|, [=ASCII serialization of an origin|serialized=] and [=isomorphic encoded=],
-as the [:Origin:] header of the request.
+[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09#section-4.1-2.2.1),
+using |origin|, [=ASCII serialization of an origin|serialized=] and
+[=isomorphic encoded|isomorphically encoded=], as the [:Origin:] header of the request, and the
+[=isomorphic encoded|isomorphically encoded=] |protocols| as the list of protocols the client would
+like the server to use in this session, in preference order, following
+[Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09#section-3.1).
 When establishing a session, the client MUST NOT provide any [=credentials=].
 The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
-Additionally, if the |protocols| array is non-empty,
-add a `WT-Available-Protocols` header field to the CONNECT request, containing
-[=isomorphic encoded=] protocols from |protocols| in the order given, following [[!WEB-TRANSPORT-HTTP3]]
-[Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 <div class="note">
-  This should reference [[!WEB-TRANSPORT-OVERVIEW]] instead pending
-  [issue 15](https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-overview/issues/15).
+  If the [=underlying connection=] is using HTTP/3, the protocols will be listed in the
+  `WT-Available-Protocols` header field of the CONNECT request, following [[!WEB-TRANSPORT-HTTP3]]
+  [Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3/#section-3.4).
 </div>
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the


### PR DESCRIPTION
Partial fix for #616.

Do we likewise need on overview doc for draining?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/640.html" title="Last updated on Mar 26, 2025, 3:13 PM UTC (5bab511)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/640/e5abd59...jan-ivar:5bab511.html" title="Last updated on Mar 26, 2025, 3:13 PM UTC (5bab511)">Diff</a>