### PR TITLE
Remove redundant optionality check for exportKeyingMaterial's context arg

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1330,8 +1330,7 @@ the application will receive the number of streams it anticipates.
 
    1. Let |labelLength| be |label|.[=BufferSource/byte length=].
    1. If |labelLength| is more than 255, return [=a promise rejected with=] a {{RangeError}}.
-   1. Let |contextLength| be 0.
-   1. If |context| is given, set |contextLength| to |context|.[=BufferSource/byte length=].
+   1. Let |contextLength| be |context|.[=BufferSource/byte length=].
    1. If |contextLength| is more than 255, return [=a promise rejected with=] a {{RangeError}}.
    1. If |outputLength| is 0 or more than an [=implementation-defined=] value--
        which [=must=] be at least 4096--


### PR DESCRIPTION
Fixes #774.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/775.html" title="Last updated on Jul 2, 2026, 9:49 PM UTC (8519d79)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/775/fff8e1b...jan-ivar:8519d79.html" title="Last updated on Jul 2, 2026, 9:49 PM UTC (8519d79)">Diff</a>