### PR TITLE
Update references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -92,12 +92,12 @@ urlPrefix: http://www.ecma-international.org/ecma-262/6.0/index.html; spec: ECMA
     text: resolved; url: sec-promise-objects
     text: settled; url: sec-promise-objects
     text: the typed array constructors table; url: #table-49
-urlPrefix: https://heycam.github.io/webidl/; spec: WEBIDL
+urlPrefix: https://webidl.spec.whatwg.org/; spec: WEBIDL
   type: dfn
     text: created; for:DOMException; url: dfn-create-exception
     text: name; for:DOMException; url: domexception-name
     text: message; for:DOMException; url: domexception-message
-urlPrefix: https://w3ctag.github.io/privacy-principles/;
+urlPrefix: https://www.w3.org/TR/2025/STMT-privacy-principles-20250515/;
   type: dfn
     text: cross-site recognition; url: dfn-cross-site-recognition
 </pre>


### PR DESCRIPTION
webidl is now at https://webidl.spec.whatwg.org/
Privacy Principle is now a W3C Statement at https://www.w3.org/TR/2025/STMT-privacy-principles-20250515/


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/780.html" title="Last updated on Jul 23, 2026, 12:54 PM UTC (d8a735d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/780/6207baf...d8a735d.html" title="Last updated on Jul 23, 2026, 12:54 PM UTC (d8a735d)">Diff</a>