### PR TITLE
Fix link to {{WebTransportDatagramsWritable/[[OutgoingDatagramsQueue]]}}

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -367,7 +367,7 @@ A {{WebTransportDatagramsWritable}} object has the following internal slot.
  and a |sendOrder|, perform the following steps.
 
  1. Let |stream| be a [=new=] {{WebTransportDatagramsWritable}}, with:
-    : {{[[OutgoingDatagramsQueue]]}}
+    : {{WebTransportDatagramsWritable/[[OutgoingDatagramsQueue]]}}
     :: an empty queue
     : {{WebTransportDatagramsWritable/[[Transport]]}}
     :: |transport|
@@ -1337,7 +1337,7 @@ optionally |closeInfo|, run these steps:
 1. Let |incomingUnidirectionalStreams| be |transport|.{{[[IncomingUnidirectionalStreams]]}}.
 1. Set |transport|.{{[[SendStreams]]}} to an empty [=set=].
 1. Set |transport|.{{[[ReceiveStreams]]}} to an empty [=set=].
-1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[OutgoingDatagramsQueue]]}}
+1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramsWritable/[[OutgoingDatagramsQueue]]}}
    to an empty [=queue=].
 1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[IncomingDatagramsQueue]]}}
    to an empty [=queue=].


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/677.html" title="Last updated on Jul 15, 2025, 9:14 PM UTC (8466d27)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/677/ae9bc68...jan-ivar:8466d27.html" title="Last updated on Jul 15, 2025, 9:14 PM UTC (8466d27)">Diff</a>