### PR TITLE
Fix algorithms to highlight method arguments

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -624,27 +624,25 @@ The user agent MAY update {{[[OutgoingMaxDatagramSize]]}} for any {{WebTransport
 
 ## Methods ##  {#datagram-duplex-stream-methods}
 
-: <dfn for="WebTransportDatagramDuplexStream" method>createWritable()</dfn>
-:: Creates a {{WebTransportDatagramsWritable}}.
+<div algorithm="createWritable(options)">
 
-  <div algorithm="createWritable">
-   When `createWritable()` method is called, the user agent MUST
-   run the following steps:
+: <dfn for="WebTransportDatagramDuplexStream" method>createWritable(|options|)</dfn>
+:: Creates a {{WebTransportDatagramsWritable}}. When called, the user agent MUST
+   run these steps:
+
      1. Let |transport| be {{WebTransport}} object associated with [=this=].
      1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
         [=throw=] an {{InvalidStateError}}.
-     1. Let |sendGroup| be {{WebTransportDatagramDuplexStream/createWritable(options)/options}}'s
-        {{WebTransportSendOptions/sendGroup}}.
+     1. Let |sendGroup| be |options|'s {{WebTransportSendOptions/sendGroup}}.
      1. If |sendGroup| is not null, and
         |sendGroup|.{{WebTransportSendGroup/[[Transport]]}} is not
         [=this=].{{WebTransportDatagramDuplexStream/[[Transport]]}}, [=throw=]
         an {{InvalidStateError}}.
-     1. Let |sendOrder| be {{WebTransportDatagramDuplexStream/createWritable(options)/options}}'s
-        {{WebTransportSendOptions/sendOrder}}.
+     1. Let |sendOrder| be |options|'s {{WebTransportSendOptions/sendOrder}}.
      1. Return the result of [=WebTransportDatagramsWritable/creating=] a {{WebTransportDatagramsWritable}}
         with |transport|, |sendGroup| and |sendOrder|.
 
-  </div>
+</div>
 
 ## Attributes ##  {#datagram-duplex-stream-attributes}
 
@@ -1258,12 +1256,12 @@ the application will receive the number of streams it anticipates.
 
 ## Methods ##  {#webtransport-methods}
 
-<div algorithm>
+<div algorithm="close(closeInfo)">
 
-: <dfn for="WebTransport" method>close(closeInfo)</dfn>
+: <dfn for="WebTransport" method>close(|closeInfo|)</dfn>
 :: Terminates the [=WebTransport session=] associated with the WebTransport object.
+   When called, the user agent MUST run these steps:
 
-   When close is called, the user agent MUST run the following steps:
      1. Let |transport| be [=this=].
      1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`, then abort these steps.
      1. If |transport|.{{[[State]]}} is `"connecting"`:
@@ -1290,7 +1288,7 @@ the application will receive the number of streams it anticipates.
 :: Gathers stats for this {{WebTransport}}'s [=underlying connection=]
    and reports the result asynchronously.
 
-   When getStats is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
      1. Let |transport| be [=this=].
      1. Let |p| be a new promise.
      1. If |transport|.{{[[State]]}} is `"failed"`, [=reject=] |p| with an
@@ -1323,14 +1321,15 @@ the application will receive the number of streams it anticipates.
 
 </div>
 
-: <dfn for="WebTransport" method>exportKeyingMaterial(BufferSource label, BufferSource context, unsigned long outputLength)</dfn>
+<div algorithm="exportKeyingMaterial(label, context, outputLength)">
+
+: <dfn for="WebTransport" method>exportKeyingMaterial(BufferSource |label|, BufferSource |context|, unsigned long |outputLength|)</dfn>
 :: Exports keying material from a [TLS Keying Material Exporter](https://www.rfc-editor.org/rfc/rfc8446#section-7.3)
    for the TLS session uniquely associated with this {{WebTransport}}'s [=underlying connection=].
-
-   When `exportKeyingMaterial` is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
 
    1. If |transport|.{{[[State]]}} is `"closed"` or `"failed"`,
-     return a [=a promise rejected with=] an {{InvalidStateError}}. 
+     return a [=a promise rejected with=] an {{InvalidStateError}}.
    1. Let |transport| be [=this=].
    1. Let |labelLength| be |label|.[=BufferSource/byte length=].
    1. If |labelLength| is more than 255, return [=a promise rejected with=] a {{RangeError}}.
@@ -1350,26 +1349,28 @@ the application will receive the number of streams it anticipates.
      1. [=Queue a network task=] with |transport| to [=resolve=] |p| with |keyingMaterial|.
    1. Return |p|.
 
-: <dfn for="WebTransport" method>createBidirectionalStream()</dfn>
+</div>
+
+<div algorithm="createBidirectionalStream(options)">
+
+: <dfn for="WebTransport" method>createBidirectionalStream(|options|)</dfn>
 :: Creates a {{WebTransportBidirectionalStream}} object for an outgoing bidirectional
    stream.  Note that the mere creation of a stream is not immediately visible to the peer until
    it is used to send data.
 
    Note: There is no expectation that the server will be aware of the stream until data is sent on it.
 
-  <div algorithm="createBidirectionalStream">
-   When `createBidirectionalStream` is called, the user agent MUST run the
-   following steps:
+   When called, the user agent MUST run these steps:
 
    1. If [=this=].{{[[State]]}} is `"closed"` or `"failed"`,
       return a new [=rejected=] promise with an {{InvalidStateError}}.
-   1. Let |sendGroup| be {{WebTransport/createBidirectionalStream(options)/options}}'s
+   1. Let |sendGroup| be |options|'s
       {{WebTransportSendOptions/sendGroup}}.
    1. If |sendGroup| is not null, and |sendGroup|.{{WebTransportSendGroup/[[Transport]]}}
       is not [=this=], [=throw=] an {{InvalidStateError}}.
-   1. Let |sendOrder| be {{WebTransport/createBidirectionalStream(options)/options}}'s
+   1. Let |sendOrder| be |options|'s
       {{WebTransportSendOptions/sendOrder}}.
-   1. Let |waitUntilAvailable| be {{WebTransport/createBidirectionalStream(options)/options}}'s
+   1. Let |waitUntilAvailable| be |options|'s
       {{WebTransportSendStreamOptions/waitUntilAvailable}}.
    1. Let |p| be a new promise.
    1. Let |transport| be [=this=].
@@ -1394,29 +1395,28 @@ the application will receive the number of streams it anticipates.
         1. [=Resolve=] |p| with |stream|.
    1. Return |p|.
 
-  </div>
+</div>
 
-: <dfn for="WebTransport" method>createUnidirectionalStream()</dfn>
+<div algorithm="createUnidirectionalStream(options)">
 
+: <dfn for="WebTransport" method>createUnidirectionalStream(|options|)</dfn>
 :: Creates a {{WebTransportSendStream}} for an outgoing unidirectional stream.  Note
    that the mere creation of a stream is not immediately visible to the server until it is used
    to send data.
 
    Note: There is no expectation that the server will be aware of the stream until data is sent on it.
 
-  <div algorithm="createUnidirectionalStream">
-   When `createUnidirectionalStream()` method is called, the user agent MUST
-   run the following steps:
+   When called, the user agent MUST run these steps:
      1. If [=this=].{{[[State]]}} is `"closed"` or `"failed"`,
         return a new [=rejected=] promise with an {{InvalidStateError}}.
-     1. Let |sendGroup| be {{WebTransport/createUnidirectionalStream(options)/options}}'s
+     1. Let |sendGroup| be |options|'s
         {{WebTransportSendOptions/sendGroup}}.
      1. If |sendGroup| is not null, and
         |sendGroup|.{{WebTransportSendGroup/[[Transport]]}} is not [=this=], [=throw=]
         an {{InvalidStateError}}.
-     1. Let |sendOrder| be {{WebTransport/createUnidirectionalStream(options)/options}}'s
+     1. Let |sendOrder| be |options|'s
         {{WebTransportSendOptions/sendOrder}}.
-     1. Let |waitUntilAvailable| be {{WebTransport/createUnidirectionalStream(options)/options}}'s
+     1. Let |waitUntilAvailable| be |options|'s
         {{WebTransportSendStreamOptions/waitUntilAvailable}}.
      1. Let |p| be a new promise.
      1. Let |transport| be [=this=].
@@ -1440,7 +1440,7 @@ the application will receive the number of streams it anticipates.
           1. [=Resolve=] |p| with |stream|.
      1. return |p|.
 
-    </div>
+</div>
 
 : <dfn for="WebTransport" method>createSendGroup()</dfn>
 
@@ -1999,11 +1999,13 @@ The {{WebTransportSendStream}}'s [=transfer steps=] and
 
 ## Methods ##  {#send-stream-methods}
 
+<div algorithm>
 : <dfn for="WebTransportSendStream" method>getStats()</dfn>
 :: Gathers stats specific to this {{WebTransportSendStream}}'s performance,
    and reports the result asynchronously.
 
-   When getStats is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
+     1. Let |transport| be [=this=].{{WebTransportSendStream/[[Transport]]}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=]:
          1. Let |gatheredStats| be the [=list=] of stats specific to [=this=]
@@ -2016,6 +2018,8 @@ The {{WebTransportSendStream}}'s [=transfer steps=] and
                the corresponding [=map/entries|entry=] in |gatheredStats|.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.
+
+</div>
 
 <div algorithm>
 : <dfn for="WebTransportSendStream" method>getWriter()</dfn>
@@ -2339,12 +2343,14 @@ A {{WebTransportSendGroup}} is always created by the
 
 ## Methods ##  {#sendGroup-methods}
 
+<div algorithm>
 : <dfn for="WebTransportSendGroup" method>getStats()</dfn>
 :: Aggregates stats from all {{WebTransportSendStream}}s
    [=grouped=] under [=this=] sendGroup, and reports the result
     asynchronously.
 
-   When getStats is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
+     1. Let |transport| be [=this=].{{WebTransportSendGroup/[[Transport]]}}.
      1. Let |p| be a new promise.
      1. Let |streams| be all {{WebTransportSendStream}}s whose
        {{WebTransportSendStream/[[SendGroup]]}} is [=this=].
@@ -2359,6 +2365,8 @@ A {{WebTransportSendGroup}} is always created by the
                the corresponding [=map/entries|entry=] in |gatheredStats|.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.
+
+</div>
 
 ## Internal Slots ## {#sendGroup-internal-slots}
 
@@ -2421,11 +2429,13 @@ The {{WebTransportReceiveStream}}'s [=transfer steps=] and
 
 ## Methods ##  {#receive-stream-methods}
 
+<div algorithm>
 : <dfn for="WebTransportReceiveStream" method>getStats()</dfn>
 :: Gathers stats specific to this {{WebTransportReceiveStream}}'s performance,
    and reports the result asynchronously.
 
-   When getStats is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
+     1. Let |transport| be [=this=].{{WebTransportReceiveStream/[[Transport]]}}.
      1. Let |p| be a new promise.
      1. Run the following steps [=in parallel=]:
          1. Let |gatheredStats| be the [=list=] of stats specific to [=this=]
@@ -2438,6 +2448,8 @@ The {{WebTransportReceiveStream}}'s [=transfer steps=] and
                the corresponding [=map/entries|entry=] in |gatheredStats|.
            1. [=Resolve=] |p| with |stats|.
      1. Return |p|.
+
+</div>
 
 ## Internal Slots ## {#receive-stream-internal-slots}
 
@@ -2704,7 +2716,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
 
 ## Methods ##  {#web-transport-writer-methods}
 
-<div algorithm>
+<div algorithm="atomicWrite(chunk)">
 : <dfn for="WebTransportWriter" method>atomicWrite(|chunk|)</dfn>
 :: The {{atomicWrite}} method will reject if the |chunk| given to it
    could not be sent in its entirety within the [=flow control=] window that
@@ -2724,7 +2736,7 @@ interface WebTransportWriter : WritableStreamDefaultWriter {
    [=WritableStream/error=] the stream. Applications are therefore encouraged to
    always await atomic writes.
 
-   When {{atomicWrite(chunk)}} is called, the user agent MUST run the following steps:
+   When called, the user agent MUST run these steps:
    1. Let |stream| be
       [=this=].<a href="https://streams.spec.whatwg.org/#writablestreamdefaultwriter-stream">stream</a>.
    1. If |stream| is undefined, return [=a promise rejected with=] a {{TypeError}}.


### PR DESCRIPTION
This cleans up all methods with proper argument highlighting when clicked (try it in preview).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/773.html" title="Last updated on Jul 2, 2026, 1:17 AM UTC (3d70fa3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/773/dccfba5...jan-ivar:3d70fa3.html" title="Last updated on Jul 2, 2026, 1:17 AM UTC (3d70fa3)">Diff</a>