### PR TITLE
Fix typo in exportKeyingMaterial steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1329,8 +1329,8 @@ the application will receive the number of streams it anticipates.
 
    When `exportKeyingMaterial` is called, the user agent MUST run the following steps:
 
-   1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
-     return a [=a promise rejected with=] an {{InvalidStateError}}. 
+   1. If |this|.{{[[State]]}} is `"closed"` or `"failed"`,
+     return [=a promise rejected with=] an {{InvalidStateError}}. 
    1. Let |transport| be [=this=].
    1. Let |labelLength| be |label|.[=BufferSource/byte length=].
    1. If |labelLength| is more than 255, return [=a promise rejected with=] a {{RangeError}}.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/770.html" title="Last updated on Jul 1, 2026, 4:04 PM UTC (756189d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/770/dccfba5...756189d.html" title="Last updated on Jul 1, 2026, 4:04 PM UTC (756189d)">Diff</a>