### PR TITLE
More References update

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -27,14 +27,14 @@ Boilerplate: omit conformance
 {
   "quic": {
     "authors": ["Jana Iyengar", "Martin Thomson"],
-    "href": "https://www.rfc-editor.org/rfc/rfc9000",
+    "href": "https://www.rfc-editor.org/info/rfc9000/",
     "title": "QUIC: A UDP-Based Multiplexed and Secure Transport",
     "status": "Proposed Standard",
     "publisher": "IETF"
   },
   "quic-datagram": {
     "authors": ["Tommy Pauly", "Eric Kinnear", "David Schinazi"],
-    "href": "https://www.rfc-editor.org/rfc/rfc9221",
+    "href": "https://www.rfc-editor.org/info/rfc9221/",
     "title": "An Unreliable Datagram Extension to QUIC",
     "status": "Proposed Standard",
     "publisher": "IETF"
@@ -977,7 +977,7 @@ agent MUST run the following steps:
 
     Note: Using 64 kibibytes buffers with datagrams is recommended because the effective
     maximum WebTransport datagram frame size has an upper bound of the QUIC maximum datagram frame size
-    which is recommended to be 64 kibibytes (See [[!QUIC-DATAGRAM]] [Section 3](https://datatracker.ietf.org/doc/html/rfc9221#section-3)).
+    which is recommended to be 64 kibibytes (See [[!QUIC-DATAGRAM]] [Section 3](https://www.rfc-editor.org/info/rfc9221/#section-3)).
     This will ensure the stream is not errored due to a datagram being larger than the buffer.
 
 1. If |datagramsReadableType| is `"bytes"`, [=ReadableStream/set up with byte reading support=]
@@ -1378,7 +1378,7 @@ the application will receive the number of streams it anticipates.
       [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
       1. Let |streamId| be a new stream ID that is valid and unique for
          |transport|.{{[[Session]]}}, as defined in [[!QUIC]]
-         [Section 19.11](https://www.rfc-editor.org/rfc/rfc9000#section-19.11). If one is not
+         [Section 19.11](https://www.rfc-editor.org/info/rfc9000/#section-19.11). If one is not
          immediately available due to exhaustion, either wait for it to become
          available if |waitUntilAvailable| is true, or if |waitUntilAvailable| is false,
          abort these steps after [=queueing a network task=] with |transport| to [=reject=] |p|
@@ -1424,7 +1424,7 @@ the application will receive the number of streams it anticipates.
         [=queue a network task=] with |transport| to [=reject=] |p| with an {{InvalidStateError}}:
         1. Let |streamId| be a new stream ID that is valid and unique for
            |transport|.{{[[Session]]}}, as defined in [[!QUIC]]
-           [Section 19.11](https://www.rfc-editor.org/rfc/rfc9000#section-19.11). If one is not
+           [Section 19.11](https://www.rfc-editor.org/info/rfc9000/#section-19.11). If one is not
            immediately available due to exhaustion, either wait for it to become
            available if |waitUntilAvailable| is true, or if |waitUntilAvailable| is false,
            abort these steps after [=queueing a network task=] with |transport| to [=reject=] |p|


### PR DESCRIPTION
Updating some RFC references following the new URL scheme for rfc-editor


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/pull/781.html" title="Last updated on Jul 23, 2026, 1:19 PM UTC (2e7f0b5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/781/c47f1f7...2e7f0b5.html" title="Last updated on Jul 23, 2026, 1:19 PM UTC (2e7f0b5)">Diff</a>