### PR TITLE
Adding RFC link to minRTT definition

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1745,7 +1745,7 @@ The dictionary SHALL have the following attributes:
    [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
 : <dfn for="WebTransportConnectionStats" dict-member>minRtt</dfn>
 :: The minimum round-trip time observed on the entire connection, as defined in
-   [[!RFC9002]] [Section 5.2](https://www.rfc-editor.org/rfc/rfc9002#name-estimating-min_rtt).
+   [[!RFC9002]] [Section 5.2](https://www.rfc-editor.org/rfc/rfc9002#section-5.2).
 : <dfn for="WebTransportConnectionStats" dict-member>estimatedSendRate</dfn>
 :: The estimated rate at which queued data will be sent by the user agent, in bits per second.
    This rate applies to all streams and datagrams that share a [=WebTransport session=]


### PR DESCRIPTION
Fixes #683


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/686.html" title="Last updated on Aug 20, 2025, 3:32 PM UTC (c5a2926)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/686/ade98ee...c5a2926.html" title="Last updated on Aug 20, 2025, 3:32 PM UTC (c5a2926)">Diff</a>