### PR TITLE
Update WebTransport section links to latest draft

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -249,7 +249,7 @@ A [=WebTransport stream=] has the following capabilities:
   <tr>
    <td><dfn>abort receiving</dfn> on a [=WebTransport stream=]
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09.html#section-4.3-9.8.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11.html#section-4.3-9.8.1)
    <td>Yes
    <td>No
    <td>Yes
@@ -257,7 +257,7 @@ A [=WebTransport stream=] has the following capabilities:
   <tr>
    <td><dfn>abort sending</dfn> on a [=WebTransport stream=]
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09.html#section-4.3-9.6.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11.html#section-4.3-9.6.1)
    <td>No
    <td>Yes
    <td>Yes
@@ -281,7 +281,7 @@ A [=WebTransport stream=] has the following signals:
   <tr>
    <td><dfn>receiving aborted</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09.html#section-4.3-11.4.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11.html#section-4.3-11.4.1)
    <td>No
    <td>Yes
    <td>Yes
@@ -289,7 +289,7 @@ A [=WebTransport stream=] has the following signals:
   <tr>
    <td><dfn>sending aborted</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09.html#section-4.3-11.2.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11.html#section-4.3-11.2.1)
    <td>Yes
    <td>No
    <td>Yes


### PR DESCRIPTION
Fixes #680


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/717.html" title="Last updated on Jan 14, 2026, 3:45 PM UTC (5909661)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/717/1b2c223...5909661.html" title="Last updated on Jan 14, 2026, 3:45 PM UTC (5909661)">Diff</a>