### PR TITLE
Mark serverCertificateHashes as at risk

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1491,6 +1491,15 @@ that determine how the [=WebTransport session=] is established and used.
    If empty, the user agent SHALL use certificate verification procedures it would
    use for normal [=fetch=] operations.
 :: This cannot be used with {{WebTransportOptions/allowPooling}}.
+   <div class="issue atrisk">
+     {{serverCertificateHashes}} has been identified by the chairs as a feature at
+     risk, in spite of having two implementations. This is due to lack of consensus
+     over the following two open issues:
+     <ul>
+       <li><a href="https://github.com/w3c/webtransport/issues/623">https://github.com/w3c/webtransport/issues/623</a></li>
+       <li><a href="https://github.com/w3c/webtransport/issues/59">https://github.com/w3c/webtransport/issues/59</a></li>
+     </ul>
+   </div>
 
 : <dfn for="WebTransportOptions" dict-member>congestionControl</dfn>
 :: Optionally specifies an application's preference for a congestion control


### PR DESCRIPTION
Marking at risk over #623 and the serverCertificateHashes part of #59. Procedurally, this would allows for the option of removing the feature should there be pushback at wide review. 