### PR TITLE
Fix issue #768 - return synchronously if closed/failed in ExportKeyingMaterial

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1329,6 +1329,8 @@ the application will receive the number of streams it anticipates.
 
    When `exportKeyingMaterial` is called, the user agent MUST run the following steps:
 
+   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
+     return a [=a promise rejected with=] an {{InvalidStateError}}. 
    1. Let |transport| be [=this=].
    1. Let |labelLength| be |label|.[=BufferSource/byte length=].
    1. If |labelLength| is more than 255, return [=a promise rejected with=] a {{RangeError}}.
@@ -1338,8 +1340,6 @@ the application will receive the number of streams it anticipates.
    1. If |outputLength| is 0 or more than an [=implementation-defined=] value--
        which [=must=] be at least 4096--
        return [=a promise rejected with=] a {{RangeError}}.
-   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
-     return a [=a promise rejected with=] an {{InvalidStateError}}. 
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but [=abort when=] |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead

--- a/index.bs
+++ b/index.bs
@@ -1338,7 +1338,8 @@ the application will receive the number of streams it anticipates.
    1. If |outputLength| is 0 or more than an [=implementation-defined=] value--
        which [=must=] be at least 4096--
        return [=a promise rejected with=] a {{RangeError}}.
-   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, return a [=a promise rejected with=] an {{InvalidStateError}}. 
+   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
+     return a [=a promise rejected with=] an {{InvalidStateError}}. 
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but [=abort when=] |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead

--- a/index.bs
+++ b/index.bs
@@ -1338,6 +1338,7 @@ the application will receive the number of streams it anticipates.
    1. If |outputLength| is 0 or more than an [=implementation-defined=] value--
        which [=must=] be at least 4096--
        return [=a promise rejected with=] a {{RangeError}}.
+   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, return a [=a promise rejected with=] an {{InvalidStateError}}. 
    1. Let |p| be a new promise.
    1. Run the following steps [=in parallel=], but [=abort when=] |transport|'s
       {{[[State]]}} becomes `"closed"` or `"failed"`, and instead


### PR DESCRIPTION
Fixes #768.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jesup/webtransport/pull/769.html" title="Last updated on Jul 1, 2026, 2:46 PM UTC (ed8cc3b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/769/aa6961f...jesup:ed8cc3b.html" title="Last updated on Jul 1, 2026, 2:46 PM UTC (ed8cc3b)">Diff</a>