### PR TITLE
Fix atomicWrite() when the queue is empty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2693,9 +2693,9 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    always await atomic writes.
 
    When {{atomicWrite(chunk)}} is called, the user agent MUST run the following steps:
-   1. Let |stream| be [=this=].<a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream">stream</a>.
+   1. Let |stream| be
+      [=this=].<a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream">stream</a>.
    1. If |stream| is undefined, return [=a promise rejected with=] a {{TypeError}}.
-
    1. Set |stream|.{{WebTransportSendStream/[[InsideSynchronousAtomicWrite]]}} to true.
    1. Let |p| be the result of {{WritableStreamDefaultWriter/write(chunk)}}
        on {{WritableStreamDefaultWriter}} with |chunk|.


### PR DESCRIPTION
Fixes #739.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/740.html" title="Last updated on Mar 5, 2026, 11:13 PM UTC (97c2771)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/740/452d360...jan-ivar:97c2771.html" title="Last updated on Mar 5, 2026, 11:13 PM UTC (97c2771)">Diff</a>