### PR TITLE
Exclude counter-based stats from pooled connections

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1285,6 +1285,7 @@ the application will receive the number of streams it anticipates.
 
 </div>
 
+<div algorithm>
 : <dfn for="WebTransport" method>getStats()</dfn>
 :: Gathers stats for this {{WebTransport}}'s [=underlying connection=]
    and reports the result asynchronously.
@@ -1307,6 +1308,8 @@ the application will receive the number of streams it anticipates.
             [=underlying connection=] needed to populate the
             [=dictionary members=] of {{WebTransportConnectionStats}} and
             {{WebTransportDatagramStats}} accurately.
+         1. If |transport|.{{[[NewConnection]]}} is "`no`", then remove from
+            |gatheredStats| all stats not marked as [=pooled connection stats=].
          1. [=Queue a network task=] with |transport| to run the following steps:
            1. Let |stats| be a [=new=] {{WebTransportConnectionStats}} object.
            1. Let |datagramStats| be a [=new=] {{WebTransportDatagramStats}} object.
@@ -1317,6 +1320,8 @@ the application will receive the number of streams it anticipates.
                the corresponding [=map/entries|entry=] in |gatheredStats|.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.
+
+</div>
 
 : <dfn for="WebTransport" method>exportKeyingMaterial(BufferSource label, BufferSource context, unsigned long outputLength)</dfn>
 :: Exports keying material from a [TLS Keying Material Exporter](https://www.rfc-editor.org/rfc/rfc8446#section-7.3)
@@ -1811,9 +1816,13 @@ The dictionary SHALL have the following attributes:
 ## `WebTransportConnectionStats` Dictionary ##  {#web-transport-connection-stats}
 
 The <dfn dictionary>WebTransportConnectionStats</dfn> dictionary includes information
-on WebTransport-specific stats about the [=WebTransport session=]'s [=underlying connection=].
+about the [=WebTransport session=]'s [=underlying connection=]. Members of
+{{WebTransportConnectionStats}} that are not marked as a
+<dfn>pooled connection stat</dfn> are [=map/exists|absent=] for
+[=underlying connections=] that are subject to pooling.
 
-Note: When pooling is used, multiple [=WebTransport sessions=] pooled
+Note: When pooling is allowed, only [=pooled connection stats=] are revealed,
+and multiple [=WebTransport sessions=] pooled
 on the same [=connection=] all receive the same information, i.e. the information
 is disclosed across pooled [=WebTransport sessions | sessions=] holding the
 same [[fetch#network-partition-keys|network partition key]].
@@ -1875,13 +1884,16 @@ The dictionary SHALL have the following attributes:
 : <dfn for="WebTransportConnectionStats" dict-member>smoothedRtt</dfn>
 :: The smoothed round-trip time (RTT) currently observed on the connection, as defined
    in [[!RFC9002]] [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
+   This is a [=pooled connection stat=].
 : <dfn for="WebTransportConnectionStats" dict-member>rttVariation</dfn>
 :: The mean variation in round-trip time samples currently observed on the
    connection, as defined in [[!RFC9002]]
    [Section 5.3](https://www.rfc-editor.org/rfc/rfc9002#section-5.3).
+   This is a [=pooled connection stat=].
 : <dfn for="WebTransportConnectionStats" dict-member>minRtt</dfn>
 :: The minimum round-trip time observed on the entire connection, as defined in
    [[!RFC9002]] [Section 5.2](https://www.rfc-editor.org/rfc/rfc9002#section-5.2).
+   This is a [=pooled connection stat=].
 : <dfn for="WebTransportConnectionStats" dict-member>estimatedSendRate</dfn>
 :: The estimated rate at which queued data will be sent by the user agent, in bits per second.
    This rate applies to all streams and datagrams that share a [=WebTransport session=]
@@ -1890,6 +1902,7 @@ The dictionary SHALL have the following attributes:
    represents the rate at which an application payload might be sent. If the user agent
    does not currently have an estimate, the member MUST be the `null` value.
    The member can be `null` even if it was not `null` in previous results.
+   This is a [=pooled connection stat=].
 : <dfn for="WebTransportConnectionStats" dict-member>atSendCapacity</dfn>
 :: A value of false indicates the {{estimatedSendRate}} might be application limited,
    meaning the application is sending significantly less data than the congestion
@@ -1905,6 +1918,7 @@ The dictionary SHALL have the following attributes:
    to network conditions. However, {{estimatedSendRate}} is allowed to be `null` while
    {{atSendCapacity}} is true.
    </div>
+   This is a [=pooled connection stat=].
 
 ## `WebTransportDatagramStats` Dictionary ##  {#web-transport-datagram-stats}
 
@@ -1926,16 +1940,20 @@ The dictionary SHALL have the following attributes:
 :: The number of incoming datagrams that were dropped due to the application not reading
   from {{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}
   before new datagrams overflow the receive queue.
+  This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>expiredIncoming</dfn>
 :: The number of incoming datagrams that were dropped due to being older than
   {{incomingMaxAge}} before they were read from {{WebTransport/datagrams}}'
   {{WebTransportDatagramDuplexStream/readable}}.
+  This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>expiredOutgoing</dfn>
 :: The number of datagrams queued for sending that were dropped due to being
    older than {{outgoingMaxAge}} before they were able to be sent.
+   This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>lostOutgoing</dfn>
 :: The number of sent datagrams that were declared lost, as defined in
    [[!RFC9002]] [Section 6.1](https://www.rfc-editor.org/rfc/rfc9002#section-6.1).
+   This is a [=pooled connection stat=].
 
 # Interface `WebTransportSendStream` #  {#send-stream}
 

--- a/index.bs
+++ b/index.bs
@@ -1940,20 +1940,16 @@ The dictionary SHALL have the following attributes:
 :: The number of incoming datagrams that were dropped due to the application not reading
   from {{WebTransport/datagrams}}' {{WebTransportDatagramDuplexStream/readable}}
   before new datagrams overflow the receive queue.
-  This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>expiredIncoming</dfn>
 :: The number of incoming datagrams that were dropped due to being older than
   {{incomingMaxAge}} before they were read from {{WebTransport/datagrams}}'
   {{WebTransportDatagramDuplexStream/readable}}.
-  This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>expiredOutgoing</dfn>
 :: The number of datagrams queued for sending that were dropped due to being
    older than {{outgoingMaxAge}} before they were able to be sent.
-   This is a [=pooled connection stat=].
 : <dfn for="WebTransportDatagramStats" dict-member>lostOutgoing</dfn>
 :: The number of sent datagrams that were declared lost, as defined in
    [[!RFC9002]] [Section 6.1](https://www.rfc-editor.org/rfc/rfc9002#section-6.1).
-   This is a [=pooled connection stat=].
 
 # Interface `WebTransportSendStream` #  {#send-stream}
 


### PR DESCRIPTION
Fixes #762.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/766.html" title="Last updated on Jun 12, 2026, 7:12 PM UTC (6f2a370)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/766/826fe29...jan-ivar:6f2a370.html" title="Last updated on Jun 12, 2026, 7:12 PM UTC (6f2a370)">Diff</a>