### PR TITLE
Fix echo sample client

### DIFF
--- a/samples/echo/client.js
+++ b/samples/echo/client.js
@@ -33,7 +33,7 @@ async function connect() {
   currentTransport = transport;
   streamNumber = 1;
   try {
-    currentTransportDatagramWriter = transport.datagrams.writable.getWriter();
+    currentTransportDatagramWriter = transport.datagrams.createWritable().getWriter();
     addToEventLog('Datagram writer ready.');
   } catch (e) {
     addToEventLog('Sending datagrams not supported: ' + e, 'error');


### PR DESCRIPTION
The deprecated writable property is no longer available in Safari 27.0 so I get an error when trying the echo sample client:

This pull request updates client.js to use the new method to get a writable instance.

See https://github.com/w3c/webtransport/issues/624 

<img width="701" height="859" alt="Screenshot 2026-08-13 at 5 57 34 am" src="https://github.com/user-attachments/assets/28c85926-f140-497b-903b-294310e7dbca" />