### PR TITLE
Remove comparison to WebRTC in Privacy and Security section

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3228,7 +3228,7 @@ way might be <a
 href="https://infra.spec.whatwg.org/#tracking-vector">identifying</a>.
 
 It is important to recognize that very similar networking capabilities are
-provided by other web platform APIs (such as [=fetch=] and [[webrtc]]).  The net
+provided by other web platform APIs such as [=fetch=].  The net
 adverse effect on privacy due to adding WebTransport is therefore minimal.  The
 considerations in this section applies equally to other networking capabilities.
 

--- a/index.bs
+++ b/index.bs
@@ -3228,7 +3228,7 @@ way might be <a
 href="https://infra.spec.whatwg.org/#tracking-vector">identifying</a>.
 
 It is important to recognize that very similar networking capabilities are
-provided by other web platform APIs such as [=fetch=].  The net
+provided by other web platform APIs (such as [=fetch=] and [=websocket=]).  The net
 adverse effect on privacy due to adding WebTransport is therefore minimal.  The
 considerations in this section applies equally to other networking capabilities.
 


### PR DESCRIPTION
Feedback from privacy review is that the comparison to WebRTC as _"very similar networking capabilities"_ in [§ 14.5. Fingerprinting and Tracking](https://www.w3.org/TR/webtransport/#fingerprinting) section was confusing and likely to cause unnecessary concern (entirely different stack).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/758.html" title="Last updated on May 19, 2026, 11:12 PM UTC (bb5579b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/758/c05f125...jan-ivar:bb5579b.html" title="Last updated on May 19, 2026, 11:12 PM UTC (bb5579b)">Diff</a>