### PR TITLE
Add some guidance on how to pick maxDatagramSize

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -552,12 +552,19 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
   <tr>
    <td><dfn>`[[OutgoingMaxDatagramSize]]`</dfn>
    <td class="non-normative">An integer representing the maximum size for an outgoing datagram.
-   <p class=note>The maximum datagram size depends on the protocol that is in use.
-   In HTTP/3 [[WEB-TRANSPORT-HTTP3]], the value is related to the estimate of the
-   path <acronym title="Maximum Transmission Unit">MTU</acronym>,
-   which is reduced by some implementation-defined amount to account for any overheads.
-   In HTTP/2  [[WEB-TRANSPORT-HTTP2]], the value primarily comes from
-   the SETTINGS_MAX_DATAGRAM_SIZE \[TODO!] setting.
+   <div class=note>
+     The maximum datagram size depends on the protocol that is in use.
+     In HTTP/3 [[WEB-TRANSPORT-HTTP3]], the value is related to the estimate of the
+     path <acronym title="Maximum Transmission Unit">MTU</acronym>,
+     which is reduced by some implementation-defined amount to account for any overheads.
+     In HTTP/2 [[WEB-TRANSPORT-HTTP2]], there is no equivalent limit.
+
+     As the processing of datagrams generally involves holding
+     the entire datagram in memory,
+     implementations will have limits on size.
+     A future protocol extension could enable the signaling of these size limits
+     for all protocol variants.
+   </div>
   </tr>
  </tbody>
 </table>

--- a/index.bs
+++ b/index.bs
@@ -552,6 +552,12 @@ A {{WebTransportDatagramDuplexStream}} object has the following internal slots.
   <tr>
    <td><dfn>`[[OutgoingMaxDatagramSize]]`</dfn>
    <td class="non-normative">An integer representing the maximum size for an outgoing datagram.
+   <p class=note>The maximum datagram size depends on the protocol that is in use.
+   In HTTP/3 [[WEB-TRANSPORT-HTTP3]], the value is related to the estimate of the
+   path <acronym title="Maximum Transmission Unit">MTU</acronym>,
+   which is reduced by some implementation-defined amount to account for any overheads.
+   In HTTP/2  [[WEB-TRANSPORT-HTTP2]], the value primarily comes from
+   the SETTINGS_MAX_DATAGRAM_SIZE \[TODO!] setting.
   </tr>
  </tbody>
 </table>
@@ -1085,7 +1091,7 @@ these steps.
 :: Returns a {{ReadableStream}} of {{WebTransportBidirectionalStream}}s that have been
    received from the server.
 
-   Note: Whether the incoming streams already have data on them will depend on server behavior. 
+   Note: Whether the incoming streams already have data on them will depend on server behavior.
 
    The getter steps for the `incomingBidirectionalStreams` attribute SHALL be:
      1. Return [=this=]'s {{[[IncomingBidirectionalStreams]]}}.
@@ -1093,7 +1099,7 @@ these steps.
 :: A {{ReadableStream}} of unidirectional streams, each represented by a
    {{WebTransportReceiveStream}}, that have been received from the server.
 
-   Note: Whether the incoming streams already have data on them will depend on server behavior. 
+   Note: Whether the incoming streams already have data on them will depend on server behavior.
 
    The getter steps for `incomingUnidirectionalStreams` are:
      1. Return [=this=].{{[[IncomingUnidirectionalStreams]]}}.


### PR DESCRIPTION
Turns out, this is not quite that easy, so it was worth chasing this down.

Waiting on a resolution to https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-http2/issues/124 before I can resolve the TODO.

Closes #642.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/webtransport/pull/648.html" title="Last updated on Apr 23, 2025, 12:26 AM UTC (b60765e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/648/d5a6eec...martinthomson:b60765e.html" title="Last updated on Apr 23, 2025, 12:26 AM UTC (b60765e)">Diff</a>