### PR TITLE
Updating references to IETF Webtrans Overview doc

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2989,8 +2989,10 @@ WebTransport imposes a set of requirements as described in
    field on the session establishment request carries this information.
 
 Protocol security related considerations are described in the
-*Security Considerations* sections of [[!WEB-TRANSPORT-OVERVIEW]],
-[[!WEB-TRANSPORT-HTTP3]] and [[!WEB-TRANSPORT-HTTP2]].
+*Security Considerations* sections of
+[[!WEB-TRANSPORT-OVERVIEW]] [Section 6](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview#section-6),
+[[!WEB-TRANSPORT-HTTP3]] [Section 8](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http3#section-8), and
+[[!WEB-TRANSPORT-HTTP2]] [Section 9](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-http2#section-9).
 
 Networking APIs can be commonly used to scan the local network for available
 hosts, and thus be used for fingerprinting and other forms of attacks.


### PR DESCRIPTION
Still waiting on https://github.com/ietf-wg-webtrans/draft-ietf-webtrans-overview/issues/40 to resolve link.

Fixes #681


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/688.html" title="Last updated on Sep 9, 2025, 11:09 PM UTC (3437d4e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/688/a738c57...3437d4e.html" title="Last updated on Sep 9, 2025, 11:09 PM UTC (3437d4e)">Diff</a>