### PR TITLE
Rely on request's WebTransport-hash list for CSP & cert verification

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -980,7 +980,7 @@ agent MUST run the following steps:
    [=request/credentials mode=] is "`omit`", [=request/cache mode=] is "`no-store`",
    [=request/policy container=] is |client|'s
    [=environment settings object/policy container=], [=request/destination=] is "",
-   [=request/origin=] is |origin|, [=request/webtransport-hash list=] is
+   [=request/origin=] is |origin|, [=request/WebTransport-hash list=] is
    |serverCertificateHashes| and [=request/redirect mode=] is "error".
 
    Note: Redirects are not followed. Network errors caused by redirection are intentionally
@@ -1011,7 +1011,7 @@ To <dfn export>obtain a WebTransport connection</dfn>, given a [=network partiti
   1. Let |url| be |request|'s [=request/current URL=].
   1. Let |newConnection| be |transport|.{{[[NewConnection]]}}.
   1. Let |requireUnreliable| be |transport|.{{[[RequireUnreliable]]}}.
-  1. Let |webTransportHashes| be the values in |request|'s [=request/webtransport-hash list=].
+  1. Let |webTransportHashes| be the values in |request|'s [=request/WebTransport-hash list=].
   1. Let |connection| be the result of [=obtain a connection|obtaining a connection=] with
      |networkPartitionKey|, |url|, false, |newConnection|, |requireUnreliable| and
      |webTransportHashes|.


### PR DESCRIPTION
Fixes #59. Blocked on https://github.com/whatwg/fetch/pull/1896.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/711.html" title="Last updated on Jan 13, 2026, 3:08 PM UTC (66ad116)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/711/1b2c223...jan-ivar:66ad116.html" title="Last updated on Jan 13, 2026, 3:08 PM UTC (66ad116)">Diff</a>