### PR TITLE
Updating expected behavior around application protocols

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1529,9 +1529,9 @@ that determine how the [=WebTransport session=] is established and used.
    negotiations with the server.
 
 : <dfn for="WebTransportOptions" dict-member>protocols</dfn>
-:: An optionally provided array of application-level <dfn>protocol names</dfn>. The connection
-   will only be established if the server reports that it has selected one of these
-   application-level protocols.
+:: An optionally provided array of application-level <dfn>protocol names</dfn>. Selecting a
+   preferred application-protocol and communicating it to the client is optional for the server.
+   Servers might reject the request if a suitable protocol was not provided.
 
 <div algorithm>
 To <dfn>compute a certificate hash</dfn>, given a |certificate|, perform the following steps:


### PR DESCRIPTION
Indicates that the server may not reply with a selected application-level protocol even if the  protocols argument is used in the constructor and the server accepts the conneciton. 

Fixes #653 