### PR TITLE
Fix broken [[OutgoingDatagramsQueue]] refs

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1481,8 +1481,8 @@ optionally |closeInfo|, run these steps:
 1. Let |incomingUnidirectionalStreams| be |transport|.{{[[IncomingUnidirectionalStreams]]}}.
 1. Set |transport|.{{[[SendStreams]]}} to an empty [=set=].
 1. Set |transport|.{{[[ReceiveStreams]]}} to an empty [=set=].
-1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramsWritable/[[OutgoingDatagramsQueue]]}}
-   to an empty [=queue=].
+1. [=For each=] |writable| in |outgoingDatagramWritables|, set
+   |writable|.{{WebTransportDatagramsWritable/[[OutgoingDatagramsQueue]]}} to an empty [=queue=].
 1. Set |transport|.{{[[Datagrams]]}}.{{WebTransportDatagramDuplexStream/[[IncomingDatagramsQueue]]}}
    to an empty [=queue=].
 1. If |closeInfo| is given, then set |transport|.{{[[State]]}} to `"closed"`.
@@ -1597,8 +1597,7 @@ A {{WebTransport}} object whose {{[[State]]}} is `"draining"` must not be garbag
 are [=ReadableStream/locked=], or if the {{closed}} promise is being observed.
 
 A {{WebTransport}} object with an [=session/established=] [=WebTransport session=]
-that has data queued to be transmitted to the network, including datagrams in
-{{[[Datagrams]]}}.{{[[OutgoingDatagramsQueue]]}}, must not be garbage collected.
+that has data queued to be transmitted to the network, must not be garbage collected.
 
 If a {{WebTransport}} object is garbage collected while the [=underlying connection=]
 is still open, the user agent must


### PR DESCRIPTION
[[OutgoingDatagramsQueue]] lives on each datagram-writable now. Fix some old refs.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jan-ivar/webtransport/pull/789.html" title="Last updated on Sep 8, 2026, 10:32 PM UTC (35dd9ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/webtransport/789/681b520...jan-ivar:35dd9ee.html" title="Last updated on Sep 8, 2026, 10:32 PM UTC (35dd9ee)">Diff</a>