### PR TITLE
Revert "Mark serverCertificateHashes as at risk"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1506,15 +1506,6 @@ that determine how the [=WebTransport session=] is established and used.
    If empty, the user agent SHALL use certificate verification procedures it would
    use for normal [=fetch=] operations.
 :: This cannot be used with {{WebTransportOptions/allowPooling}}.
-   <div class="issue atrisk">
-     {{serverCertificateHashes}} has been identified by the chairs as a feature at
-     risk, in spite of having two implementations. This is due to lack of consensus
-     over the following two open issues:
-     <ul>
-       <li><a href="https://github.com/w3c/webtransport/issues/623">https://github.com/w3c/webtransport/issues/623</a></li>
-       <li><a href="https://github.com/w3c/webtransport/issues/59">https://github.com/w3c/webtransport/issues/59</a></li>
-     </ul>
-   </div>
 
 : <dfn for="WebTransportOptions" dict-member>congestionControl</dfn>
 :: Optionally specifies an application's preference for a congestion control


### PR DESCRIPTION
This reverts commit 34ef7b2c2e91b1d337015d3b71028ea0e144d54d now that #623 is closed.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/657.html" title="Last updated on May 21, 2025, 3:05 PM UTC (d472a61)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/657/399f6c2...jan-ivar:d472a61.html" title="Last updated on May 21, 2025, 3:05 PM UTC (d472a61)">Diff</a>