### PR TITLE
Add wt.idleTimeout read-only attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1055,7 +1055,6 @@ sequence&lt;{{WebTransportHash}}&gt; |serverCertificateHashes|, run these steps.
         1. Set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
         1. Set |transport|.{{[[IdleTimeout]]}} to an [=implementation-defined=]
            value.
-
     1. [=Resolve=] |transport|.{{[[Ready]]}} with undefined.
 
 </div>


### PR DESCRIPTION
Fixes #614.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/685.html" title="Last updated on Aug 12, 2025, 8:42 PM UTC (ff32011)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/685/ade98ee...jan-ivar:ff32011.html" title="Last updated on Aug 12, 2025, 8:42 PM UTC (ff32011)">Diff</a>