### PR TITLE
Combine step 3 and 4 in the process a WebTransport fetch response algo

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1051,8 +1051,8 @@ To <dfn>process a WebTransport fetch response</dfn>, given a |response|, and |co
   1. Let |connection| be the underlying connection associated with |response|.
   1. Follow any restrictions in [[!WEB-TRANSPORT-OVERVIEW]]
      [Section 4.1](https://datatracker.ietf.org/doc/html/draft-ietf-webtrans-overview-11#section-4.1-2.2.1)
-     to <dfn for=session>establish</dfn> a [=WebTransport session=] on |connection| using the server's |response|.
-  1. Let |session| be a the [=WebTransport session=] just [=establish|established=] on |connection|.
+     to <dfn for=session>establish</dfn> a [=WebTransport session=] on |connection| using the server's |response|,
+     and let |session| be the resulting [=WebTransport session=].
      The resulting underlying transport stream is referred to as the session's <dfn>CONNECT stream</dfn>.
 
      Note: This step also concludes the transport parameter exchange specified in [[!QUIC-DATAGRAM]].


### PR DESCRIPTION
Makes the subsequent line "If the previous step fails," make sense [again](https://www.w3.org/TR/2025/WD-webtransport-20251118/#ref-for-session-establish%E2%91%A1).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/721.html" title="Last updated on Feb 4, 2026, 2:54 PM UTC (dc0c1ce)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/721/2217193...jan-ivar:dc0c1ce.html" title="Last updated on Feb 4, 2026, 2:54 PM UTC (dc0c1ce)">Diff</a>