### PR TITLE
The quota exceeded error values can both be null

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1356,7 +1356,8 @@ the application will receive the number of streams it anticipates.
          immediately available due to exhaustion, either wait for it to become
          available if |waitUntilAvailable| is true, or if |waitUntilAvailable| is false,
          abort these steps after [=queueing a network task=] with |transport| to [=reject=] |p|
-         with a {{QuotaExceededError}}.
+         with a {{QuotaExceededError}} whose [=QuotaExceededError/requested=] and [=QuotaExceededError/quota=]
+         are both null.
       1. Let |internalStream| be the result of [=creating a bidirectional stream=] with
            |transport|.{{[[Session]]}} and |streamId|.
       1. [=Queue a network task=] with |transport| to run the following steps:


### PR DESCRIPTION
We can't share information about limits in h3 because that is shared state.
Maybe we could in h2, but the values aren't useful there.

So both null.

No note added; this is not a detail we need to burden people with.

Closes #730.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/martinthomson/webtransport/pull/734.html" title="Last updated on Feb 25, 2026, 12:48 AM UTC (8661f83)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/734/45b3a12...martinthomson:8661f83.html" title="Last updated on Feb 25, 2026, 12:48 AM UTC (8661f83)">Diff</a>