### PR TITLE
Remove duplicate send-order rules language

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2114,19 +2114,11 @@ To <dfn for="WebTransportSendStream">write</dfn> |chunk| to a {{WebTransportSend
     1. [=Abort all atomic write requests=] on |stream|.
   1. Otherwise, [=stream/send=] |bytes| on |stream|.{{WebTransportSendStream/[[InternalStream]]}}
      and wait for the operation to complete.
-     This sending MAY be interleaved with sending of previously queued streams and datagrams,
-     as well as streams and datagrams yet to be queued to be sent over this transport.
+     This sending MUST follow the [=send-order rules=].
 
      The user-agent MAY have a buffer to improve the transfer performance. Such a buffer
      SHOULD have a fixed upper limit, to carry the backpressure information to the user of the
      {{WebTransportSendStream}}.
-
-     This sending MUST starve
-     until all bytes queued for sending on streams with the
-     same {{WebTransportSendStream/[[SendGroup]]}} and a higher
-     {{WebTransportSendStream/[[SendOrder]]}}, that are neither
-     [=WritableStream/Error | errored=] nor blocked by [=flow control=], have been
-     sent.
 
      We access |stream|.{{WebTransportSendStream/[[SendOrder]]}} [=in parallel=] here.
      User agents SHOULD respond to live updates of these values during sending, though


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/744.html" title="Last updated on Mar 18, 2026, 7:47 PM UTC (aead085)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/744/4662f34...jan-ivar:aead085.html" title="Last updated on Mar 18, 2026, 7:47 PM UTC (aead085)">Diff</a>