### PR TITLE
Update WebTransport references to draft-11

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -163,56 +163,56 @@ A [=WebTransport session=] has the following capabilities defined in [[!WEB-TRAN
  </thead>
  <tbody>
   <tr>
-   <td><dfn>send a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#name-datagrams)</dfn>
+   <td><dfn>send a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#name-datagrams)</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.2-6.2.1)
+   [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.2-6.2.1)
   </tr>
   <tr>
-   <td><dfn>receive a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#name-datagrams)</dfn>
+   <td><dfn>receive a [datagram](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#name-datagrams)</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.2-6.4.1)
+   [Section 4.2](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.2-6.4.1)
   </tr>
   <tr>
    <td><dfn>create an [=stream/outgoing unidirectional=] stream</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-7.2.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-7.2.1)
   </tr>
   <tr>
    <td><dfn>create a [=stream/bidirectional=] stream</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-7.4.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-7.4.1)
   </tr>
   <tr>
    <td><dfn>receive an [=stream/incoming unidirectional=] stream</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-7.6.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-7.6.1)
   </tr>
   <tr>
    <td><dfn>receive a [=stream/bidirectional=] stream</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-7.8.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-7.8.1)
   </tr>
  </tbody>
 </table>
 
 A [=WebTransport session=] |session| is <dfn for=session>draining</dfn> when the [=CONNECT stream=] is
 asked to gracefully close by the server, as described in [[!WEB-TRANSPORT-OVERVIEW]]
-[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09/#section-4.1).
+[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11/#section-4.1).
 
 To <dfn for=session>terminate</dfn> a [=WebTransport session=] |session| with an optional integer
 |code| and an optional [=byte sequence=] |reason|, follow [[!WEB-TRANSPORT-OVERVIEW]]
-[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-2.2.1).
+[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.1-2.2.1).
 
 A [=WebTransport session=] |session| is <dfn for=session>terminated</dfn>, with optionally
 an integer |code| and a [=byte sequence=] |reason|, when the [=CONNECT stream=] is closed by the server,
 as described at [[!WEB-TRANSPORT-OVERVIEW]]
-[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.1-4.2.1).
+[Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.1-4.2.1).
 
 ## WebTransport stream ## {#webtransport-stream}
 
 A <dfn for="protocol">WebTransport stream</dfn> is a concept for a reliable in-order stream of
 bytes on a [=WebTransport session=], as described in [[!WEB-TRANSPORT-OVERVIEW]]
-[Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3).
+[Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3).
 
 A [=WebTransport stream=] is one of <dfn for=stream>incoming unidirectional</dfn>,
 <dfn for=stream>outgoing unidirectional</dfn> or <dfn for=stream>bidirectional</dfn>.
@@ -233,7 +233,7 @@ A [=WebTransport stream=] has the following capabilities:
   <tr>
    <td><dfn>send</dfn> bytes (potentially with FIN)
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-9.2.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-9.2.1)
    <td>No
    <td>Yes
    <td>Yes
@@ -241,7 +241,7 @@ A [=WebTransport stream=] has the following capabilities:
   <tr>
    <td><dfn>receive</dfn> bytes (potentially with FIN)
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-9.4.1)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-9.4.1)
    <td>Yes
    <td>No
    <td>Yes
@@ -297,7 +297,7 @@ A [=WebTransport stream=] has the following signals:
   <tr>
    <td><dfn>flow control</dfn>
    <td>[[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-06#section-4.3-5)
+   [Section 4.3](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.3-5)
    <td>No
    <td>Yes
    <td>Yes
@@ -909,7 +909,7 @@ agent MUST run the following steps:
    application protocol as defined by the WebTransport protocol, or have an [=isomorphic encoded=]
    length of 0 or exceeding 512, [=throw=] a {{SyntaxError}} exception.
    [[!WEB-TRANSPORT-OVERVIEW]]
-   [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09/#section-3.1).
+   [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11/#section-3.1).
 1. Let |anticipatedConcurrentIncomingUnidirectionalStreams| be {{WebTransport/constructor(url, options)/options}}'s
    {{WebTransportOptions/anticipatedConcurrentIncomingUnidirectionalStreams}}.
 1. Let |anticipatedConcurrentIncomingBidirectionalStreams| be {{WebTransport/constructor(url, options)/options}}'s
@@ -1062,7 +1062,7 @@ To <dfn>process a WebTransport fetch response</dfn>, given a |response|, and |co
 
   1. Let |connection| be the underlying connection associated with |response|.
   1. Follow any restrictions in [[!WEB-TRANSPORT-OVERVIEW]]
-     [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09#section-4.1-2.2.1)
+     [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.1-2.2.1)
      to <dfn for=session>establish</dfn> a [=WebTransport session=] on |connection| using the server's |response|.
   1. Let |session| be a the [=WebTransport session=] just [=establish|established=] on |connection|.
      The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
@@ -1086,7 +1086,7 @@ To <dfn>process a WebTransport fetch response</dfn>, given a |response|, and |co
     1. Set |transport|.{{[[Session]]}} to |session|.
     1. Set |transport|.{{[[Protocol]]}} to either the string value of the negotiated application
        protocol if present, following [[!WEB-TRANSPORT-OVERVIEW]]
-       [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-09/#section-3.1),
+       [Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11/#section-3.1),
        or `""` if not present.
     1. If the connection is an HTTP/3 connection, set |transport|.{{[[Reliability]]}} to `"supports-unreliable"`.
     1. If the connection is an HTTP/2 connection [[!WEB-TRANSPORT-HTTP2]], set |transport|'s {{[[Reliability]]}} to `"reliable-only"`.
@@ -1546,7 +1546,7 @@ that has data queued to be transmitted to the network, including datagrams in
 
 If a {{WebTransport}} object is garbage collected while the [=underlying connection=]
 is still open, the user agent must
-<a href="https://www.ietf.org/archive/id/draft-ietf-webtrans-overview-06.html#section-4.1-2.4.1">terminate the WebTransport session</a>
+<a href="https://www.ietf.org/archive/id/draft-ietf-webtrans-overview-11.html#section-4.1-2.4.1">terminate the WebTransport session</a>
 with an Application Error Code of `0` and Application Error Message of `""`.
 
 ## Configuration ##  {#web-transport-configuration}


### PR DESCRIPTION
Fixes: #718


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/719.html" title="Last updated on Jan 15, 2026, 12:09 PM UTC (400442f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/719/1d3d59f...400442f.html" title="Last updated on Jan 15, 2026, 12:09 PM UTC (400442f)">Diff</a>