### PR TITLE
Make WebTransportHash members required

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1545,8 +1545,8 @@ that determine how the [=WebTransport session=] is established and used.
    {{WebTransportOptions/serverCertificateHashes}}
    and satisfies [=custom certificate requirements=].  The user agent SHALL
    ignore any hash that uses an unknown {{WebTransportHash/algorithm}}.
-   If [=set/is empty|empty=] or all {{WebTransportHash/algorithm}}s are unknown, the user agent SHALL
-   use certificate verification procedures it would use for normal [=fetch=] operations.
+   If [=set/is empty|empty=], the user agent SHALL use certificate verification 
+   procedures it would use for normal [=fetch=] operations.
 :: This cannot be used with {{WebTransportOptions/allowPooling}}.
 
 : <dfn for="WebTransportOptions" dict-member>congestionControl</dfn>


### PR DESCRIPTION
Fixes #705.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/707.html" title="Last updated on Dec 3, 2025, 12:31 AM UTC (b19a11e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/707/cc7add2...jan-ivar:b19a11e.html" title="Last updated on Dec 3, 2025, 12:31 AM UTC (b19a11e)">Diff</a>