### PR TITLE
Fix references to fetch() and websocket

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3231,7 +3231,8 @@ way might be <a
 href="https://infra.spec.whatwg.org/#tracking-vector">identifying</a>.
 
 It is important to recognize that very similar networking capabilities are
-provided by other web platform APIs (such as [=fetch=] and [=websocket=]).  The net
+provided by other web platform APIs (such as
+{{WindowOrWorkerGlobalScope/fetch()}} and {{WebSocket}}).  The net
 adverse effect on privacy due to adding WebTransport is therefore minimal.  The
 considerations in this section applies equally to other networking capabilities.
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/765.html" title="Last updated on Jun 4, 2026, 8:59 PM UTC (a7b7f4c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/765/f321bec...a7b7f4c.html" title="Last updated on Jun 4, 2026, 8:59 PM UTC (a7b7f4c)">Diff</a>