### PR TITLE
Add headers constructor option and readonly response wt.responseHeaders attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -727,7 +727,7 @@ interface WebTransport {
   readonly attribute WebTransportCongestionControl congestionControl;
   [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingUnidirectionalStreams;
   [EnforceRange] attribute unsigned short? anticipatedConcurrentIncomingBidirectionalStreams;
-  [SameObject] readonly attribute Headers? headers;
+  [SameObject] readonly attribute Headers? responseHeaders;
   readonly attribute DOMString protocol;
 
   readonly attribute Promise&lt;WebTransportCloseInfo&gt; closed;
@@ -823,7 +823,7 @@ A {{WebTransport}} object has the following internal slots.
    [=bidirectional=] streams the application anticipates the server creating, or null.
   </tr>
   <tr>
-   <td><dfn>`[[Headers]]`</dfn>
+   <td><dfn>`[[ResponseHeaders]]`</dfn>
    <td class="non-normative">A {{Headers}} object or null. Initially null.
   </tr>
   <tr>
@@ -929,7 +929,7 @@ agent MUST run the following steps:
     :: |anticipatedConcurrentIncomingUnidirectionalStreams|
     : {{[[AnticipatedConcurrentIncomingBidirectionalStreams]]}}
     :: |anticipatedConcurrentIncomingBidirectionalStreams|
-    : {{[[Headers]]}}
+    : {{[[ResponseHeaders]]}}
     :: null
     : {{[[Protocol]]}}
     :: an empty string
@@ -987,13 +987,19 @@ agent MUST run the following steps:
 
 1. Set |request|'s [=request/method=] to "`CONNECT`", and set the method's associated
    `:protocol` <dfn>pseudo-header</dfn> to `"webtransport"`.
-1. Let |headers| be {{WebTransport/constructor(url, options)/options}}["{{WebTransportOptions/headers}}"].
-1. If |headers| is a not a {{Headers}} object, then set |headers| to a new {{Headers}}
-   object [=Headers/filled=] with
+1. Let |headers| be a new {{Headers}} object [=Headers/filled=] with
    {{WebTransport/constructor(url, options)/options}}["{{WebTransportOptions/headers}}"].
-1. Set |request|'s [=request/header list=] to a copy of |headers|'s [=Headers/header list=].
-1. If |request|'s [=request/header list=] [=header list/contains=] `WT-Available-Protocols`, then
-   throw a {{TypeError}}.
+1. Let |requestHeaders| be a new {{Headers}} object whose [=Headers/header list=] is
+   |request|'s [=request/header list=] and [=Headers/guard=] is "`request`".
+1. For each |header| of |headers|'s [=Headers/header list=]:
+    1. If [=ascii lowercase=] |header|'s [=header/name=] is "`wt-available-protocols`",
+       then throw a {{TypeError}}.
+    1. [=Headers/append=] |header| to |requestHeaders|.
+
+    Note: Headers are subject to Fetch’s
+    <a href="https://fetch.spec.whatwg.org/#forbidden-request-header">forbidden request-header</a>
+    restrictions.
+
 1. If |protocols| is not empty, [=header list/set a structured field value=] with
     (`WT-Available-Protocols`, a
     <a href="https://html.spec.whatwg.org/#http-structured-header-list">
@@ -1049,7 +1055,8 @@ To <dfn export>obtain a WebTransport connection</dfn>, given a [=network partiti
 </div>
 
 <div algorithm="process a WebTransport fetch response">
-To <dfn>process a WebTransport fetch response</dfn>, given a |response| and |transport|, run these steps:
+To <dfn>process a WebTransport fetch response</dfn>, given a [=/response=] |response| and a {{WebTransport}}
+|transport|, run these steps:
   1. If |response| is [=network error=], then abort the remaining steps and [=queue a network task=] with
      |transport| to run these steps:
     1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
@@ -1081,10 +1088,10 @@ To <dfn>process a WebTransport fetch response</dfn>, given a |response| and |tra
       1. Abort these steps.
     1. Set |transport|.{{[[State]]}} to `"connected"`.
     1. Set |transport|.{{[[Session]]}} to |session|.
-    1. Let |headers| be a copy of |response|’s [=response/header list=].
-    1. Remove from |headers| each header whose name is a [=byte-case-insensitive=] match for `WT-Protocol`.
-    1. Set |transport|.{{[[Headers]]}} to a new {{Headers}} object with |transport|'s [=relevant realm=],
-       whose [=Headers/header list=] is |headers| and guard is "`immutable`".
+    1. Let |responseHeaders| be a copy of |response|’s [=response/header list=].
+    1. [=header list/Delete=] "`wt-protocol`" from |responseHeaders|.
+    1. Set |transport|.{{[[ResponseHeaders]]}} to a new {{Headers}} object, whose
+       [=Headers/header list=] is |responseHeaders| and guard is "`immutable`".
     1. Set |transport|.{{[[Protocol]]}} to either the string value of the negotiated application
        protocol if present, following [[!WEB-TRANSPORT-OVERVIEW]]
        [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09/#section-3.1),
@@ -1217,10 +1224,10 @@ Note: Setting {{WebTransport/anticipatedConcurrentIncomingUnidirectionalStreams}
 {{WebTransport/anticipatedConcurrentIncomingBidirectionalStreams}} does not guarantee
 the application will receive the number of streams it anticipates.
 
-: <dfn for="WebTransport" attribute>headers</dfn>
+: <dfn for="WebTransport" attribute>responseHeaders</dfn>
 :: Once a [=WebTransport session=] has been established, holds the application-level
-   headers set by the server, if any. Initially null.
-   The getter steps are to return [=this=]'s {{[[Headers]]}}.
+   response headers set by the server, if any. Initially null.
+   The getter steps are to return [=this=]'s {{[[ResponseHeaders]]}}.
 
 : <dfn for="WebTransport" attribute>protocol</dfn>
 :: Once a [=WebTransport session=] has been established and the {{protocols}}


### PR DESCRIPTION
Fixes #263.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/713.html" title="Last updated on Feb 25, 2026, 12:12 AM UTC (cdbd062)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/713/2adf970...jan-ivar:cdbd062.html" title="Last updated on Feb 25, 2026, 12:12 AM UTC (cdbd062)">Diff</a>